### PR TITLE
Pessimistically allocate IPv6 addresses

### DIFF
--- a/root/apps/titus-executor/bin/run
+++ b/root/apps/titus-executor/bin/run
@@ -14,8 +14,11 @@ if [[ -e /etc/profile.d/titus_environment.sh ]]; then
   . /etc/profile.d/titus_environment.sh
 fi
 
+# This might break if the user always intended to have allexport set
 if [[ -e /etc/titus-executor/config.sh ]]; then
+  set -o allexport
   . /etc/titus-executor/config.sh
+  set +o allexport
 fi
 
 log_bucket=${TITUS_LOG_BUCKET}

--- a/vpc/allocate/allocate_network.go
+++ b/vpc/allocate/allocate_network.go
@@ -250,7 +250,7 @@ func doAllocateNetwork(parentCtx *context.VPCContext, deviceIdx, batchSize int, 
 
 	// Optionally, get an IPv6 address
 	if allocateIPv6Address {
-		allocation.ip6Address, allocation.exclusiveIP6Lock, err = ipPoolManager.allocateIPv6(ctx, networkInterface)
+		allocation.ip6Address, allocation.exclusiveIP6Lock, err = ipPoolManager.allocateIPv6(ctx, batchSize, ipRefreshTimeout)
 		if err != nil {
 			allocation.deallocate(ctx)
 			return nil, err

--- a/vpc/ec2wrapper/ec2metadata_test.go
+++ b/vpc/ec2wrapper/ec2metadata_test.go
@@ -1,0 +1,140 @@
+package ec2wrapper
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+const region = "us-east-1"
+const primaryInterfaceMac = "aa:bb:cc:dd:ee:ff"
+const secondaryInterfaceMac = "11:22:33:44:55:66"
+
+var errUnknownEndpoint = errors.New("Unknown endpoint")
+
+func init() {
+	logrus.SetLevel(logrus.DebugLevel)
+}
+
+type testInterface struct {
+	mac              string
+	deviceNumber     int
+	interfaceID      string
+	ipv4s            []string
+	ipv6s            []string
+	securityGroupIds []string
+}
+
+func (ti *testInterface) getMetadata(p string) (string, error) {
+	if p == "device-number" {
+		return fmt.Sprintf("%d\n", ti.deviceNumber), nil
+	} else if p == "interface-id" {
+		return fmt.Sprintf("%s\n", ti.interfaceID), nil
+	} else if p == "subnet-id" {
+		return "subnet-foo", nil
+	} else if p == "security-group-ids" {
+		return fmt.Sprintf("%s\n", strings.Join(ti.securityGroupIds, "\n")), nil
+	} else if p == "local-ipv4s" {
+		return fmt.Sprintf("%s\n", strings.Join(ti.ipv4s, "\n")), nil
+	} else if p == "ipv6s" {
+		return fmt.Sprintf("%s\n", strings.Join(ti.ipv6s, "\n")), nil
+	}
+
+	return "", errUnknownEndpoint
+}
+
+type testMetadataServer struct {
+	interfaces map[string]*testInterface
+}
+
+func (*testMetadataServer) Available() bool {
+	return true
+}
+
+func (*testMetadataServer) GetDynamicData(p string) (string, error) {
+	panic("GetDynamicData not implemented")
+}
+
+func (*testMetadataServer) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
+	panic("GetInstanceIdentityDocument not implemented")
+}
+
+func (tms *testMetadataServer) GetMetadata(p string) (string, error) {
+	logrus.WithField("path", p).Info("Handling request")
+	path := strings.Trim(p, "/")
+	if path == "mac" {
+		return fmt.Sprintf("%s\n", primaryInterfaceMac), nil
+	} else if path == "network/interfaces/macs" {
+		ret := ""
+		for mac := range tms.interfaces {
+			ret = fmt.Sprintf("%s/\n%s", mac, ret)
+		}
+		return ret, nil
+	} else if strings.HasPrefix(path, "network/interfaces/macs/") {
+		subPath := strings.TrimPrefix(path, "network/interfaces/macs/")
+		mac := strings.Split(subPath, "/")[0]
+		iface := tms.interfaces[mac]
+		if iface == nil {
+			panic("Received request for unknown interface")
+		}
+		return iface.getMetadata(strings.TrimPrefix(subPath, mac+"/"))
+	}
+
+	return "", errUnknownEndpoint
+}
+
+func (*testMetadataServer) GetUserData() (string, error) {
+	panic("GetUserData not implemented")
+}
+
+func (*testMetadataServer) IAMInfo() (ec2metadata.EC2IAMInfo, error) {
+	panic("IAMInfo not implemented")
+}
+
+func (*testMetadataServer) Region() (string, error) {
+	return region, nil
+}
+
+func TestMetadataService(t *testing.T) {
+
+	logger := logrus.New()
+	logger.Level = logrus.DebugLevel
+	primaryInterface := &testInterface{
+		mac:          primaryInterfaceMac,
+		deviceNumber: 0,
+		interfaceID:  "eni-primary",
+	}
+	secondaryInterface := &testInterface{
+		mac:          secondaryInterfaceMac,
+		ipv4s:        []string{"01.2.3.4", "9.8.1.02"},
+		ipv6s:        []string{"2604:5000::bb", "aa:0000:0000::cc"},
+		deviceNumber: 1,
+		interfaceID:  "eni-secondary",
+	}
+	tms := &testMetadataServer{
+		interfaces: map[string]*testInterface{
+			primaryInterfaceMac:   primaryInterface,
+			secondaryInterfaceMac: secondaryInterface,
+		},
+	}
+
+	ec2MetadataClientWrapper := EC2MetadataClientWrapper{
+		logger:      logger.WithField("logger", "EC2MetadataClientWrapperTest"),
+		ec2metadata: tms,
+	}
+
+	mac, err := ec2MetadataClientWrapper.PrimaryInterfaceMac()
+	assert.Nil(t, err)
+	assert.Equal(t, primaryInterfaceMac, mac)
+
+	interfaces, err := ec2MetadataClientWrapper.Interfaces()
+	assert.Nil(t, err)
+	assert.Len(t, interfaces, 2)
+	assert.Equal(t, []string{"1.2.3.4", "9.8.1.2"}, interfaces[secondaryInterfaceMac].GetIPv4Addresses())
+	assert.Equal(t, []string{"2604:5000::bb", "aa::cc"}, interfaces[secondaryInterfaceMac].GetIPv6Addresses())
+}

--- a/vpc/genconf/genconf.go
+++ b/vpc/genconf/genconf.go
@@ -41,7 +41,7 @@ func genConf(parentCtx *context.VPCContext) error {
 
 func doGenConf(parentCtx *context.VPCContext) error {
 	maxInterfaces := vpc.GetMaxInterfaces(parentCtx.InstanceType)
-	maxIPs := vpc.GetMaxIPv4Addresses(parentCtx.InstanceType)
+	maxIPs := vpc.GetMaxIPAddresses(parentCtx.InstanceType)
 	maxNetworkMbps := vpc.GetMaxNetworkMbps(parentCtx.InstanceType)
 	// The number of interfaces exposed to the Titus scheduler is the maximum number of interfaces this instance can handle minus 1.
 	resourceSet := fmt.Sprintf("ResourceSet-ENIs-%d-%d", maxInterfaces-1, maxIPs)

--- a/vpc/limits.go
+++ b/vpc/limits.go
@@ -6,9 +6,8 @@ import (
 )
 
 type limits struct {
-	interfaces               int
-	ipAddressesPerInterface  int
-	ip6AddressesPerInterface int
+	interfaces              int
+	ipAddressesPerInterface int
 	// in Mbps
 	networkThroughput int
 }
@@ -16,216 +15,183 @@ type limits struct {
 var interfaceLimits = map[string]map[string]limits{
 	"m4": {
 		"large": limits{
-			interfaces:               2,
-			ipAddressesPerInterface:  10,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        100,
+			interfaces:              2,
+			ipAddressesPerInterface: 10,
+			networkThroughput:       100,
 		},
 		"xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        1000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       1000,
 		},
 		"2xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        1000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       1000,
 		},
 		"4xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        2000,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       2000,
 		},
 		"10xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
 			// Is this number correct?
 			networkThroughput: 10000,
 		},
 		"16xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        23000,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       23000,
 		},
 	},
 	"m5": {
 		"large": limits{
-			interfaces:               3,
-			ipAddressesPerInterface:  10,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        100,
+			interfaces:              3,
+			ipAddressesPerInterface: 10,
+			networkThroughput:       100,
 		},
 		"xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        1000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       1000,
 		},
 		"2xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        1000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       1000,
 		},
 		"4xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        2000,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       2000,
 		},
 		"12xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
 			// Is this number correct?
 			networkThroughput: 10000,
 		},
 		"24xlarge": limits{
-			interfaces:               15,
-			ipAddressesPerInterface:  50,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        23000,
+			interfaces:              15,
+			ipAddressesPerInterface: 50,
+			networkThroughput:       23000,
 		},
 	},
 	"r4": {
 		"large": limits{
-			interfaces:               3,
-			ipAddressesPerInterface:  10,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        1000,
+			interfaces:              3,
+			ipAddressesPerInterface: 10,
+			networkThroughput:       1000,
 		},
 		"xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        1000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       1000,
 		},
 		"2xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        2000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       2000,
 		},
 		"4xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        4000,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       4000,
 		},
 		"8xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        9000,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       9000,
 		},
 		"16xlarge": limits{
-			interfaces:               15,
-			ipAddressesPerInterface:  24,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        23000,
+			interfaces:              15,
+			ipAddressesPerInterface: 24,
+			networkThroughput:       23000,
 		},
 	},
 	"r5": {
 		"large": limits{
-			interfaces:               3,
-			ipAddressesPerInterface:  10,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        1000,
+			interfaces:              3,
+			ipAddressesPerInterface: 10,
+			networkThroughput:       1000,
 		},
 		"xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        1000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       1000,
 		},
 		"2xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        2000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       2000,
 		},
 		"4xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        4000,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       4000,
 		},
 		"12xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        9000,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       9000,
 		},
 		"24xlarge": limits{
-			interfaces:               15,
-			ipAddressesPerInterface:  50,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        23000,
+			interfaces:              15,
+			ipAddressesPerInterface: 50,
+			networkThroughput:       23000,
 		},
 	},
 	"p2": {
 		"xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
 			// Maybe?
 			networkThroughput: 2000,
 		},
 		"8xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        6000,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       6000,
 		},
 		"16xlarge": limits{
-			interfaces:               8,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        20000,
+			interfaces:              8,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       20000,
 		},
 	},
 	"c5": {
 		"large": limits{
-			interfaces:               3,
-			ipAddressesPerInterface:  10,
-			ip6AddressesPerInterface: 2,
+			interfaces:              3,
+			ipAddressesPerInterface: 10,
 			// Maybe?
 			networkThroughput: 1000,
 		},
 		"xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        2000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       2000,
 		},
 		"2xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  15,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        2000,
