### PR TITLE
Move to adminlogs for logs

### DIFF
--- a/executor/mock/jobrunner.go
+++ b/executor/mock/jobrunner.go
@@ -27,7 +27,7 @@ import (
 var errStatusChannelClosed = errors.New("Status channel closed")
 
 const (
-	logViewerTestImage = "titusoss/titus-logviewer@sha256:4375303a8ce6dfb297cc47f2103ae140af89c88e393392c2c7ea01943345bef5"
+	logViewerTestImage = "titusoss/titus-logviewer@sha256:750a908c244c3f44b2b7abf1d9297aca859592e02736b3bd48aaebac022a87e5"
 	metatronTestImage  = "titusoss/metatron:20190716-1563251672"
 )
 

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -979,7 +979,7 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 			image:         r.cfg.ContainerLogViewerImage,
 			containerName: &logViewerContainerName,
 			volumes: map[string]struct{}{
-				"/titus/logviewer": {},
+				"/titus/adminlogs": {},
 			},
 		}))
 	}

--- a/hack/images/titus-logviewer/Dockerfile
+++ b/hack/images/titus-logviewer/Dockerfile
@@ -12,4 +12,4 @@ FROM scratch
 
 ENV GOPATH /go
 ENV EXECUTOR_DIR "$GOPATH/src/github.com/Netflix/titus-executor"
-COPY --from=builder $EXECUTOR_DIR/titus-logviewer /titus/logviewer/bin/titus-logviewer
+COPY --from=builder $EXECUTOR_DIR/titus-logviewer /titus/adminlogs/bin/adminlogs

--- a/root/lib/systemd/system/titus-logviewer@.service
+++ b/root/lib/systemd/system/titus-logviewer@.service
@@ -5,7 +5,7 @@ ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
 # Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work
-ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/logviewer/bin/titus-logviewer
+ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE --cwd /titus/adminlogs ${TITUS_CONTAINER_ID} bin/adminlogs
 
 Restart=on-failure
 RestartSec=1


### PR DESCRIPTION
Move to using the standard (internal) adminlogs logviewer, rather than titus-logviewer.