### PR TITLE
Add labels describing resource allocation to containers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,8 @@ const (
 )
 
 // Config contains the executor configuration
-type Config struct { // nolint: maligned
+type Config struct {
+	// nolint: maligned
 	// MetatronEnabled returns if Metatron is enabled
 	MetatronEnabled bool
 	// PrivilegedContainersEnabled returns whether to give tasks CAP_SYS_ADMIN

--- a/executor/runtime/container.go
+++ b/executor/runtime/container.go
@@ -12,12 +12,17 @@ import (
 func NewContainer(taskID string, titusInfo *titus.ContainerInfo, constraints *runtimeTypes.Resources, labels map[string]string, cfg config.Config) *runtimeTypes.Container {
 	networkCfgParams := titusInfo.GetNetworkConfigInfo()
 
-	env := cfg.GetNetflixEnvForTask(titusInfo,
-		strconv.FormatInt(constraints.Mem, 10),
-		strconv.FormatInt(constraints.CPU, 10),
-		strconv.FormatUint(constraints.Disk, 10),
-		strconv.FormatUint(uint64(networkCfgParams.GetBandwidthLimitMbps()), 10))
+	strCPU := strconv.FormatInt(constraints.CPU, 10)
+	strMem := strconv.FormatInt(constraints.Mem, 10)
+	strDisk := strconv.FormatUint(constraints.Disk, 10)
+	strNetwork := strconv.FormatUint(uint64(networkCfgParams.GetBandwidthLimitMbps()), 10)
+
+	env := cfg.GetNetflixEnvForTask(titusInfo, strMem, strCPU, strDisk, strNetwork)
 	labels["TITUS_TASK_INSTANCE_ID"] = env["TITUS_TASK_INSTANCE_ID"]
+	labels["com.netflix.titus.cpu"] = strCPU
+	labels["com.netflix.titus.mem"] = strMem
+	labels["com.netflix.titus.disk"] = strDisk
+	labels["com.netflix.titus.network"] = strNetwork
 
 	c := &runtimeTypes.Container{
 		TaskID:             taskID,

--- a/executor/runtime/container.go
+++ b/executor/runtime/container.go
@@ -8,26 +8,58 @@ import (
 	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
 )
 
+const (
+	cpuLabelKey            = "com.netflix.titus.cpu"
+	memLabelKey            = "com.netflix.titus.mem"
+	diskLabelKey           = "com.netflix.titus.disk"
+	networkLabelKey        = "com.netflix.titus.network"
+	workloadTypeLabelKey   = "com.netflix.titus.workload.type"
+	titusTaskInstanceIDKey = "TITUS_TASK_INSTANCE_ID"
+)
+
+// WorkloadType classifies isolation behaviors on resources (e.g. CPU).  The exact implementation details of the
+// isolation mechanism are determine by an isolation service (e.g. titus-isolate).
+type WorkloadType string
+
+// Regardless of isolation mechanism:
+//
+//     "static" workloads are provided resources which to the greatest degree possible are isolated from other workloads
+//     on a given host.  In return they opt out of the opportunity to consume unused resources opportunistically.
+//
+//     "burst" workloads opt in to consumption of unused resources on a host at the cost of accepting the possibility of
+//     more resource interference from other workloads.
+const (
+	StaticWorkloadType WorkloadType = "static"
+	BurstWorkloadType  WorkloadType = "burst"
+)
+
 // NewContainer allocates and initializes a new container struct object
-func NewContainer(taskID string, titusInfo *titus.ContainerInfo, constraints *runtimeTypes.Resources, labels map[string]string, cfg config.Config) *runtimeTypes.Container {
+func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources *runtimeTypes.Resources, labels map[string]string, cfg config.Config) *runtimeTypes.Container {
 	networkCfgParams := titusInfo.GetNetworkConfigInfo()
 
-	strCPU := strconv.FormatInt(constraints.CPU, 10)
-	strMem := strconv.FormatInt(constraints.Mem, 10)
-	strDisk := strconv.FormatUint(constraints.Disk, 10)
+	strCPU := strconv.FormatInt(resources.CPU, 10)
+	strMem := strconv.FormatInt(resources.Mem, 10)
+	strDisk := strconv.FormatUint(resources.Disk, 10)
 	strNetwork := strconv.FormatUint(uint64(networkCfgParams.GetBandwidthLimitMbps()), 10)
 
 	env := cfg.GetNetflixEnvForTask(titusInfo, strMem, strCPU, strDisk, strNetwork)
-	labels["TITUS_TASK_INSTANCE_ID"] = env["TITUS_TASK_INSTANCE_ID"]
-	labels["com.netflix.titus.cpu"] = strCPU
-	labels["com.netflix.titus.mem"] = strMem
-	labels["com.netflix.titus.disk"] = strDisk
-	labels["com.netflix.titus.network"] = strNetwork
+	labels[titusTaskInstanceIDKey] = env[titusTaskInstanceIDKey]
+	labels[cpuLabelKey] = strCPU
+	labels[memLabelKey] = strMem
+	labels[diskLabelKey] = strDisk
+	labels[networkLabelKey] = strNetwork
+
+	workloadType := StaticWorkloadType
+	if titusInfo.GetAllowCpuBursting() {
+		workloadType = BurstWorkloadType
+	}
+
+	labels[workloadTypeLabelKey] = string(workloadType)
 
 	c := &runtimeTypes.Container{
 		TaskID:             taskID,
 		TitusInfo:          titusInfo,
-		Resources:          constraints,
+		Resources:          resources,
 		Env:                env,
 		Labels:             labels,
 		SecurityGroupIDs:   networkCfgParams.GetSecurityGroups(),


### PR DESCRIPTION
Docker container creation events don't contain information about resources.  In order to avoid a second call to inspect a container after construction we put this information in _small_ labels on the container here.

```bash
$ docker run --rm --label com.netflix.titus.cpu=1 --cpu-shares 100 ubuntu:latest ls
...
```

```bash
$ docker events --format "{{json .}}" | jq .
{
  "status": "create",
  "id": "d15607d8bb28b8a8038cc80b49ef65e22b1669c25e3af07131be4e60595320e9",
  "from": "ubuntu:latest",
  "Type": "container",
  "Action": "create",
  "Actor": {
    "ID": "d15607d8bb28b8a8038cc80b49ef65e22b1669c25e3af07131be4e60595320e9",
    "Attributes": {
      "com.netflix.titus.cpu": "1",
      "image": "ubuntu:latest",
      "name": "gifted_vaughan"
    }
  },
  "scope": "local",
  "time": 1539819620,
  "timeNano": 1539819620158171600
}
...
```