### PR TITLE
Reduce the available IP addresses 24 per ENI on the r4.16xlarge

### DIFF
--- a/vpc/limits.go
+++ b/vpc/limits.go
@@ -125,8 +125,8 @@ var interfaceLimits = map[string]map[string]limits{
 		},
 		"16xlarge": limits{
 			interfaces:               15,
-			ipAddressesPerInterface:  50,
-			ip6AddressesPerInterface: 50,
+			ipAddressesPerInterface:  24,
+			ip6AddressesPerInterface: 24,
 			networkThroughput:        23000,
 		},
 	},


### PR DESCRIPTION
This is to prevent "overshoot" - otherwise we would do 31. The reason
why we're doing this is TITUS-2255. :( Bugs in AWS.
