### PR TITLE
Return better error message on metatron initialization failure

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1733,8 +1733,8 @@ func (r *DockerRuntime) setupPostStartLogDirTiniHandleConnection2(parentCtx cont
 		return os.Remove(darionRoot)
 	})
 
-	if err := setupSystemPods(parentCtx, c, r.cfg, cred); err != nil {
-		log.Warning("Unable to launch pod: ", err)
+	if err := setupSystemServices(parentCtx, c, r.cfg, cred); err != nil {
+		log.WithError(err).Error("Unable to launch system services")
 		return err
 	}
 	return nil

--- a/executor/runtime/docker/docker_unsupported.go
+++ b/executor/runtime/docker/docker_unsupported.go
@@ -27,7 +27,7 @@ func hasProjectQuotasEnabled(rootDir string) bool {
 	return false
 }
 
-func setupSystemPods(parentCtx context.Context, c *runtimeTypes.Container, cfg config.Config, cred ucred) error {
+func setupSystemServices(parentCtx context.Context, c *runtimeTypes.Container, cfg config.Config, cred ucred) error {
 	return nil
 }
 

--- a/hack/test-images/metatron/titus-metatrond
+++ b/hack/test-images/metatron/titus-metatrond
@@ -8,6 +8,10 @@ echo "titus-metatrond: start"
 
 if [[ "$1" == "--init" ]]; then
     echo "titus-metatrond: init"
+    if [[ -n "$TITUS_TEST_FAIL_METATRON_INIT" ]]; then
+        echo "initialization failed"
+        exit 1
+    fi
     exec /titus/metatron/bin/metatron-identity
 fi
 

--- a/root/lib/systemd/system/titus-metatron-sync@.service
+++ b/root/lib/systemd/system/titus-metatron-sync@.service
@@ -4,7 +4,6 @@ ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
-ExecStartPre=/usr/sbin/runc --root /var/run/docker/runtime-runc/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/metatron/bin/titus-metatrond --init
 ExecStart=/usr/sbin/runc --root /var/run/docker/runtime-runc/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/metatron/bin/titus-metatrond
 
 Restart=on-failure


### PR DESCRIPTION
Return a useful error message to users, rather than a systemd error message.
