### PR TITLE
Fix system service init commands not working for non-runc runtimes

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -1,9 +1,8 @@
 package types
 
-import "fmt"
-
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/Netflix/titus-executor/api/netflix/titus"
 	"github.com/Netflix/titus-executor/config"
+
 	vpcTypes "github.com/Netflix/titus-executor/vpc/types"
 
 	// The purpose of this is to tell gometalinter to keep vendoring this package
@@ -131,6 +131,8 @@ type Container struct {
 
 	// GPU devices
 	GPUInfo GPUContainer
+	// Set if using a non-runc runtime to run system service init commands
+	Runtime string
 
 	AllocationCommand       *exec.Cmd
 	AllocationCommandStatus chan error

--- a/nvidia/nvidia.go
+++ b/nvidia/nvidia.go
@@ -164,6 +164,7 @@ fail:
 // UpdateContainerConfig updates the container and host configs to delegate the given devices
 func (n *PluginInfo) UpdateContainerConfig(c *types.Container, dockerCfg *container.Config, hostCfg *container.HostConfig, runtime string) {
 	hostCfg.Runtime = runtime
+	c.Runtime = runtime
 
 	// Now setup the environment variables that `nvidia-container-runtime` uses to configure itself,
 	// and remove any that may have been set by the user.  See https://github.com/NVIDIA/nvidia-container-runtime


### PR DESCRIPTION
The root path for a runtime changes based on its name, which was causing metatron init to fail on GPU-enabled containers (as they are now run with the `oci-add-hooks` runtime).