### PR TITLE
Ensure /run is executable for backward compatibility

### DIFF
--- a/executor/mock/standalone/standalone_test.go
+++ b/executor/mock/standalone/standalone_test.go
@@ -141,6 +141,7 @@ func TestStandalone(t *testing.T) {
 		testCachedDockerPull,
 		testMetatron,
 		testRunTmpFsMount,
+		testExecSlashRun,
 	}
 	for _, fun := range testFunctions {
 		fullName := runtime.FuncForPC(reflect.ValueOf(fun).Pointer()).Name()
@@ -971,6 +972,19 @@ func testRunTmpFsMount(t *testing.T, jobID string) {
 		Version:       ubuntu.tag,
 		Mem:           &mem,
 		EntrypointOld: `/bin/bash -c 'findmnt -l -t tmpfs -o target,size | grep -e "/run[^/]" | grep 128M'`,
+		JobID:         jobID,
+	}
+	if !mock.RunJobExpectingSuccess(ji) {
+		t.Fail()
+	}
+}
+
+// Test that we can execute files in `/run`
+func testExecSlashRun(t *testing.T, jobID string) {
+	ji := &mock.JobInput{
+		ImageName:     ubuntu.name,
+		Version:       ubuntu.tag,
+		EntrypointOld: `/bin/bash -c 'cp /bin/ls /run/ && /run/ls'`,
 		JobID:         jobID,
 	}
 	if !mock.RunJobExpectingSuccess(ji) {

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -487,7 +487,7 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 
 	// Always setup tmpfs: it's needed to ensure Metatron credentials don't persist across reboots and for SystemD to work
 	hostCfg.Tmpfs = map[string]string{
-		"/run": "rw,noexec,nosuid,size=" + defaultRunTmpFsSize,
+		"/run": "rw,exec,suid,size=" + defaultRunTmpFsSize,
 	}
 
 	if r.storageOptEnabled {


### PR DESCRIPTION
The previous pre-tmpfs behaviour was to allow executables in `/run`, so preserve that behaviour.
