### PR TITLE
Add titus-sshd docker build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,23 @@ jobs:
       - run:
           name: Push builder image
           command: docker push titusoss/titus-ci-builder
+  titus-sshd:
+    resource_class: xlarge
+    docker:
+      - image: docker:17.05.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Login into Docker hub
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Build titus-sshd image
+          command: docker build -t titusoss/titus-sshd hack/titus-sshd
+      - run:
+          name: Push titus-sshd image
+          command: docker push titusoss/titus-sshd
   test-local:
     docker:
       - image: titusoss/titus-ci-builder


### PR DESCRIPTION
### Description of the Change

This builds the Titus SSHD image, and pushes it to Docker Hub