### PR TITLE
Generate metatron credentials with IP address

### DIFF
--- a/executor/metatron/metatron.go
+++ b/executor/metatron/metatron.go
@@ -3,6 +3,7 @@ package metatron
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -179,7 +180,7 @@ func RemovePassports(taskID string) error {
 
 // GetPassports gets Metatron passports for a container/task and stores
 // them in a file system location.
-func (mts *TrustStore) GetPassports(encodedAppMetadata *string, encodedAppSig *string, taskID string, titusMetadata TitusMetadata) (*CredentialsConfig, error) {
+func (mts *TrustStore) GetPassports(ctx context.Context, encodedAppMetadata *string, encodedAppSig *string, taskID string, titusMetadata TitusMetadata) (*CredentialsConfig, error) {
 	var err error
 	// Create a writeable directory path for the passports to go
 	if err = createPassportDir(taskID); err != nil {
@@ -202,7 +203,7 @@ func (mts *TrustStore) GetPassports(encodedAppMetadata *string, encodedAppSig *s
 		return nil, err
 	}
 
-	cmd := exec.Command(passportScript) // nolint: gas
+	cmd := exec.CommandContext(ctx, passportScript) // nolint: gas
 
 	var stdin io.WriteCloser
 	if stdin, err = cmd.StdinPipe(); err != nil {

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -201,22 +201,10 @@ func (r *Runner) startRunner(parentCtx context.Context, setupCh chan error, rp R
 		le = r.launchGuard.NewLaunchEvent(ctx, r.container.TitusInfo.GetNetworkConfigInfo().GetEniLabel())
 	}
 	if r.config.MetatronEnabled {
-		// TODO: Teach metatron about context
-		r.container.MetatronConfig, err = r.setupMetatron(ctx)
-		defer func() {
-			// Remove any Metatron credential stored for the task since they will
-			// get copied into the container.
-			if err = metatron.RemovePassports(r.container.TaskID); err != nil {
-				r.logger.Errorf("Failed to remove Metatron passport dir: %v", err)
-			} else {
-				r.logger.Infoln("Removed Metadata host passport dir")
-			}
-		}()
+		err = r.setupMetatron()
 		if err != nil {
-			// We are expecting executor container cleanup to remove
-			// any files created during the process
-			r.logger.Errorf("Failed to acquire Metatron certificates: %s", err)
 			r.err = err
+			r.logger.Error("Failed to acquire Metatron certificates: ", err)
 			r.updateStatus(ctx, titusdriver.Lost, err.Error())
 			return
 		}
@@ -481,46 +469,49 @@ func (r *Runner) maybeSetupExternalLogger(ctx context.Context, logDir string) er
 	return r.watcher.Watch(ctx)
 }
 
-// setupMetatron returns a Docker formatted string bind mount for a container for a directory that will contain
-func (r *Runner) setupMetatron(ctx context.Context) (*metatron.CredentialsConfig, error) {
-	if r.container.TitusInfo.GetMetatronCreds() == nil {
-		return nil, nil
+// mkGetMetatronConfigFunc is broken out into its own function to prevent accidentally capturing environment we shouldn't.
+func mkGetMetatronConfigFunc(mts *metatron.TrustStore) func(ctx context.Context, c *runtimeTypes.Container) (*metatron.CredentialsConfig, error) {
+	return func(ctx context.Context, c *runtimeTypes.Container) (*metatron.CredentialsConfig, error) {
+		envMap := c.TitusInfo.GetUserProvidedEnv()
+		if envMap == nil {
+			envMap = make(map[string]string)
+		}
+		titusMetadata := metatron.TitusMetadata{
+			App:          c.TitusInfo.GetAppName(),
+			Stack:        c.TitusInfo.GetJobGroupStack(),
+			ImageName:    c.TitusInfo.GetImageName(),
+			ImageVersion: c.TitusInfo.GetVersion(),
+			Entrypoint:   c.TitusInfo.GetEntrypointStr(),
+			IPAddress:    c.Allocation.IPV4Address,
+			Env:          envMap,
+			TaskID:       c.TaskID,
+			LaunchTime:   (time.Now().UnixNano() / int64(time.Millisecond)),
+		}
+
+		metatronConfig, err := mts.GetPassports(
+			c.TitusInfo.MetatronCreds.AppMetadata,
+			c.TitusInfo.MetatronCreds.MetadataSig,
+			c.TaskID,
+			titusMetadata)
+		if err != nil {
+			return nil, fmt.Errorf("Get Metatron Passport credentials failed: %s", err.Error())
+		}
+		return metatronConfig, nil
 	}
+}
 
-	r.updateStatus(ctx, titusdriver.Starting, "creating_metatron")
-
+// setupMetatron returns a Docker formatted string bind mount for a container for a directory that will contain
+func (r *Runner) setupMetatron() error {
+	if r.container.TitusInfo.GetMetatronCreds() == nil {
+		return nil
+	}
 	mts, err := metatron.InitMetatronTruststore()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to initialize Metatron trust store: %s", err)
+		return fmt.Errorf("Failed to initialize Metatron trust store: %s", err)
 	}
 
-	envMap := r.container.TitusInfo.GetUserProvidedEnv()
-	if envMap == nil {
-		envMap = make(map[string]string)
-	}
-
-	titusMetadata := metatron.TitusMetadata{
-		App:          r.container.TitusInfo.GetAppName(),
-		Stack:        r.container.TitusInfo.GetJobGroupStack(),
-		ImageName:    r.container.TitusInfo.GetImageName(),
-		ImageVersion: r.container.TitusInfo.GetVersion(),
-		Entrypoint:   r.container.TitusInfo.GetEntrypointStr(),
-		Env:          envMap,
-		TaskID:       r.container.TaskID,
-		LaunchTime:   (time.Now().UnixNano() / int64(time.Millisecond)),
-	}
-
-	metatronConfig, err := mts.GetPassports(
-		r.container.TitusInfo.MetatronCreds.AppMetadata,
-		r.container.TitusInfo.MetatronCreds.MetadataSig,
-		r.container.TaskID,
-		titusMetadata)
-	if err != nil {
-		r.logger.Error("Get Metatron Passport credentials failed: ", err)
-		return nil, err
-	}
-	r.logger.Info("Retrieved Metatron Passport credentials")
-	return metatronConfig, nil
+	r.container.GetMetatronConfig = mkGetMetatronConfigFunc(mts)
+	return nil
 }
 
 func (r *Runner) waitForTask(parentCtx, ctx context.Context) (*task, error) {

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -489,6 +489,7 @@ func mkGetMetatronConfigFunc(mts *metatron.TrustStore) func(ctx context.Context,
 		}
 
 		metatronConfig, err := mts.GetPassports(
+			ctx,
 			c.TitusInfo.MetatronCreds.AppMetadata,
 			c.TitusInfo.MetatronCreds.MetadataSig,
 			c.TaskID,

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -661,6 +661,8 @@ func prepareNetworkDriver(cfg Config, c *runtimeTypes.Container) error {
 		"--batch-size", strconv.Itoa(cfg.batchSize),
 	}
 
+	// We intentionally don't use context here, because context only KILLs.
+	// Instead we rely on the idea of the cleanup function below.
 	if cfg.debugAllocate {
 		args = append([]string{"-e", "trace=file,network,desc", "-e", "trace=!pselect6,futex,utimensat", "-s", "8192", "-tt", "-f", "-o", "allocate.trace", "/apps/titus-executor/bin/titus-vpc-tool"}, args...)
 		c.AllocationCommand = exec.Command("/usr/bin/strace", args...) // nolint: gas

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Netflix/metrics-client-go/metrics"
 	"github.com/Netflix/titus-executor/api/netflix/titus"
 	"github.com/Netflix/titus-executor/config"
+	"github.com/Netflix/titus-executor/executor/metatron"
 	"github.com/Netflix/titus-executor/executor/runtime/docker/seccomp"
 	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
 	"github.com/Netflix/titus-executor/nvidia"
@@ -799,6 +800,8 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 	}
 	log.WithField("containerID", c.ID).Debug("Container successfully created")
 
+	// pushMetatron MUST be called after setting up the network driver, because it relies on
+	// c.Allocation being set
 	err = r.pushMetatron(parentCtx, c)
 	if err != nil {
 		goto error
@@ -882,9 +885,9 @@ func (r *DockerRuntime) logDir(c *runtimeTypes.Container) string {
 	return filepath.Join(netflixLoggerTempDir(r.cfg, c), "logs")
 }
 
-func metatronTarWalk(tw *tar.Writer, c *runtimeTypes.Container) error {
+func metatronTarWalk(tw *tar.Writer, mcc *metatron.CredentialsConfig) error {
 	// Iterate the Metatron credentials path and add contents to the tar
-	if err := filepath.Walk(c.MetatronConfig.HostCredentialsPath, func(path string, fileInfo os.FileInfo, inErr error) error {
+	if err := filepath.Walk(mcc.HostCredentialsPath, func(path string, fileInfo os.FileInfo, inErr error) error {
 		var (
 			data    []byte
 			written int
@@ -899,7 +902,7 @@ func metatronTarWalk(tw *tar.Writer, c *runtimeTypes.Container) error {
 			return err
 		}
 		// Add full path name to header, not base name
-		if header.Name, err = filepath.Rel(c.MetatronConfig.HostCredentialsPrefix, path); err != nil {
+		if header.Name, err = filepath.Rel(mcc.HostCredentialsPrefix, path); err != nil {
 			return err
 		}
 
@@ -926,7 +929,7 @@ func metatronTarWalk(tw *tar.Writer, c *runtimeTypes.Container) error {
 
 		return nil
 	}); err != nil {
-		return fmt.Errorf("Walking Metatron host credentials path %s failed: %s", c.MetatronConfig.HostCredentialsPath, err)
+		return fmt.Errorf("Walking Metatron host credentials path %s failed: %s", mcc.HostCredentialsPath, err)
 	}
 
 	return nil
@@ -934,19 +937,26 @@ func metatronTarWalk(tw *tar.Writer, c *runtimeTypes.Container) error {
 
 // pushMetatron adds Metatron credentials to the container
 func (r *DockerRuntime) pushMetatron(parentCtx context.Context, c *runtimeTypes.Container) error {
-	if c.MetatronConfig == nil {
+	if c.GetMetatronConfig == nil {
 		return nil
 	}
 
 	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
+	mcc, err := c.GetMetatronConfig(ctx, c)
+	if err != nil {
+		return err
+	}
+
 	cco := types.CopyToContainerOptions{
 		AllowOverwriteDirWithFile: true,
 	}
 
+	// TODO: Collapse these two into one tarball extract / copy, and not two
+
 	// Push trust store tar
-	if err := r.client.CopyToContainer(ctx, c.ID, "/", bytes.NewReader(c.MetatronConfig.TruststoreTarBuf.Bytes()), cco); err != nil {
+	if err := r.client.CopyToContainer(ctx, c.ID, "/", bytes.NewReader(mcc.TruststoreTarBuf.Bytes()), cco); err != nil {
 		return err
 	}
 
@@ -964,7 +974,7 @@ func (r *DockerRuntime) pushMetatron(parentCtx context.Context, c *runtimeTypes.
 		}
 	}()
 
-	if err := metatronTarWalk(tw, c); err != nil {
+	if err := metatronTarWalk(tw, mcc); err != nil {
 		return err
 	}
 

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -72,7 +72,7 @@ type Container struct {
 	Resources *Resources
 
 	// Metatron fields
-	MetatronConfig *metatron.CredentialsConfig
+	GetMetatronConfig func(ctx context.Context, c *Container) (*metatron.CredentialsConfig, error)
 
 	// cleanup callbacks that runtime implementations can register to do cleanup
 	// after a launchGuard on the taskID has been lifted


### PR DESCRIPTION
This makes the generation of metatron credentials a callback, versus
the previous, which was a generation "ahead of time". Although,
this introduces a higher chance of error, and latency at container
startup, it lets us pass the IP address of the container into
the metatron init script.