### PR TITLE
Map TASK_KILLED to PodFailed

### DIFF
--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -36,7 +36,7 @@ func state2phase(state titusdriver.TitusTaskState) v1.PodPhase {
 	case titusdriver.Failed:
 		return v1.PodFailed
 	case titusdriver.Killed:
-		return v1.PodSucceeded
+		return v1.PodFailed
 	case titusdriver.Lost:
 		return v1.PodFailed
 	default:


### PR DESCRIPTION
> Finished (failed) = Failed - All Containers in the Pod have terminated, and at least one Container has terminated in failure. That is, the Container either exited with non-zero status or was terminated by the system.

In Titus today we only every have 1 container per pod.  If that container was killed it's _very_ unlikely it exited with a 0 exit code.  Ideally we'd check that exit code to determine the `state --> phase` mapping, but plumbing the exit code through to this point doesn't seem worth catching the 0.001% of cases where killing a process generates a 0 exit code.