### PR TITLE
containers get a tmpfs at /run by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ atlassian-ide-plugin.xml
 # Scala build
 *.cache
 
+tags
+
 # Go
 test.out
 test.xml
@@ -72,6 +74,7 @@ tests.xml
 test-standalone.out
 test-standalone.xml
 test-standalone-docker.out
+journald-standalone.json
 test-standalone-docker.xml
 checkstyle-result.xml
 /titus-executor
@@ -81,6 +84,11 @@ checkstyle-result.xml
 /root/apps/titus-executor/bin/titus-metadata-service
 /root/apps/titus-executor/bin/titus-mount
 /root/apps/titus-executor/bin/tini-static
+/root/apps/titus-executor/bin/titus-inject-metadataproxy
+/root/apps/titus-executor/bin/titus-launchguard-server
+/root/apps/titus-executor/bin/titus-standalone
+/root/apps/titus-executor/bin/titus-vpc-tool
+
 /mount/titus-mount
 
 # unignore directories named titus-executor

--- a/executor/mock/standalone/standalone_test.go
+++ b/executor/mock/standalone/standalone_test.go
@@ -77,6 +77,8 @@ func TestStandalone(t *testing.T) {
 	}
 	testFunctions := []func(*testing.T){
 		testSimpleJob,
+		testSimpleJobWithBadEnvironment,
+		testTmpfsAtRun,
 		testNoCapPtraceByDefault,
 		testCanAddCapabilities,
 		testDefaultCapabilities,
@@ -94,7 +96,6 @@ func TestStandalone(t *testing.T) {
 		testCancelPullBigImage,
 		testMetadataProxyInjection,
 		testMetdataProxyDefaultRoute,
-		testSimpleJobWithBadEnvironment,
 		testTerminateTimeout,
 	}
 	for _, fun := range testFunctions {
@@ -133,6 +134,17 @@ func testSimpleJobWithBadEnvironment(t *testing.T) {
 			"BAD":     `"`,
 			"AlsoBAD": "",
 		},
+	}
+	if !mock.RunJobExpectingSuccess(ji, false) {
+		t.Fail()
+	}
+}
+
+func testTmpfsAtRun(t *testing.T) {
+	ji := &mock.JobInput{
+		ImageName:  alpine.name,
+		Version:    alpine.tag,
+		Entrypoint: "/bin/sh -c '/bin/df -m -T /run | grep tmpfs | grep 200'",
 	}
 	if !mock.RunJobExpectingSuccess(ji, false) {
 		t.Fail()

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	docker "github.com/docker/docker/client"
 	"github.com/docker/go-units"
 	"github.com/ftrvxmtrx/fd"
@@ -418,6 +419,20 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 			"net.ipv6.conf.all.disable_ipv6":     "0",
 			"net.ipv6.conf.default.disable_ipv6": "0",
 			"net.ipv6.conf.lo.disable_ipv6":      "0",
+		},
+		Mounts: []mount.Mount{
+			{
+				Type:     mount.TypeTmpfs,
+				Target:   "/run",
+				ReadOnly: false,
+				TmpfsOptions: &mount.TmpfsOptions{
+					// we set a size mostly so processes get ENOSPACE instead of being shot by the cgroup OOM killer
+					// 50% of the container memory limit by default to leave some room for other things, tmpfs mounts
+					// by default on most distros have a size that is half of the host memory
+					SizeBytes: (c.Resources.Mem / 2) * MiB,
+					Mode:      01777,
+				},
+			},
 		},
 	}
 	hostCfg.CgroupParent = r.pidCgroupPath


### PR DESCRIPTION
... with a default size of 50% of the memory allocated to the container. This mirrors what most distros do by default.

In the future, if needed, this can be extended to be configurable.