### PR TITLE
Do not deallocate GPUs if GPU allocation failed before

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1950,7 +1950,7 @@ stopped:
 		log.WithField("taskId", c.TaskID).Info("No need to deallocate, no allocation command")
 	}
 
-	if c.TitusInfo.GetNumGpus() > 0 {
+	if c.TitusInfo.GetNumGpus() > 0 && c.GPUInfo != nil {
 		numDealloc := c.GPUInfo.Deallocate()
 		log.Infof("Deallocated %d GPU devices for task %s", numDealloc, c.TaskID)
 	}


### PR DESCRIPTION
There's a race condition where if network allocation fails, then
GPU deallocation proceeds, but it can fail because GPU
allocation didn't succeed on the "bring up" side.
