### PR TITLE
System services should use the new runc path for newer containerd releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ $(TEST_DIRS): | $(clean)
 .PHONY: build-tests-darwin
 build-tests-darwin: $(TEST_DIRS)
 
+.PHONY: cross-linux
+cross-linux:
+	gox -osarch="linux/amd64" -output="build/bin/{{.OS}}-{{.Arch}}/{{.Dir}}" -verbose ./cmd/...
+
 .PHONY: test-local
 test-local: | $(clean)
 	go test $(TEST_FLAGS) -covermode=count -coverprofile=coverage-local.out -coverpkg=github.com/Netflix/... ./... \

--- a/executor/runtime/container.go
+++ b/executor/runtime/container.go
@@ -51,6 +51,8 @@ func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources *runt
 	strNetwork := strconv.FormatUint(uint64(networkCfgParams.GetBandwidthLimitMbps()), 10)
 
 	env := cfg.GetNetflixEnvForTask(titusInfo, strMem, strCPU, strDisk, strNetwork)
+	// System service systemd units need this to be set in order to run with the right runtime path
+	env[runtimeTypes.TitusRuntimeEnvVariableName] = runtimeTypes.DefaultOciRuntime
 	labels[titusTaskInstanceIDKey] = env[titusTaskInstanceIDKey]
 	labels[cpuLabelKey] = strCPU
 	labels[memLabelKey] = strMem

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -51,7 +51,6 @@ type serviceOpts struct {
 }
 
 const (
-	defaultRuntime            = "runc"
 	titusInits                = "/var/lib/titus-inits"
 	systemServiceStartTimeout = 90 * time.Second
 	umountNoFollow            = 0x8
@@ -160,7 +159,7 @@ func setupSystemServices(parentCtx context.Context, c *runtimeTypes.Container, c
 
 		// Different runtimes have different root paths that need to be passed to runc with `--root`.
 		// In particular, we use the `oci-add-hooks` runtime for GPU containers.
-		runtime := defaultRuntime
+		runtime := runtimeTypes.DefaultOciRuntime
 		if c.Runtime != "" {
 			runtime = c.Runtime
 		}
@@ -184,7 +183,7 @@ func runServiceInitCommand(ctx context.Context, log *logrus.Entry, cID string, r
 	cmdArgStr := fmt.Sprintf(runcArgFormat, runtime, cID, opts.initCommand)
 	cmdArgs := strings.Split(cmdArgStr, " ")
 
-	runcCommand, err := exec.LookPath(defaultRuntime)
+	runcCommand, err := exec.LookPath(runtimeTypes.DefaultOciRuntime)
 	if err != nil {
 		return err
 	}

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -32,6 +32,11 @@ const (
 	// TitusEnvironmentsDir is the directory we write Titus environment files and JSON configs to
 	TitusEnvironmentsDir            = "/var/lib/titus-environments"
 	titusContainerIDEnvVariableName = "TITUS_CONTAINER_ID"
+	// TitusRuntimeEnvVariableName is used to pass the name of the oci-compliant runtime used to run a container.
+	// This can be used to construct the root path for runc to use to run system services.
+	TitusRuntimeEnvVariableName = "TITUS_OCI_RUNTIME"
+	// DefaultOciRuntime is the default oci-compliant runtime used to run system services
+	DefaultOciRuntime = "runc"
 
 	// VPCIPv4Label is the VPC address of the container.
 	//

--- a/nvidia/nvidia.go
+++ b/nvidia/nvidia.go
@@ -165,6 +165,7 @@ fail:
 func (n *PluginInfo) UpdateContainerConfig(c *types.Container, dockerCfg *container.Config, hostCfg *container.HostConfig, runtime string) {
 	hostCfg.Runtime = runtime
 	c.Runtime = runtime
+	c.Env[types.TitusRuntimeEnvVariableName] = runtime
 
 	// Now setup the environment variables that `nvidia-container-runtime` uses to configure itself,
 	// and remove any that may have been set by the user.  See https://github.com/NVIDIA/nvidia-container-runtime

--- a/root/lib/systemd/system/titus-metatron-sync@.service
+++ b/root/lib/systemd/system/titus-metatron-sync@.service
@@ -4,7 +4,7 @@ ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
-ExecStart=/usr/sbin/runc --root /var/run/docker/runtime-runc/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/metatron/bin/titus-metatrond
+ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/metatron/bin/titus-metatrond
 
 Restart=on-failure
 RestartSec=1


### PR DESCRIPTION
Also account for a non-runc runtime when running the service