+			interfaces:              4,
+			ipAddressesPerInterface: 15,
+			networkThroughput:       2000,
 		},
 		"4xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        4000,
+			interfaces:              4,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       4000,
 		},
 		"9xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  30,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        10000,
+			interfaces:              4,
+			ipAddressesPerInterface: 30,
+			networkThroughput:       10000,
 		},
 		"18xlarge": limits{
-			interfaces:               4,
-			ipAddressesPerInterface:  50,
-			ip6AddressesPerInterface: 2,
-			networkThroughput:        23000,
+			interfaces:              4,
+			ipAddressesPerInterface: 50,
+			networkThroughput:       23000,
 		},
 	},
 }
@@ -253,14 +219,9 @@ func GetMaxInterfaces(instanceType string) int {
 	return getLimits(instanceType).interfaces
 }
 
-// GetMaxIPv4Addresses returns  the maximum number of IPv4 addresses that this instance type can handle
-func GetMaxIPv4Addresses(instanceType string) int {
+// GetMaxIPAddresses returns  the maximum number of IPv4 addresses that this instance type can handle
+func GetMaxIPAddresses(instanceType string) int {
 	return getLimits(instanceType).ipAddressesPerInterface
-}
-
-// GetMaxIPv6Addresses returns  the maximum number of IPv6 addresses that this instance type can handle per interface
-func GetMaxIPv6Addresses(instanceType string) int {
-	return getLimits(instanceType).ip6AddressesPerInterface
 }
 
 // GetMaxNetworkMbps returns the maximum network throughput in Megabits per second that this instance type can handle

--- a/vpc/setup/setup.go
+++ b/vpc/setup/setup.go
@@ -109,9 +109,11 @@ func attachInterfaceAtIdx(ctx *context.VPCContext, instanceID, subnetID string, 
 	svc := ec2.New(ctx.AWSSession)
 
 	createNetworkInterfaceInput := &ec2.CreateNetworkInterfaceInput{
-		Description:      aws.String(vpc.NetworkInterfaceDescription),
-		SubnetId:         aws.String(subnetID),
-		Ipv6AddressCount: aws.Int64(int64(vpc.GetMaxIPv6Addresses(ctx.InstanceType))),
+		Description: aws.String(vpc.NetworkInterfaceDescription),
+		SubnetId:    aws.String(subnetID),
+		// We know there will always be at least 1 IPv6 address, and this way we also can check if the subnet is wired
+		// up with v6
+		Ipv6AddressCount: aws.Int64(1),
 	}
 	createNetworkInterfaceResult, err := svc.CreateNetworkInterfaceWithContext(ctx, createNetworkInterfaceInput)
 	if err != nil {


### PR DESCRIPTION
 * This changes it so that it assumes the IPv4 and IPv6 address limit are
   the same. This is true for all the instance types we care about
 * This adds basic tests for IPv6 allocation
 * This only allocates 1 IPv6 address at ENI creation time (vs 3)
 * This adds tests around the allocation logic

