### PR TITLE
Mount all nvidia libraries into the container, for backwards compatibility

### DIFF
--- a/nvidia/nvidia.go
+++ b/nvidia/nvidia.go
@@ -168,6 +168,9 @@ func (n *PluginInfo) UpdateContainerConfig(c *types.Container, dockerCfg *contai
 	// Now setup the environment variables that `nvidia-container-runtime` uses to configure itself,
 	// and remove any that may have been set by the user.  See https://github.com/NVIDIA/nvidia-container-runtime
 	c.Env["NVIDIA_VISIBLE_DEVICES"] = strings.Join(c.GPUInfo.Devices(), ",")
+	// nvidia-docker 1.0 would mount all of `/usr/local/nvidia/`, bringing in all of the shared libs.
+	// Setting this to "all" will mount all of those libs:
+	c.Env["NVIDIA_DRIVER_CAPABILITIES"] = "all"
 	dockerCfg.Env = c.GetSortedEnvArray()
 }
 


### PR DESCRIPTION
Before:
```
(root) / # find /usr/lib | grep nvidia
/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.1
/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1
```
After:
```
(root) / # find /usr/lib | grep nvidia
/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-fatbinaryloader.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-compiler.so.410.104
/usr/lib/x86_64-linux-gnu/libvdpau_nvidia.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-encode.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-eglcore.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-glcore.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-tls.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-glsi.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-fbc.so.410.104
/usr/lib/x86_64-linux-gnu/libnvidia-ifr.so.410.104
/usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.410.104
/usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.410.104
/usr/lib/x86_64-linux-gnu/libGLESv2_nvidia.so.410.104
/usr/lib/x86_64-linux-gnu/libGLESv1_CM_nvidia.so.410.104
/usr/lib/x86_64-linux-gnu/libGLESv1_CM_nvidia.so.1
/usr/lib/x86_64-linux-gnu/libGLESv2_nvidia.so.2
/usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.0
/usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.0
/usr/lib/x86_64-linux-gnu/libnvidia-ifr.so.1
/usr/lib/x86_64-linux-gnu/libnvidia-fbc.so.1
/usr/lib/x86_64-linux-gnu/libnvidia-encode.so.1
/usr/lib/x86_64-linux-gnu/libvdpau_nvidia.so.1
/usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.1
/usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.1
/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1
/usr/lib/i386-linux-gnu/libnvidia-ml.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-cfg.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-ptxjitcompiler.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-fatbinaryloader.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-compiler.so.410.104
/usr/lib/i386-linux-gnu/libvdpau_nvidia.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-encode.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-eglcore.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-glcore.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-tls.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-glsi.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-fbc.so.410.104
/usr/lib/i386-linux-gnu/libnvidia-ifr.so.410.104
/usr/lib/i386-linux-gnu/libGLX_nvidia.so.410.104
/usr/lib/i386-linux-gnu/libEGL_nvidia.so.410.104
/usr/lib/i386-linux-gnu/libGLESv2_nvidia.so.410.104
/usr/lib/i386-linux-gnu/libGLESv1_CM_nvidia.so.410.104
/usr/lib/i386-linux-gnu/libGLESv1_CM_nvidia.so.1
/usr/lib/i386-linux-gnu/libGLESv2_nvidia.so.2
/usr/lib/i386-linux-gnu/libEGL_nvidia.so.0
/usr/lib/i386-linux-gnu/libGLX_nvidia.so.0
/usr/lib/i386-linux-gnu/libnvidia-ifr.so.1
/usr/lib/i386-linux-gnu/libnvidia-fbc.so.1
/usr/lib/i386-linux-gnu/libnvidia-encode.so.1
/usr/lib/i386-linux-gnu/libvdpau_nvidia.so.1
/usr/lib/i386-linux-gnu/libnvidia-ptxjitcompiler.so.1
/usr/lib/i386-linux-gnu/libnvidia-cfg.so.1
/usr/lib/i386-linux-gnu/libnvidia-ml.so.1
```