### PR TITLE
Update debian dependencies to cleanly install on Bionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,18 @@ Ensure that your build environment (i.e. VM) has the following commands prior to
 ### Building and testing
 In order to build titus-executor, check out the project into your `$GOPATH/src/github.com/Netflix`, and run the following command:
 
-`sudo -E PATH=${PATH} make builder all`
+```sh-session
+sudo -E PATH=${PATH} make builder all
+```
 
 This will output a debian file at the path, which you can then install on your system:
 `./build/distributions/titus-executor_latest.deb`
+
+To only build the .deb, and not rebuild the builder image:
+
+```sh-session
+sudo -E PATH=${PATH} make build
+```
 
 #### Building without Docker
 If you want to build a dpkg, without Docker, once the code is checked out, you can run the following:

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:bionic
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     apt-get install -y build-essential make cmake g++ gcc libc6-dev pkg-config \

--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -77,7 +77,6 @@ systemctl reload apparmor || echo "Could not reload apparmor"
 EOF
 chmod +x /tmp/post-install.sh
 
-
 fpm -t deb -s dir -C root \
   -a amd64 \
   -n titus-executor \
@@ -99,7 +98,7 @@ fpm -t deb -s dir -C root \
   --deb-field "Branch: ${git_sha}" \
   --deb-activate ldconfig \
   --depends libc6 \
-  --depends 'apparmor >= 2.12-4ubuntu7' \
+  --depends 'apparmor >= 2.12' \
   --depends 'docker-ce >= 5:18.09.1~3-0~ubuntu-xenial' \
   --deb-recommends lxcfs \
   --deb-recommends atlas-titus-agent \

--- a/hack/ci-builder/Dockerfile
+++ b/hack/ci-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:bionic
 
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common && apt-get clean


### PR DESCRIPTION
- Don't hardcode the xenial apparmor version
- The postinstall explicitly restarts the lxc service, so make it an explicit dependency
