### PR TITLE
make it easier to override the nflx env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ checkstyle-result.xml
 /root/apps/titus-executor/bin/titus-launchguard-server
 /root/apps/titus-executor/bin/titus-standalone
 /root/apps/titus-executor/bin/titus-vpc-tool
+/root/apps/titus-executor/bin/titus-nsenter
 
 /mount/titus-mount
 

--- a/executor/mock/standalone/standalone_test.go
+++ b/executor/mock/standalone/standalone_test.go
@@ -813,7 +813,7 @@ func testNewEnvironmentLocationPositive(t *testing.T, jobID string) {
 	ji := &mock.JobInput{
 		ImageName:     envLabel.name,
 		Version:       envLabel.tag,
-		EntrypointOld: `cat /etc/nflx/base-environment.d/titus`,
+		EntrypointOld: `cat /etc/nflx/base-environment.d/200titus`,
 		JobID:         jobID,
 	}
 	if !mock.RunJobExpectingSuccess(ji) {
@@ -849,7 +849,7 @@ func testOldEnvironmentLocationNegative(t *testing.T, jobID string) {
 	ji := &mock.JobInput{
 		ImageName:     ubuntu.name,
 		Version:       ubuntu.tag,
-		EntrypointOld: `cat /etc/nflx/base-environment.d/titus`,
+		EntrypointOld: `cat /etc/nflx/base-environment.d/200titus`,
 		JobID:         jobID,
 	}
 	if !mock.RunJobExpectingFailure(ji) {

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1150,7 +1150,7 @@ func (r *DockerRuntime) pushEnvironment(c *runtimeTypes.Container, imageInfo *ty
 
 	path := "etc/profile.d/netflix_environment.sh"
 	if version, ok := imageInfo.Config.Labels["nflxenv"]; ok && strings.HasPrefix(version, "1.") {
-		path = "etc/nflx/base-environment.d/titus"
+		path = "etc/nflx/base-environment.d/200titus"
 	}
 
 	hdr := &tar.Header{


### PR DESCRIPTION
All other nflx env files provided by nflx base images follow the convention of prefixing files in /etc/nflx/base-environment.d/ with a number in the NNN format. This will make it easier to
override variables defined in the file supplied by the titus executor, and ensure that overrides are loaded after the titus file (for the common use case of loading files in the alphabetical order).

cc @bmoyles @amit-git 