### PR TITLE
TITUS-2247 Added container tunable titusParameter.agent.hostnameStyle…

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -236,7 +236,7 @@ func (r *Runner) prepareContainer(ctx context.Context, updateChan chan update) u
 		r.logger.Error("task failed to create container: ", err)
 		// Treat registry pull errors as LOST and non-existent images as FAILED.
 		switch err.(type) {
-		case *runtimeTypes.RegistryImageNotFoundError, *runtimeTypes.InvalidSecurityGroupError, *runtimeTypes.BadEntryPointError:
+		case *runtimeTypes.RegistryImageNotFoundError, *runtimeTypes.InvalidSecurityGroupError, *runtimeTypes.BadEntryPointError, *runtimeTypes.InvalidConfigurationError:
 			r.logger.Error("Returning TASK_FAILED for task: ", err)
 			return update{status: titusdriver.Failed, msg: err.Error()}
 		}

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -402,7 +402,12 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 		return nil, nil, err
 	}
 
-	hostname := strings.ToLower(c.TaskID)
+	// hostname style: ip-{ip-addr} or {task ID}
+	hostname, err := c.ComputeHostname()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	containerCfg := &container.Config{
 		Image:      c.QualifiedImageName(),
 		Entrypoint: entrypoint,

--- a/executor/runtime/docker/docker_test.go
+++ b/executor/runtime/docker/docker_test.go
@@ -1,12 +1,11 @@
 package docker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
 	"time"
-
-	"bytes"
 
 	"github.com/Netflix/metrics-client-go/metrics"
 	docker "github.com/docker/docker/client"


### PR DESCRIPTION
… to optionally set hostname in EC2 style (e.g. ip-12-34-56-78) to DNS resolvable within the same EC2 region.

Verified
```
(nfsuper) ~ $ docker exec -it 20b84b4f-661e-4c07-b2d7-bd9bb57193bc /bin/bash
root@ip-100-65-12-156:/# hostname
ip-100-65-12-156
```

```
(nfsuper) ~ $ nslookup ip-100-65-12-156
Server:		100.66.0.2
Address:	100.66.0.2#53

Non-authoritative answer:
Name:	ip-100-65-12-156.ec2.internal
Address: 100.65.12.156
```