### PR TITLE
Wait for IPv6 address to be available at boot

### DIFF
--- a/vpc/allocate/allocate_network.go
+++ b/vpc/allocate/allocate_network.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
-
-	"path/filepath"
 
 	"github.com/Netflix/titus-executor/fslocker"
 	"github.com/Netflix/titus-executor/vpc"


### PR DESCRIPTION
Wait for the IPv6 Address to be usable before considering it done set…ting up

Previous to this, we would give up an IPv6 immediately to the container, but
due to the way SLAAC works, it takes a moment for the actual IPv6 address to
be usable.

This chooses a more conservative option, and waits for the address to become
usable before giving it to the user. On average, it takes about 5 seconds,
but I've seen as high as 20 seconds, when EC2 is having issues.
