### PR TITLE
Fix describe interfaces code / parsing private IP list

### DIFF
--- a/vpc/service/ec2wrapper/ec2_network_interface.go
+++ b/vpc/service/ec2wrapper/ec2_network_interface.go
@@ -54,11 +54,14 @@ func (s *ec2NetworkInterfaceSession) GetNetworkInterface(ctx context.Context, de
 		return nil, handleEC2Error(err, span)
 	}
 
-	privateIPs := make([]string, len(networkInterface.PrivateIpAddresses)+1)
-	for idx := range networkInterface.PrivateIpAddresses {
-		privateIPs[idx+1] = aws.StringValue(networkInterface.PrivateIpAddresses[idx].PrivateIpAddress)
-	}
+	privateIPs := make([]string, 1, len(networkInterface.PrivateIpAddresses))
 	privateIPs[0] = aws.StringValue(networkInterface.PrivateIpAddress)
+
+	for idx := range networkInterface.PrivateIpAddresses {
+		if !aws.BoolValue(networkInterface.PrivateIpAddresses[idx].Primary) {
+			privateIPs = append(privateIPs, aws.StringValue(networkInterface.PrivateIpAddresses[idx].PrivateIpAddress))
+		}
+	}
 
 	ipv6Addresses := make([]string, len(networkInterface.Ipv6Addresses))
 	for idx := range networkInterface.Ipv6Addresses {


### PR DESCRIPTION
currently the code adds the primary ipv4 address twice to the
interface. This isn't what we want.
