### PR TITLE
Add iputils-ping to ubuntu image

### DIFF
--- a/hack/test-images/ubuntu/Dockerfile
+++ b/hack/test-images/ubuntu/Dockerfile
@@ -1,2 +1,2 @@
 FROM ubuntu:xenial
-RUN apt-get update && apt-get install -y curl libcap2-bin grep iproute2 httpie
+RUN apt-get update && apt-get install -y curl libcap2-bin grep iproute2 httpie iputils-ping


### PR DESCRIPTION
We require iputils-ping because we want ping6