### PR TITLE
Add gox to CI builder image

### DIFF
--- a/hack/ci-builder/Dockerfile
+++ b/hack/ci-builder/Dockerfile
@@ -46,3 +46,4 @@ RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install
 RUN go get -u github.com/kardianos/govendor
 RUN go get github.com/mattn/goveralls
+RUN go get github.com/mitchellh/gox


### PR DESCRIPTION
This is so the CI builder can be used by other projects.