### PR TITLE
Use Describe Network Interfaces instead of the IMDS

### DIFF
--- a/vpc/allocate/ip_pool_manager_test.go
+++ b/vpc/allocate/ip_pool_manager_test.go
@@ -82,7 +82,7 @@ func (tni *testNetworkInterface) GetIPv4Addresses() []string {
 	return tni.ipv4Addresses
 }
 
-func (tni *testNetworkInterface) Refresh() error {
+func (tni *testNetworkInterface) Refresh(ctx context.Context, session client.ConfigProvider) error {
 	if tni.refresh != nil {
 		return tni.refresh()
 	}

--- a/vpc/ec2wrapper/ec2metadata_test.go
+++ b/vpc/ec2wrapper/ec2metadata_test.go
@@ -132,16 +132,4 @@ func TestMetadataService(t *testing.T) {
 	mac, err := ec2MetadataClientWrapper.PrimaryInterfaceMac()
 	assert.Nil(t, err)
 	assert.Equal(t, primaryInterfaceMac, mac)
-
-	interfaces, err := ec2MetadataClientWrapper.Interfaces()
-	assert.Nil(t, err)
-	assert.Len(t, interfaces, 2)
-	assert.Equal(t, []string{"1.2.3.4", "9.8.1.2"}, interfaces[secondaryInterfaceMac].GetIPv4Addresses())
-	assert.Equal(t, []string{"2604:5000::bb", "aa::cc"}, interfaces[secondaryInterfaceMac].GetIPv6Addresses())
-	assert.Equal(t, []string{}, interfaces[primaryInterfaceMac].GetIPv6Addresses())
-}
-
-func TestIPStringToList(t *testing.T) {
-	assert.Equal(t, []string{}, ipStringToList(""))
-	assert.Equal(t, []string{"1.2.3.4", "4.5.6.8"}, ipStringToList("1.2.3.4\n4.5.6.8\n"))
 }

--- a/vpc/gc/gc.go
+++ b/vpc/gc/gc.go
@@ -47,7 +47,7 @@ func gc(parentCtx *context.VPCContext) error {
 }
 
 func doGc(parentCtx *context.VPCContext, gracePeriod time.Duration) error {
-	interfaces, err := parentCtx.EC2metadataClientWrapper.Interfaces()
+	interfaces, err := parentCtx.EC2metadataClientWrapper.Interfaces(parentCtx, parentCtx.AWSSession, &parentCtx.InstanceID)
 	if err != nil {
 		return err
 	}

--- a/vpc/setup/setup.go
+++ b/vpc/setup/setup.go
@@ -70,7 +70,7 @@ func setup(parentCtx *context.VPCContext) error {
 
 // TODO: Wrap in CLI errrors
 func setupInterfaces(ctx *context.VPCContext, disableIPv6 bool) error {
-	allInterfaces, err := ctx.EC2metadataClientWrapper.Interfaces()
+	allInterfaces, err := ctx.EC2metadataClientWrapper.Interfaces(ctx, ctx.AWSSession, &ctx.InstanceID)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func attachInterfaceAtIdx(ctx *context.VPCContext, disableIPv6 bool, instanceID,
 func waitForInterfaces(ctx *context.VPCContext) error {
 	waitUntil := time.Now().Add(time.Minute)
 	for time.Until(waitUntil) > 0 {
-		allInterfaces, err := ctx.EC2metadataClientWrapper.Interfaces()
+		allInterfaces, err := ctx.EC2metadataClientWrapper.Interfaces(ctx, ctx.AWSSession, &ctx.InstanceID)
 		if err != nil {
 			return err
 		}

--- a/vpc/setup/setup_linux.go
+++ b/vpc/setup/setup_linux.go
@@ -47,7 +47,7 @@ func configureQdiscs(ctx *context.VPCContext) error {
 		return err
 	}
 
-	networkInterfaces, err := ctx.EC2metadataClientWrapper.Interfaces()
+	networkInterfaces, err := ctx.EC2metadataClientWrapper.Interfaces(ctx, ctx.AWSSession, &ctx.InstanceID)
 	if err != nil {
 		return err
 	}

--- a/vpc/types/types.go
+++ b/vpc/types/types.go
@@ -4,12 +4,14 @@ import "errors"
 
 // Allocation is the public interface exposed when we allocate a namespace
 type Allocation struct {
-	IPV4Address string `json:"ipv4Address"`
-	IPV6Address string `json:"ipv6Address"`
-	DeviceIndex int    `json:"deviceIndex"`
-	Success     bool   `json:"success"`
-	Error       string `json:"error"`
-	ENI         string `json:"eni"`
+	IPV4Address   string `json:"ipv4Address"`
+	IPV6Address   string `json:"ipv6Address"`
+	DeviceIndex   int    `json:"deviceIndex"`
+	Success       bool   `json:"success"`
+	Error         string `json:"error"`
+	ENI           string `json:"eni"`
+	ENIMACAddress string `json:"eniMACAddress"`
+	SubnetID      string `json:"subnetID"`
 }
 
 // WiringStatus indicates whether or not wiring was successful


### PR DESCRIPTION
This moves from using the IMDS for (relatively) dynamic information
like what interfaces are attached / available, to using the Describe*
(DescribeInstances, DescribeNetworkInterfaces) calls.
