### PR TITLE
 add custom CMD (new style entrypoint/cmd) to metatron validation

### DIFF
--- a/executor/metatron/metatron.go
+++ b/executor/metatron/metatron.go
@@ -170,15 +170,6 @@ func createPassportDir(taskID string) error {
 	return os.MkdirAll(getMetatronOutputPath(taskID), os.FileMode(0700))
 }
 
-// RemovePassports removes a task's Metatron credential directory on the host
-func RemovePassports(taskID string) error {
-	err := os.RemoveAll(getPassportHostPath(taskID))
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("Failed to remove Metatron host path %s: %s", getPassportHostPath(taskID), err)
-	}
-	return nil
-}
-
 // GetPassports gets Metatron passports for a container/task and stores
 // them in a file system location.
 func (mts *TrustStore) GetPassports(ctx context.Context, encodedAppMetadata *string, encodedAppSig *string, taskID string, titusMetadata TitusMetadata) (*CredentialsConfig, error) {

--- a/executor/metatron/metatron.go
+++ b/executor/metatron/metatron.go
@@ -129,7 +129,8 @@ type TitusMetadata struct {
 	ImageName    string            `json:"imageName"`
 	ImageVersion string            `json:"imageVersion"`
 	ImageDigest  string            `json:"imageDigest"`
-	Entrypoint   string            `json:"entry"`
+	Entrypoint   []string          `json:"entry,omitempty"`
+	Command      []string          `json:"command,omitempty"`
 	Env          map[string]string `json:"env"`
 	TaskID       string            `json:"instanceId"`
 	LaunchTime   int64             `json:"launchTime"`
@@ -172,8 +173,12 @@ func createPassportDir(taskID string) error {
 
 // GetPassports gets Metatron passports for a container/task and stores
 // them in a file system location.
-func (mts *TrustStore) GetPassports(ctx context.Context, encodedAppMetadata *string, encodedAppSig *string, taskID string, titusMetadata TitusMetadata) (*CredentialsConfig, error) {
-	var err error
+func (mts *TrustStore) GetPassports(ctx context.Context, encodedAppMetadata string, encodedAppSig string, titusMetadata TitusMetadata) (*CredentialsConfig, error) {
+	var (
+		err    error
+		taskID = titusMetadata.TaskID
+	)
+
 	// Create a writeable directory path for the passports to go
 	if err = createPassportDir(taskID); err != nil {
 		return nil, err
@@ -184,8 +189,8 @@ func (mts *TrustStore) GetPassports(ctx context.Context, encodedAppMetadata *str
 	passportRequest := PassportRequest{
 		Version:        metatronRequestVersion,
 		RequestType:    metatronRequestType,
-		AppMetadata:    *encodedAppMetadata,
-		AppMetadataSig: *encodedAppSig,
+		AppMetadata:    encodedAppMetadata,
+		AppMetadataSig: encodedAppSig,
 		OutputPath:     outputPath,
 		TitusMetadata:  titusMetadata,
 	}

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -497,8 +497,8 @@ func mkGetMetatronConfigFunc(mts *metatron.TrustStore) func(ctx context.Context,
 		}
 		metatronConfig, err := mts.GetPassports(
 			ctx,
-			*c.TitusInfo.MetatronCreds.AppMetadata,
-			*c.TitusInfo.MetatronCreds.MetadataSig,
+			c.TitusInfo.GetMetatronCreds().GetAppMetadata(),
+			c.TitusInfo.GetMetatronCreds().GetMetadataSig(),
 			titusMetadata,
 		)
 		if err != nil {

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1024,7 +1024,7 @@ func (r *DockerRuntime) pushMetatron(parentCtx context.Context, c *runtimeTypes.
 	// TODO: Collapse these two into one tarball extract / copy, and not two
 
 	// Push trust store tar
-	if err := r.client.CopyToContainer(ctx, c.ID, "/", bytes.NewReader(mcc.TruststoreTarBuf.Bytes()), cco); err != nil {
+	if err := r.client.CopyToContainer(ctx, c.ID, "/", mcc.TruststoreTarBuf, cco); err != nil {
 		return err
 	}
 
@@ -1045,8 +1045,7 @@ func (r *DockerRuntime) pushMetatron(parentCtx context.Context, c *runtimeTypes.
 	if err := metatronTarWalk(tw, mcc); err != nil {
 		return err
 	}
-
-	return r.client.CopyToContainer(ctx, c.ID, "/", bytes.NewReader(tarBuf.Bytes()), cco)
+	return r.client.CopyToContainer(ctx, c.ID, "/", tarBuf, cco)
 }
 
 func (r *DockerRuntime) pushEnvironment(c *runtimeTypes.Container, imageInfo *types.ImageInspect) error { // nolint: gocyclo


### PR DESCRIPTION
### Description of the Change

`entrypoint` and `command` are now verified as arrays by metatron. Backwards and forwards compatibility is being done by the metatron service itself.