### PR TITLE
Cleanup Launchguard test

### DIFF
--- a/executor/drivers/testdriver/testdriver.go
+++ b/executor/drivers/testdriver/testdriver.go
@@ -1,6 +1,8 @@
 package testdriver
 
 import (
+	"time"
+
 	"github.com/Netflix/titus-executor/executor/drivers"
 	"github.com/Netflix/titus-executor/executor/runtime"
 	log "github.com/sirupsen/logrus"
@@ -8,8 +10,11 @@ import (
 
 // TaskStatus describes a particular task's status
 type TaskStatus struct {
-	TaskID string
-	Status string
+	TaskID    string
+	Status    string
+	Msg       string
+	Details   *runtime.Details
+	Timestamp time.Time
 }
 
 // TitusTestDriver wraps the executor for integration with unit tests
@@ -30,5 +35,5 @@ func New(executor titusdriver.TitusExecutor) (*TitusTestDriver, error) {
 // ReportTitusTaskStatus notifies a test via a channel about a task's state
 func (driver *TitusTestDriver) ReportTitusTaskStatus(taskID string, msg string, state titusdriver.TitusTaskState, details *runtime.Details) {
 	log.Printf("Sending task status for task %s, state %s, and message %s", taskID, state.String(), msg)
-	driver.StatusChannel <- TaskStatus{TaskID: taskID, Status: state.String()}
+	driver.StatusChannel <- TaskStatus{TaskID: taskID, Status: state.String(), Msg: msg, Details: details, Timestamp: time.Now()}
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -22,6 +22,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// WaitingOnLaunchguardMessage is the status message we send to the master while we wait for launchguard
+const WaitingOnLaunchguardMessage = "waiting_on_launchguard"
 const shutdownTimeout = time.Hour
 const killTimeout = 5 * time.Minute
 
@@ -435,8 +437,7 @@ func (e *Executor) startContainer(c *containerState, startTime time.Time) { // n
 	if c.TitusInfo.GetIgnoreLaunchGuard() {
 		c.logEntry.Info("Ignoring Launchguard")
 	} else {
-		e.update <- newUpdate(c.Container.TaskID, titusdriver.Starting, "waiting_on_launchguard")
-
+		e.update <- newUpdate(c.Container.TaskID, titusdriver.Starting, WaitingOnLaunchguardMessage)
 		// Wait until the launchGuard is released.
 		// TODO(Andrew L): We only block concurrent launches to avoid a race condition introduced
 		// by the Titus master releasing resources prior to the agent releasing them.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Netflix/metrics-client-go/metrics"
 	"github.com/Netflix/titus-executor/api/netflix/titus"
 	"github.com/Netflix/titus-executor/config"
-	"github.com/Netflix/titus-executor/executor/drivers/test"
+	"github.com/Netflix/titus-executor/executor/drivers/testdriver"
 	titusruntime "github.com/Netflix/titus-executor/executor/runtime"
 	"github.com/Netflix/titus-executor/uploader"
 )


### PR DESCRIPTION
 -Rename testdriver package folder name from "test" to "testdriver"
 -Switch to sending raw task status over status chan with test driver
 -Have test use longer timeout (sorry, this means longer tests)
 -Check history and messages afterwards