### PR TITLE
Add network metadata to pod update

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -486,6 +486,17 @@ type NetworkConfigurationDetails struct {
 	ResourceID   string
 }
 
+func (n *NetworkConfigurationDetails) ToMap() map[string]string {
+	m := make(map[string]string)
+	m["IsRoutableIp"] = strconv.FormatBool(n.IsRoutableIP)
+	m["IpAddress"] = n.IPAddress
+	m["EniIpAddress"] = n.EniIPAddress
+	m["EniId"] = n.EniID
+	m["ResourceId"] = n.ResourceID
+
+	return m
+}
+
 // Details contains additional details about a container that are
 // not returned by normal container start calls.
 type Details struct {


### PR DESCRIPTION
The control plane wants this network metadata information which was previously provided by the Mesos backend.