### PR TITLE
Add context, and timeout to final upload

### DIFF
--- a/uploader/noop.go
+++ b/uploader/noop.go
@@ -1,6 +1,7 @@
 package uploader
 
 import (
+	"context"
 	"io"
 )
 
@@ -14,11 +15,11 @@ func NewNoopUploader() Uploader {
 }
 
 // Upload does nothing (i.e., noop)
-func (u *NoopUploader) Upload(local, remote string, ctypeFunc ContentTypeInferenceFunction) error {
-	return nil
+func (u *NoopUploader) Upload(ctx context.Context, local, remote string, ctypeFunc ContentTypeInferenceFunction) error {
+	return ctx.Err()
 }
 
 // UploadPartOfFile does nothing (i.e., noop)
-func (u *NoopUploader) UploadPartOfFile(local io.ReadSeeker, start, length int64, remote, contentType string) error {
-	return nil
+func (u *NoopUploader) UploadPartOfFile(ctx context.Context, local io.ReadSeeker, start, length int64, remote, contentType string) error {
+	return ctx.Err()
 }

--- a/uploader/types.go
+++ b/uploader/types.go
@@ -1,14 +1,15 @@
 package uploader
 
 import (
+	"context"
 	"io"
 )
 
 // Uploader is a common interface for a service that can upload log
 // files somewhere
 type Uploader interface {
-	Upload(local, remote string, ctypeFunc ContentTypeInferenceFunction) error
-	UploadPartOfFile(local io.ReadSeeker, start, length int64, remote, contentType string) error
+	Upload(ctx context.Context, local, remote string, ctypeFunc ContentTypeInferenceFunction) error
+	UploadPartOfFile(ctx context.Context, local io.ReadSeeker, start, length int64, remote, contentType string) error
 }
 
 // ContentTypeInferenceFunction is the callback that can be used to set the mime type of a file at upload time


### PR DESCRIPTION
Give up if uploading takes more than 5 minutes at the end of a task.