### PR TITLE
Remove tmpfs at /run

### DIFF
--- a/executor/mock/standalone/standalone_test.go
+++ b/executor/mock/standalone/standalone_test.go
@@ -73,7 +73,6 @@ func TestStandalone(t *testing.T) {
 	testFunctions := []func(*testing.T, string){
 		testSimpleJob,
 		testSimpleJobWithBadEnvironment,
-		testTmpfsAtRun,
 		testNoCapPtraceByDefault,
 		testCanAddCapabilities,
 		testDefaultCapabilities,
@@ -150,18 +149,6 @@ func testSimpleJobWithBadEnvironment(t *testing.T, jobID string) {
 			"AlsoBAD": "",
 		},
 		JobID: jobID,
-	}
-	if !mock.RunJobExpectingSuccess(ji, false) {
-		t.Fail()
-	}
-}
-
-func testTmpfsAtRun(t *testing.T, jobID string) {
-	ji := &mock.JobInput{
-		ImageName:  alpine.name,
-		Version:    alpine.tag,
-		Entrypoint: "/bin/sh -c '/bin/df -m -T /run | grep tmpfs | grep 200'",
-		JobID:      jobID,
 	}
 	if !mock.RunJobExpectingSuccess(ji, false) {
 		t.Fail()

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -31,7 +31,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
 	docker "github.com/docker/docker/client"
 	"github.com/docker/go-units"
 	"github.com/ftrvxmtrx/fd"
@@ -421,20 +420,6 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 			"net.ipv6.conf.all.disable_ipv6":     "0",
 			"net.ipv6.conf.default.disable_ipv6": "0",
 			"net.ipv6.conf.lo.disable_ipv6":      "0",
-		},
-		Mounts: []mount.Mount{
-			{
-				Type:     mount.TypeTmpfs,
-				Target:   "/run",
-				ReadOnly: false,
-				TmpfsOptions: &mount.TmpfsOptions{
-					// we set a size mostly so processes get ENOSPACE instead of being shot by the cgroup OOM killer
-					// 50% of the container memory limit by default to leave some room for other things, tmpfs mounts
-					// by default on most distros have a size that is half of the host memory
-					SizeBytes: (c.Resources.Mem / 2) * MiB,
-					Mode:      01777,
-				},
-			},
 		},
 		Init: &useInit,
 	}


### PR DESCRIPTION
Automatically mounting a tmpfs at /run causes
all sorts of interesting issues with copying stuff into the container.