### PR TITLE
Change Environment to New Netflix Style

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
       - run: ./build.sh no-entrypoint
       - run: ./build.sh ignore-signals
       - run: ./build.sh pty
+      - run: ./build.sh ubuntu-env-label
   ci-builder:
     docker:
       - image: docker:17.05.0-ce-git

--- a/executor/mock/jobrunner.go
+++ b/executor/mock/jobrunner.go
@@ -62,6 +62,16 @@ func (jobRunResponse *JobRunResponse) WaitForSuccess() bool {
 	return status == "TASK_FINISHED"
 }
 
+// WaitForFailure blocks on the jobs completion and returns true
+// if it exits with a non-zero (user) error
+func (jobRunResponse *JobRunResponse) WaitForFailure() bool {
+	status, err := jobRunResponse.WaitForCompletion()
+	if err != nil {
+		return false
+	}
+	return status == "TASK_FAILED"
+}
+
 // WaitForCompletion blocks on the jobs completion and returns its status
 // if it completed successfully.
 func (jobRunResponse *JobRunResponse) WaitForCompletion() (string, error) {
@@ -237,6 +247,15 @@ func RunJobExpectingSuccess(jobInput *JobInput) bool {
 
 	jobResult := jobRunner.StartJob(jobInput)
 	return jobResult.WaitForSuccess()
+}
+
+// RunJobExpectingFailure is similar to RunJob but returns true when the task completes successfully.
+func RunJobExpectingFailure(jobInput *JobInput) bool {
+	jobRunner := NewJobRunner()
+	defer jobRunner.StopExecutor()
+
+	jobResult := jobRunner.StartJob(jobInput)
+	return jobResult.WaitForFailure()
 }
 
 // RunJob runs a single Titus task based on provided JobInput

--- a/executor/mock/standalone/standalone_test.go
+++ b/executor/mock/standalone/standalone_test.go
@@ -66,6 +66,10 @@ var (
 		name: "titusoss/pty",
 		tag:  "20180507-1525733149",
 	}
+	envLabel = testImage{
+		name: "titusoss/ubuntu-env-label",
+		tag:  "20180621-1529540359",
+	}
 )
 
 // This file still uses log as opposed to using the testing library's built-in logging framework.
@@ -99,6 +103,10 @@ func TestStandalone(t *testing.T) {
 		testSchedBatch,
 		testSchedNormal,
 		testSchedIdle,
+		testNewEnvironmentLocationPositive,
+		testNewEnvironmentLocationNegative,
+		testOldEnvironmentLocationPositive,
+		testOldEnvironmentLocationNegative,
 	}
 	for _, fun := range testFunctions {
 		fullName := runtime.FuncForPC(reflect.ValueOf(fun).Pointer()).Name()
@@ -612,6 +620,54 @@ func testSchedIdle(t *testing.T, jobID string) {
 		Batch:      "idle",
 	}
 	if !mock.RunJobExpectingSuccess(ji) {
+		t.Fail()
+	}
+}
+
+func testNewEnvironmentLocationPositive(t *testing.T, jobID string) {
+	ji := &mock.JobInput{
+		ImageName:  envLabel.name,
+		Version:    envLabel.tag,
+		Entrypoint: `cat /etc/nflx/base-environment.d/titus`,
+		JobID:      jobID,
+	}
+	if !mock.RunJobExpectingSuccess(ji) {
+		t.Fail()
+	}
+}
+
+func testNewEnvironmentLocationNegative(t *testing.T, jobID string) {
+	ji := &mock.JobInput{
+		ImageName:  envLabel.name,
+		Version:    envLabel.tag,
+		Entrypoint: `cat /etc/profile.d/netflix_environment.sh`,
+		JobID:      jobID,
+	}
+	if !mock.RunJobExpectingFailure(ji) {
+		t.Fail()
+	}
+}
+
+func testOldEnvironmentLocationPositive(t *testing.T, jobID string) {
+	ji := &mock.JobInput{
+		ImageName:  ubuntu.name,
+		Version:    ubuntu.tag,
+		Entrypoint: `cat /etc/profile.d/netflix_environment.sh`,
+		JobID:      jobID,
+	}
+	if !mock.RunJobExpectingSuccess(ji) {
+		t.Fail()
+	}
+}
+func testOldEnvironmentLocationNegative(t *testing.T, jobID string) {
+
+	ji := &mock.JobInput{
+		ImageName:  ubuntu.name,
+		Version:    ubuntu.tag,
+		Entrypoint: `cat /etc/nflx/base-environment.d/titus`,
+		JobID:      jobID,
+	}
+	if !mock.RunJobExpectingFailure(ji) {
 		t.Fail()
 	}
 }

--- a/hack/test-images/ubuntu-env-label/Dockerfile
+++ b/hack/test-images/ubuntu-env-label/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu:xenial
+LABEL nflxenv=1.0


### PR DESCRIPTION
### Description of the Change
See: TITUS-2220

BaseAMI has deprecated the way it was setting up netflix_environment.sh. 
During EngTools sync meeting - Cory mentioned they are seeing use cases where tomcat or apache process fails to start on Titus or ends up starting with the wrong userId.

BaseAMI has a new way of setting up netflix_environment. It has made Titus differ from BaseAMI way of configuring netflix environment.

