### PR TITLE
This sets the default timeout and retries for the IAM service

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,14 @@ func NewConfig() (*Config, []cli.Flag) {
 		hardCodedEnv: []string{
 			"NETFLIX_APPUSER=appuser",
 			"EC2_DOMAIN=amazonaws.com",
+			/* See:
+			 * - https://docs.aws.amazon.com/cli/latest/topic/config-vars.html
+			 * - https://github.com/jtblin/kube2iam/issues/31
+			 * AWS_METADATA_SERVICE_TIMEOUT, and AWS_METADATA_SERVICE_NUM_ATTEMPTS are respected by all AWS standard SDKs
+			 * as timeouts for connecting to the metadata service.
+			 */
+			"AWS_METADATA_SERVICE_TIMEOUT=5",
+			"AWS_METADATA_SERVICE_NUM_ATTEMPTS=3",
 		},
 	}
 
@@ -162,7 +170,9 @@ func NewConfig() (*Config, []cli.Flag) {
 	return cfg, flags
 }
 
-func (c *Config) GetNetflixEnvForTask(taskInfo *titus.ContainerInfo, mem, cpu, disk, networkBandwidth string) map[string]string { // nolint: golint
+// GetNetflixEnvForTask fetches the "base" environment configuration, and adds in titus-specific environment variables
+// based on the ContainerInfo, and resources.
+func (c *Config) GetNetflixEnvForTask(taskInfo *titus.ContainerInfo, mem, cpu, disk, networkBandwidth string) map[string]string {
 	env := c.getEnvHardcoded()
 	env = appendMap(env, c.getEnvFromHost())
 	env = appendMap(env, c.getEnvBasedOnTask(taskInfo, mem, cpu, disk, networkBandwidth))

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Netflix/titus-executor/config"
 	"github.com/Netflix/titus-executor/executor/metatron"
 	vpcTypes "github.com/Netflix/titus-executor/vpc/types"
+
 	// The purpose of this is to tell gometalinter to keep vendoring this package
 	_ "github.com/Netflix/titus-api-definitions/src/main/proto/netflix/titus"
 	"github.com/Netflix/titus-executor/executor/dockershellparser"


### PR DESCRIPTION
When the container hits the metadata service for its IAM credentials, we lazily request them.
The Boto client expects this API to return in less than one second and return credentials.
This bumps the retries, and timeout to a bigger number.