### PR TITLE
Allow attaching TTYs to containers

### DIFF
--- a/executor/mock/standalone/standalone_test.go
+++ b/executor/mock/standalone/standalone_test.go
@@ -122,6 +122,8 @@ func TestStandalone(t *testing.T) {
 		testNoCPUBursting,
 		testCPUBursting,
 		testTwoCPUs,
+		testTty,
+		testTtyNegative,
 	}
 	for _, fun := range testFunctions {
 		fullName := runtime.FuncForPC(reflect.ValueOf(fun).Pointer()).Name()
@@ -844,6 +846,32 @@ func testTwoCPUs(t *testing.T, jobID string) {
 		CPU:           &cpuCount,
 	}
 	if !mock.RunJobExpectingSuccess(ji) {
+		t.Fail()
+	}
+}
+
+func testTty(t *testing.T, jobID string) {
+	ji := &mock.JobInput{
+		ImageName:     ubuntu.name,
+		Version:       ubuntu.tag,
+		EntrypointOld: `/usr/bin/tty`,
+		JobID:         jobID,
+		Tty:           true,
+	}
+	if !mock.RunJobExpectingSuccess(ji) {
+		t.Fail()
+	}
+}
+
+func testTtyNegative(t *testing.T, jobID string) {
+	ji := &mock.JobInput{
+		ImageName:     ubuntu.name,
+		Version:       ubuntu.tag,
+		EntrypointOld: `/usr/bin/tty`,
+		JobID:         jobID,
+		// Tty not specified
+	}
+	if !mock.RunJobExpectingFailure(ji) {
 		t.Fail()
 	}
 }

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -407,6 +407,11 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 		return nil, nil, err
 	}
 
+	tty, err := c.GetTty()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	containerCfg := &container.Config{
 		Image:      c.QualifiedImageName(),
 		Entrypoint: entrypoint,
@@ -414,6 +419,7 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 		Labels:     c.Labels,
 		Volumes:    map[string]struct{}{},
 		Hostname:   hostname,
+		Tty:        tty,
 	}
 
 	useInit := true

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -27,6 +27,7 @@ const (
 	// FuseEnabledParam is a container atttribute set to enable FUSE
 	FuseEnabledParam       = "titusParameter.agent.fuseEnabled"
 	assignIPv6AddressParam = "titusParameter.agent.assignIPv6Address"
+	ttyEnabledParam        = "titusParameter.agent.ttyEnabled"
 )
 
 // ErrMissingIAMRole indicates that the Titus job was submitted without an IAM role
@@ -272,6 +273,20 @@ func (c *Container) AssignIPv6Address() (bool, error) {
 		return false, nil
 	}
 	val, err := strconv.ParseBool(assignIPv6AddressStr)
+	if err != nil {
+		return false, err
+	}
+
+	return val, nil
+}
+
+// GetTty should the container be assigned a tty?
+func (c *Container) GetTty() (bool, error) {
+	ttyEnabledStr, ok := c.TitusInfo.GetPassthroughAttributes()[ttyEnabledParam]
+	if !ok {
+		return false, nil
+	}
+	val, err := strconv.ParseBool(ttyEnabledStr)
 	if err != nil {
 		return false, err
 	}

--- a/executor/runtime/types/types_test.go
+++ b/executor/runtime/types/types_test.go
@@ -154,3 +154,14 @@ func TestIPv6AddressAssignment(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, assignIPv6Address)
 }
+
+func TestTtyEnabled(t *testing.T) {
+	c := Container{
+		TitusInfo: &titus.ContainerInfo{
+			PassthroughAttributes: map[string]string{ttyEnabledParam: "true"},
+		},
+	}
+	tty, err := c.GetTty()
+	assert.NoError(t, err)
+	assert.True(t, tty)
+}


### PR DESCRIPTION
This exposes a new passthrough parameter `titusParameter.agent.ttyEnabled`, which causes the container to be created with a tty (same as doing a `docker run --tty`).
