### PR TITLE
Linting docs, test and build changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,5 +140,5 @@ $(GOVENDOR):
 .PHONY: testdeps
 testdeps: $(GOVENDOR)
 	$(GOVENDOR) install +local
-	# Fail if gometalinter is not present in $PATH:
+	# Fail if gometalinter is not present in PATH:
 	which gometalinter

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ consistent versions of linters, install version 2.0.11 as per the instructions i
 
 To run lint checks:
 ```sh-session
+# Lint all files:
 make validate
+# Lint only the files that have changed in git:
+make validate FAST=1
 # Run lint checks inside a docker container:
 make validate-docker
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ If you want to build a dpkg, without Docker, once the code is checked out, you c
 make build-standalone
 ```
 
+## Linting
+Linting is done via the [gometalinter](https://github.com/alecthomas/gometalinter) package, which runs various linters. In order to ensure
+consistent versions of linters, install version 2.0.11 as per the instructions in "Initial setup steps" above.
+
+To run lint checks:
+```sh-session
+make validate
+# Run lint checks inside a docker container:
+make validate-docker
+```
 
 ## Testing
 ### Local Testing

--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -117,7 +117,7 @@ if [[ $num_debs -ne 1 ]]; then
     exit 1
 fi
 
-filename=${outdir}/*.deb
+filename=$(ls -t ${outdir}/*.deb | grep -v latest | head -n 1)
 
 # TODO: only run the linter on the file above
 # see: nebula/src/main/groovy/netflix/nebula/ospackage/NebulaOsPackageDebRepositoryPublish.groovy


### PR DESCRIPTION
This includes:
* Adding linting instructions to the README
* Fixing a build issue when you've been doing multiple builds on the same machine
* Allowing the docker in docker test timeout to be overridden
* A minor Makefile comment fix