### PR TITLE
Add owner e-mail and job type labels for consumption by the cpu prediction model

### DIFF
--- a/executor/runtime/container.go
+++ b/executor/runtime/container.go
@@ -9,13 +9,17 @@ import (
 )
 
 const (
-	appNameLabelKey        = "com.netflix.titus.appName"
-	cpuLabelKey            = "com.netflix.titus.cpu"
-	memLabelKey            = "com.netflix.titus.mem"
-	diskLabelKey           = "com.netflix.titus.disk"
-	networkLabelKey        = "com.netflix.titus.network"
-	workloadTypeLabelKey   = "com.netflix.titus.workload.type"
-	titusTaskInstanceIDKey = "TITUS_TASK_INSTANCE_ID"
+	appNameLabelKey          = "com.netflix.titus.appName"
+	cpuLabelKey              = "com.netflix.titus.cpu"
+	memLabelKey              = "com.netflix.titus.mem"
+	diskLabelKey             = "com.netflix.titus.disk"
+	networkLabelKey          = "com.netflix.titus.network"
+	workloadTypeLabelKey     = "com.netflix.titus.workload.type"
+	ownerEmailLabelKey       = "com.netflix.titus.owner.email"
+	ownerEmailPassThroughKey = "titus.agent.ownerEmail"
+	jobTypeLabelKey          = "com.netflix.titus.job.type"
+	jobTypePassThroughKey    = "titus.agent.jobType"
+	titusTaskInstanceIDKey   = "TITUS_TASK_INSTANCE_ID"
 )
 
 // WorkloadType classifies isolation behaviors on resources (e.g. CPU).  The exact implementation details of the
@@ -50,6 +54,12 @@ func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources *runt
 	labels[memLabelKey] = strMem
 	labels[diskLabelKey] = strDisk
 	labels[networkLabelKey] = strNetwork
+
+	passthroughAttributes := titusInfo.GetPassthroughAttributes()
+	if passthroughAttributes != nil {
+		labels[ownerEmailLabelKey] = passthroughAttributes[ownerEmailPassThroughKey]
+		labels[jobTypeLabelKey] = passthroughAttributes[jobTypePassThroughKey]
+	}
 
 	workloadType := StaticWorkloadType
 	if titusInfo.GetAllowCpuBursting() {

--- a/executor/runtime/container_test.go
+++ b/executor/runtime/container_test.go
@@ -99,6 +99,12 @@ func TestNewContainer(t *testing.T) {
 	expectedJobStack := "stack"
 	expectedJobSeq := "seq"
 	expectedDigest := "abcd0123"
+	expectedOwnerEmail := "user@email.org"
+	expectedJobType := "SERVICE"
+
+	expectedPassthroughAttributes := make(map[string]string)
+	expectedPassthroughAttributes[ownerEmailPassThroughKey] = expectedOwnerEmail
+	expectedPassthroughAttributes[jobTypePassThroughKey] = expectedJobType
 
 	containerInfo := &titus.ContainerInfo{
 		AppName:   &expectedAppName,
@@ -107,13 +113,14 @@ func TestNewContainer(t *testing.T) {
 		NetworkConfigInfo: &titus.ContainerInfo_NetworkConfigInfo{
 			BandwidthLimitMbps: &expectedNetwork,
 		},
-		AllowCpuBursting: &batch,
-		Command:          &expectedCmd,
-		UserProvidedEnv:  expectedUserEnv,
-		JobGroupDetail:   &expectedJobDetail,
-		JobGroupStack:    &expectedJobStack,
-		JobGroupSequence: &expectedJobSeq,
-		ImageDigest:      &expectedDigest,
+		AllowCpuBursting:      &batch,
+		Command:               &expectedCmd,
+		UserProvidedEnv:       expectedUserEnv,
+		JobGroupDetail:        &expectedJobDetail,
+		JobGroupStack:         &expectedJobStack,
+		JobGroupSequence:      &expectedJobSeq,
+		ImageDigest:           &expectedDigest,
+		PassthroughAttributes: expectedPassthroughAttributes,
 	}
 
 	resources := &runtimeTypes.Resources{
@@ -129,6 +136,12 @@ func TestNewContainer(t *testing.T) {
 
 	actualAppName := container.Labels[appNameLabelKey]
 	assert.Equal(t, expectedAppName, actualAppName)
+
+	actualOwnerEmail := container.Labels[ownerEmailLabelKey]
+	assert.Equal(t, expectedOwnerEmail, actualOwnerEmail)
+
+	actualJobType := container.Labels[jobTypeLabelKey]
+	assert.Equal(t, expectedJobType, actualJobType)
 
 	actualCPU, _ := strconv.ParseInt(container.Labels[cpuLabelKey], 10, 64)
 	assert.Equal(t, expectedCPU, actualCPU)


### PR DESCRIPTION
### Description of the Change

These should be the last attributes needed by the CPU prediction model for some time.