### PR TITLE
Security. (Around Titus SSH).

### DIFF
--- a/executor/runtime/docker/capabilities.go
+++ b/executor/runtime/docker/capabilities.go
@@ -42,7 +42,7 @@ func setupAdditionalCapabilities(c *runtimeTypes.Container, hostCfg *container.H
 		}
 	}
 	seccompProfile := "default.json"
-	apparmorProfile := ""
+	apparmorProfile := "docker-titus"
 
 	if fuseEnabled {
 		hostCfg.Resources.Devices = append(hostCfg.Resources.Devices, container.DeviceMapping{
@@ -63,9 +63,7 @@ func setupAdditionalCapabilities(c *runtimeTypes.Container, hostCfg *container.H
 		c.Env["TINI_UNSHARE"] = trueString
 	}
 
-	if apparmorProfile != "" {
-		hostCfg.SecurityOpt = append(hostCfg.SecurityOpt, "apparmor:"+apparmorProfile)
-	}
+	hostCfg.SecurityOpt = append(hostCfg.SecurityOpt, "apparmor:"+apparmorProfile)
 	hostCfg.SecurityOpt = append(hostCfg.SecurityOpt, fmt.Sprintf("seccomp=%s", string(seccomp.MustAsset(seccompProfile))))
 
 	return nil

--- a/executor/runtime/docker/capabilities_test.go
+++ b/executor/runtime/docker/capabilities_test.go
@@ -20,7 +20,8 @@ func TestDefaultProfile(t *testing.T) {
 
 	assert.Len(t, hostConfig.CapAdd, 0)
 	assert.Len(t, hostConfig.CapDrop, 0)
-	assert.Len(t, hostConfig.SecurityOpt, 1)
+	assert.Contains(t, hostConfig.SecurityOpt, "apparmor:docker-titus")
+	assert.Len(t, hostConfig.SecurityOpt, 2)
 }
 
 func TestFuseProfile(t *testing.T) {

--- a/executor/runtime/docker/docker_ssh.go
+++ b/executor/runtime/docker/docker_ssh.go
@@ -38,7 +38,7 @@ PermitRootLogin without-password
 StrictModes yes
 
 PubkeyAuthentication yes
-#AuthorizedKeysFile	%h/.ssh/authorized_keys
+AuthorizedKeysFile	/titus/ssh_keys/%u
 
 TrustedUserCAKeys /titus/etc/ssh/trusted_user_ca_keys.pub
 AuthorizedPrincipalsFile /titus/etc/ssh/authorized_principals_%u

--- a/root/etc/apparmor.d/docker-fuse
+++ b/root/etc/apparmor.d/docker-fuse
@@ -19,6 +19,8 @@ profile docker-fuse flags=(attach_disconnected,mediate_deleted) {
   deny mount fstype=cgroup2,
 
   deny mount ** -> /,
+  deny mount ** -> /titus/**,
+  deny mount ** -> /titus/,
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/root/etc/apparmor.d/docker-fuse
+++ b/root/etc/apparmor.d/docker-fuse
@@ -38,4 +38,6 @@ profile docker-fuse flags=(attach_disconnected,mediate_deleted) {
   deny /sys/kernel/security/** rwklx,
 
   ptrace (trace,read) peer=docker-fuse,
+
+  deny /titus/** wl,
 }

--- a/root/etc/apparmor.d/docker-titus
+++ b/root/etc/apparmor.d/docker-titus
@@ -1,26 +1,15 @@
 #include <tunables/global>
 
-profile docker-fuse flags=(attach_disconnected,mediate_deleted) {
+profile docker-titus flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   network,
   capability,
   file,
   umount,
-  mount,
 
-  deny mount fstype=tmpfs,
-  deny mount fstype=ramfs,
-  deny mount fstype=sysfs,
-  deny mount fstype=proc,
-  deny mount fstype=debugfs,
-  deny mount fstype=devtmpfs,
-  deny mount fstype=cgroup,
-  deny mount fstype=cgroup2,
+  signal (send,receive) peer=docker-titus,
 
-  deny mount ** -> /,
-  deny mount ** -> /titus/**,
-  deny mount ** -> /titus/,
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
@@ -28,7 +17,7 @@ profile docker-fuse flags=(attach_disconnected,mediate_deleted) {
   deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
   deny @{PROC}/sysrq-trigger rwklx,
   deny @{PROC}/kcore rwklx,
-
+  deny mount,
   deny /sys/[^f]*/** wklx,
   deny /sys/f[^s]*/** wklx,
   deny /sys/fs/[^c]*/** wklx,
@@ -37,8 +26,8 @@ profile docker-fuse flags=(attach_disconnected,mediate_deleted) {
   deny /sys/firmware/** rwklx,
   deny /sys/kernel/security/** rwklx,
 
-  ptrace (trace,read) peer=docker-fuse,
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
 
   deny /titus/** wl,
 }
-


### PR DESCRIPTION
Users could write to the config under /titus, and then change it so they can get privilege from our SSH daemon. Given this is a pretty big attack vector, let's lock it down. This brings the default apparmor profile into Titus executor itself, and locks down all writes from the container(s) to /titus/*