### PR TITLE
Add KVM and tunnel devices to the container when launching a VM

### DIFF
--- a/executor/runtime/docker/capabilities.go
+++ b/executor/runtime/docker/capabilities.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	SYS_ADMIN = "SYS_ADMIN" // nolint: golint
+	NET_ADMIN = "NET_ADMIN"
 )
 
 func addAdditionalCapabilities(c *runtimeTypes.Container, hostCfg *container.HostConfig) map[string]struct{} {
@@ -63,6 +64,10 @@ func setupAdditionalCapabilities(c *runtimeTypes.Container, hostCfg *container.H
 	}
 
 	if kvmEnabled {
+		if _, ok := addedCapabilities[NET_ADMIN]; !ok {
+			hostCfg.CapAdd = append(hostCfg.CapAdd, NET_ADMIN)
+		}
+
 		hostCfg.Resources.Devices = append(hostCfg.Resources.Devices, container.DeviceMapping{
 			PathOnHost:        kvmDev,
 			PathInContainer:   kvmDev,

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -55,6 +55,8 @@ const (
 
 const (
 	fuseDev = "/dev/fuse"
+	kvmDev  = "/dev/kvm"
+	tunDev  = "/dev/net/tun"
 	// See: TITUS-1231, this is added as extra padding for container initialization
 	builtInDiskBuffer       = 1100 // In megabytes, includes extra space for /logs.
 	defaultNetworkBandwidth = 128 * MB

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -26,6 +26,7 @@ const (
 	hostnameStyleParam = "titusParameter.agent.hostnameStyle"
 	// FuseEnabledParam is a container atttribute set to enable FUSE
 	FuseEnabledParam             = "titusParameter.agent.fuseEnabled"
+	KvmEnabledParam              = "titusParameter.agent.kvmEnabled"
 	assignIPv6AddressParam       = "titusParameter.agent.assignIPv6Address"
 	ttyEnabledParam              = "titusParameter.agent.ttyEnabled"
 	optimisticIAMTokenFetchParam = "titusParameter.agent.optimisticIAMTokenFetch"
@@ -295,11 +296,21 @@ func (c *Container) ComputeHostname() (string, error) {
 
 // GetFuseEnabled determines whether the container has FUSE devices exposed to it
 func (c *Container) GetFuseEnabled() (bool, error) {
-	fuseEnabledStr, ok := c.TitusInfo.GetPassthroughAttributes()[FuseEnabledParam]
+	return c.GetPassthroughEnabled(FuseEnabledParam)
+}
+
+// GetKvmEnabled determines whether the container has KVM exposed to it
+func (c *Container) GetKvmEnabled() (bool, error) {
+	return c.GetPassthroughEnabled(KvmEnabledParam)
+}
+
+func (c *Container) GetPassthroughEnabled(key string) (bool, error) {
+	value, ok := c.TitusInfo.GetPassthroughAttributes()[key]
+
 	if !ok {
 		return false, nil
 	}
-	val, err := strconv.ParseBool(fuseEnabledStr)
+	val, err := strconv.ParseBool(value)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
In order to launch virtual machines in a Titus container the devices `/dev/kvm` and `/dev/net/tun` must be added.
