### PR TITLE
Add restart limits to system services

### DIFF
--- a/root/lib/systemd/system/atlas-titus-agent@.service
+++ b/root/lib/systemd/system/atlas-titus-agent@.service
@@ -3,6 +3,10 @@ Description=Metrics Pod for %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 ConditionPathExists=!/etc/disable-atlas-titus-agent
 
+# If the service restarts more than 10 times in 30 seconds, let it die
+StartLimitIntervalSec=30
+StartLimitBurst=10
+
 [Service]
 Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
 ExecStart=/usr/local/bin/atlas-titus-agent

--- a/root/lib/systemd/system/titus-logviewer@.service
+++ b/root/lib/systemd/system/titus-logviewer@.service
@@ -2,6 +2,10 @@
 Description=Titus logviewer for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
+# If the service restarts more than 10 times in 30 seconds, let it die
+StartLimitIntervalSec=30
+StartLimitBurst=10
+
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
 # Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work

--- a/root/lib/systemd/system/titus-metadata-proxy@.service
+++ b/root/lib/systemd/system/titus-metadata-proxy@.service
@@ -2,6 +2,10 @@
 Description=Metadata proxy pod container for %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
+# If the service restarts more than 10 times in 30 seconds, let it die
+StartLimitIntervalSec=30
+StartLimitBurst=10
+
 [Service]
 Type=notify
 NotifyAccess=all

--- a/root/lib/systemd/system/titus-metatron-sync@.service
+++ b/root/lib/systemd/system/titus-metatron-sync@.service
@@ -2,6 +2,10 @@
 Description=Metatron sync for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
+# If the service restarts more than 10 times in 30 seconds, let it die
+StartLimitIntervalSec=30
+StartLimitBurst=10
+
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
 # Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work

--- a/root/lib/systemd/system/titus-servicemesh@.service
+++ b/root/lib/systemd/system/titus-servicemesh@.service
@@ -2,6 +2,10 @@
 Description=Titus service mesh sidecar for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
+# If the service restarts more than 10 times in 30 seconds, let it die
+StartLimitIntervalSec=30
+StartLimitBurst=10
+
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
 # Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work

--- a/root/lib/systemd/system/titus-sshd@.service
+++ b/root/lib/systemd/system/titus-sshd@.service
@@ -2,6 +2,10 @@
 Description=SSHD for container %s
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
+# If the service restarts more than 10 times in 30 seconds, let it die
+StartLimitIntervalSec=30
+StartLimitBurst=10
+
 [Service]
 Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
 EnvironmentFile=/var/lib/titus-environments/%i.env


### PR DESCRIPTION
Right now, only allow 10 restarts in 30 seconds.
