### PR TITLE
Label Docker containers with app name

### DIFF
--- a/executor/runtime/container.go
+++ b/executor/runtime/container.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	appNameLabelKey        = "com.netflix.titus.appName"
 	cpuLabelKey            = "com.netflix.titus.cpu"
 	memLabelKey            = "com.netflix.titus.mem"
 	diskLabelKey           = "com.netflix.titus.disk"
@@ -43,6 +44,7 @@ func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources *runt
 	strNetwork := strconv.FormatUint(uint64(networkCfgParams.GetBandwidthLimitMbps()), 10)
 
 	env := cfg.GetNetflixEnvForTask(titusInfo, strMem, strCPU, strDisk, strNetwork)
+	labels[appNameLabelKey] = titusInfo.GetAppName()
 	labels[titusTaskInstanceIDKey] = env[titusTaskInstanceIDKey]
 	labels[cpuLabelKey] = strCPU
 	labels[memLabelKey] = strMem

--- a/executor/runtime/container_test.go
+++ b/executor/runtime/container_test.go
@@ -83,6 +83,7 @@ func TestImageByDigestIgnoresTag(t *testing.T) {
 
 func TestNewContainer(t *testing.T) {
 	taskID := "task-id"
+	expectedAppName := "appName"
 	expectedCPU := int64(2)
 	expectedMem := int64(1024)
 	expectedDisk := uint64(15000)
@@ -100,6 +101,7 @@ func TestNewContainer(t *testing.T) {
 	expectedDigest := "abcd0123"
 
 	containerInfo := &titus.ContainerInfo{
+		AppName:   &expectedAppName,
 		ImageName: protobuf.String("titusoss/alpine"),
 		Version:   protobuf.String("latest"),
 		NetworkConfigInfo: &titus.ContainerInfo_NetworkConfigInfo{
@@ -124,6 +126,9 @@ func TestNewContainer(t *testing.T) {
 	config := config.Config{}
 
 	container := NewContainer(taskID, containerInfo, resources, labels, config)
+
+	actualAppName := container.Labels[appNameLabelKey]
+	assert.Equal(t, expectedAppName, actualAppName)
 
 	actualCPU, _ := strconv.ParseInt(container.Labels[cpuLabelKey], 10, 64)
 	assert.Equal(t, expectedCPU, actualCPU)


### PR DESCRIPTION
### Description of the Change

The app name for a given container is very predictive of CPU processing time in the model developed for oversubscription.  We will also need to add the user e-mail address in a subsequent PR once @corindwyer starts passing that information to the Executor.
