### PR TITLE
Don't crash when the docker daemon doesn't respond

### DIFF
--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -106,13 +106,14 @@ func filterTitusContainers(containers []types.Container) []types.Container {
 
 func (reaper *Reaper) processContainer(ctx context.Context, container types.Container, dockerClient *docker.Client) {
 	containerJSON, err := dockerClient.ContainerInspect(ctx, container.ID)
-	taskID := containerJSON.Config.Labels[models.TaskIDLabel]
-	l := reaper.log.WithField("taskID", taskID)
 	if docker.IsErrContainerNotFound(err) {
 		return
 	} else if err != nil {
 		reaper.log.Fatal("Unable to fetch container JSON: ", err)
 	}
+
+	taskID := containerJSON.Config.Labels[models.TaskIDLabel]
+	l := reaper.log.WithField("taskID", taskID)
 
 	if shouldTerminate(ctx, &reaper.log, containerJSON) {
 		l.Info("Terminating container")


### PR DESCRIPTION
`titus-reaper` was crashing with "panic: runtime error: invalid memory address or nil pointer dereference" when there was an error talking to the Docker daemon.  The offending line in the stacktrace was titus-executor/reaper/reaper.go:109 