### PR TITLE
Configure GPU containers with the nvidia-container-runtime hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Requires docker:
 ```sh-session
 make test-standalone
 
-# Change the test timeout (useful on slower systems):
-TEST_TIMEOUT=10m make test-standalone
+# Disable running tests in parallel and change the test timeout (useful on slower systems):
+TEST_FLAGS="-v -parallel 1" TEST_TIMEOUT=10m make test-standalone
 # If you're iterating on tests and don't want to build a new executor .deb every time:
 ./hack/tests-with-dind.sh
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Tests will run inside a Docker container and run a dedicated docker daemon as do
 
 AWS specific features (VPC integration, metadata service proxy, GPU, EFS, ...) are disabled during these tests.
 
-## Generated Code 
+## Generated Code
 There are places inside of the executor where we've checked in binaries, or prebuilt pieces of code. This may be considered harmful by some, but from the perspective of pragmatism, we have such code in:
 
 In order to generate code you need `go-bindata`, which you can get via:
@@ -111,15 +111,21 @@ make -C vpc/bpf/
 ```
 
 ### api/netflix/titus
-If you update the dependency `github.com/Netflix/titus-api-definitions/src/main/proto/netflix/titus`, you will need to regenerate the Go proto definitions. 
+If you update the dependency `github.com/Netflix/titus-api-definitions/src/main/proto/netflix/titus`, you will need to regenerate the Go proto definitions.
 
 You must first install the protobuf toolchain, and the Go protobuf compiler. More documentation on that can be found [in the protobuf repo](https://github.com/golang/protobuf/blob/master/README.md#installation).
 
 Once you update, and sync the dependency, just run the following:
 
 ```sh-session
- make clean-proto-defs protogen
- ```
+make clean-proto-defs protogen
+```
+
+## Running
+
+### nvidia GPUs
+
+To use with nvidia devices, you must have an OCI runtime installed that supports running OCI prestart hooks, so that the [nvidia-container-runtime-hook](https://github.com/NVIDIA/nvidia-container-runtime) can be run before container start. You'll need to add a container runtime [as per the dockerd documentation](https://docs.docker.com/engine/reference/commandline/dockerd/#docker-runtime-execution-options). The executor looks for a runtime named `oci-add-hooks` by default, but the runtime can be configured via the `titus.executor.nvidiaOciRuntime` config option. You can use the [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) runtime, or the [oci-add-hooks](https://github.com/awslabs/oci-add-hooks) runtime if you're not comfortable running a patched version of runc.
 
 ## LICENSE
 

--- a/executor/mock/standalone/standalone_test.go
+++ b/executor/mock/standalone/standalone_test.go
@@ -999,7 +999,9 @@ func testMetatronFailure(t *testing.T, jobID string) {
 	status, err := jobResponse.WaitForFailureStatus(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, status)
-	assert.Equal(t, "error starting metatron service: initialization failed: exit status 1", status.Mesg)
+	if status != nil {
+		assert.Equal(t, "error starting metatron service: initialization failed: exit status 1", status.Mesg)
+	}
 }
 
 // Test that `/run` is a tmpfs mount, and has the default size

--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -102,6 +102,7 @@ fpm -t deb -s dir -C root \
   --depends 'docker-ce >= 5:18.09.1~3-0~ubuntu-xenial' \
   --deb-recommends lxcfs \
   --deb-recommends atlas-titus-agent \
+  --deb-recommends nvidia-container-runtime-hook \
   ${provides:-} \
   --after-install /tmp/post-install.sh \
   --package "${outdir}/"

--- a/nvidia/nvidia_test.go
+++ b/nvidia/nvidia_test.go
@@ -2,14 +2,8 @@ package nvidia
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
-	"sort"
 	"testing"
-
-	"github.com/leanovate/gopter"
-	"github.com/leanovate/gopter/gen"
-	"github.com/leanovate/gopter/prop"
 )
 
 const (
@@ -40,23 +34,4 @@ func TestRexexp(t *testing.T) {
 			t.Log(fmt.Sprintf("Correctly did not match %s", nonGpuType))
 		}
 	}
-}
-
-func TestIterator(t *testing.T) {
-	parameters := gopter.DefaultTestParameters()
-	parameters.MaxSize = 1000
-
-	properties := gopter.NewProperties(parameters)
-	properties.Property("Iterates over string slices", prop.ForAll(
-		func(slice []string) bool {
-			ret := []string{}
-			for val := range iterOverDevices(slice) {
-				ret = append(ret, val)
-			}
-			sort.Strings(slice)
-			sort.Strings(ret)
-			return reflect.DeepEqual(ret, slice)
-		}, gen.SliceOf(gen.AnyString())))
-
-	properties.TestingRun(t)
 }


### PR DESCRIPTION
- Use the [nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime) instead of nvidia-docker 1.0 to configure containers
- This relies on using a non-default OCI runtime, as per [the dockerd docs](https://docs.docker.com/engine/reference/commandline/dockerd/#docker-runtime-execution-options)
- Default to a runtime named `oci-add-hooks`, eg: https://github.com/Netflix-Skunkworks/oci-add-hooks - this is preferable to the nvidia-docker2 runtime, as it doesn't rely on patching runc.
- Allow an alternate runtime to be configured via a config option
- The executor only sets the visible devices in the container - it leaves all other Nvidia config environment variables at their defaults, which matches the nvidia-docker 1.0 behaviour. More details can be found in the [nvidia-container-runtime README](https://github.com/NVIDIA/nvidia-container-runtime#environment-variables-oci-spec)
- Run standalone tests serially when the `DISABLE_PARALLEL_TESTS` env var is set