### PR TITLE
Cast shmSize before multiplying, not after

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -482,7 +482,7 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 
 	shmSize := c.GetShmSize()
 	if shmSize > 0 {
-		hostCfg.ShmSize = int64(shmSize * MiB)
+		hostCfg.ShmSize = int64(shmSize) * MiB
 	}
 
 	if r.storageOptEnabled {


### PR DESCRIPTION
This was truncating SHM values.