### PR TITLE
Mount /run as tmpfs, and default to 128MiB of size

### DIFF
--- a/executor/mock/jobrunner.go
+++ b/executor/mock/jobrunner.go
@@ -64,6 +64,8 @@ type JobInput struct {
 	Tty bool
 	// MetatronEnabled enables running with the metatron sidecar container
 	MetatronEnabled bool
+	// Mem sets the memory resource attribute in MiB
+	Mem *int64
 }
 
 // JobRunResponse returned from RunJob
@@ -303,6 +305,9 @@ func (jobRunner *JobRunner) StartJob(jobInput *JobInput) *JobRunResponse { // no
 		cpu = *jobInput.CPU
 	}
 	memMiB := int64(400)
+	if jobInput.Mem != nil {
+		memMiB = *jobInput.Mem
+	}
 	diskMiB := uint64(100)
 
 	// Get a reference to the executor and somewhere to stash results

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -59,6 +59,7 @@ const (
 	builtInDiskBuffer       = 1100 // In megabytes, includes extra space for /logs.
 	defaultNetworkBandwidth = 128 * MB
 	defaultKillWait         = 10 * time.Second
+	defaultRunTmpFsSize     = "134217728" // 128 MiB
 	trueString              = "true"
 	jumboFrameParam         = "titusParameter.agent.allowNetworkJumbo"
 )
@@ -483,6 +484,11 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 
 	// Maybe set cfs bandwidth has to be called _after_
 	maybeSetCFSBandwidth(r.dockerCfg.cfsBandwidthPeriod, c, hostCfg)
+
+	// Always setup tmpfs: it's needed to ensure Metatron credentials don't persist across reboots and for SystemD to work
+	hostCfg.Tmpfs = map[string]string{
+		"/run": "rw,noexec,nosuid,size=" + defaultRunTmpFsSize,
+	}
 
 	if r.storageOptEnabled {
 		hostCfg.StorageOpt = map[string]string{


### PR DESCRIPTION
We can now do this, since we don't use `docker cp` to copy in the Metatron certs.
