### PR TITLE
Add container logviewer proxy

### DIFF
--- a/cmd/titus-logviewer/main.go
+++ b/cmd/titus-logviewer/main.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/Netflix/titus-executor/logsutil"
 	"github.com/Netflix/titus-executor/logviewer/api"
+	"github.com/Netflix/titus-executor/logviewer/conf"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -25,8 +27,14 @@ func main() {
 
 func newMux() *http.ServeMux {
 	r := http.NewServeMux()
+
 	r.HandleFunc("/ping", pingHandler)
-	r.HandleFunc("/logs/", api.LogHandler)
-	r.HandleFunc("/listlogs/", api.ListLogsHandler)
+
+	if conf.ProxyMode {
+		api.RegisterProxyHandlers(r)
+		return r
+	}
+
+	api.RegisterHandlers(r)
 	return r
 }

--- a/logviewer/api/proxy.go
+++ b/logviewer/api/proxy.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+)
+
+// The URL to connect to once we've done a Setns() into the container
+const inContainerURL = "http://127.0.0.1:8004"
+
+func doProxy(w http.ResponseWriter, r *http.Request, containerID string, proxy *httputil.ReverseProxy) {
+	proxyURL, _ := url.Parse(inContainerURL)
+	containerDialer, err := newDialer(containerID)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	// These values were taken from http.DefaultTransport
+	proxyTransport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           containerDialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	if proxy == nil {
+		proxy = httputil.NewSingleHostReverseProxy(proxyURL)
+	}
+	proxy.Transport = proxyTransport
+	proxy.ServeHTTP(w, r)
+}
+
+// LogProxyHandler is an HTTP handler that proxies /logs/:containerid/... to the in-container logviewer
+func LogProxyHandler(w http.ResponseWriter, r *http.Request) {
+	containerID, err := containerIDFromURL(r.URL.Path, logsExp)
+	if err != nil {
+		http.Error(w, err.Error(), 404)
+		return
+	}
+
+	doProxy(w, r, containerID, nil)
+}
+
+// LogViewerProxyHandler is an HTTP handler that proxies all requests to the underlying logviewer,
+// so `/logviewer/:id/foo` will hit `/foo` on the in-container logviewer
+func LogViewerProxyHandler(w http.ResponseWriter, r *http.Request) {
+	containerID, err := containerIDFromURL(r.URL.Path, logViewerExp)
+	if err != nil {
+		http.Error(w, err.Error(), 404)
+		return
+	}
+
+	proxyURL, _ := url.Parse(inContainerURL)
+	director := func(req *http.Request) {
+		req.URL.Scheme = proxyURL.Scheme
+		req.URL.Host = proxyURL.Host
+		req.URL.Path = logViewerExp.ReplaceAllString(req.URL.Path, "")
+
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
+	}
+	proxy := &httputil.ReverseProxy{Director: director}
+	doProxy(w, r, containerID, proxy)
+}
+
+// ListLogsProxyHandler is an HTTP handler that proxies /listlogs/:containerid/... to the in-container logviewer
+func ListLogsProxyHandler(w http.ResponseWriter, r *http.Request) {
+	containerID, err := containerIDFromURL(r.URL.Path, listLogsExp)
+	if err != nil {
+		http.Error(w, err.Error(), 404)
+		return
+	}
+
+	doProxy(w, r, containerID, nil)
+}
+
+func RegisterProxyHandlers(r *http.ServeMux) {
+	r.HandleFunc("/listlogs/", ListLogsProxyHandler)
+	r.HandleFunc("/logs/", LogProxyHandler)
+	r.HandleFunc("/logviewer/", LogViewerProxyHandler)
+}

--- a/logviewer/api/routes.go
+++ b/logviewer/api/routes.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/Netflix/titus-executor/logviewer/conf"
+)
+
+var (
+	logsExp             = regexp.MustCompile(`/logs/(.*)`)
+	listLogsExp         = regexp.MustCompile(`/listlogs/(.*)`)
+	logViewerExp        = regexp.MustCompile(`^/logviewer/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})`)
+	errUnknownContainer = errors.New("Unknown container")
+)
+
+func containerIDFromURL(url string, re *regexp.Regexp) (string, error) {
+	matchResult := re.FindStringSubmatch(url)
+
+	if len(matchResult) < 1 || matchResult[1] == "" {
+		return "", fmt.Errorf("invalid URI: %s: %+v", url, matchResult)
+	}
+
+	containerID := matchResult[1]
+	if containerID == "" {
+		return "", errUnknownContainer
+	}
+
+	if conf.RunningInContainer && containerID != conf.ContainerID {
+		return "", errUnknownContainer
+	}
+
+	return containerID, nil
+}

--- a/logviewer/api/transport_linux.go
+++ b/logviewer/api/transport_linux.go
@@ -5,16 +5,21 @@ package api
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sys/unix"
 	"net"
 	"os"
 	"runtime"
 	"time"
 
+	"golang.org/x/sys/unix"
+
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-const titusInits = "/var/lib/titus-inits"
+const (
+	titusInits      = "/var/lib/titus-inits"
+	curThreadNsPath = "/proc/thread-self/ns/net"
+)
 
 // nsDialer is a net.Dialer that does a Setns() into a container's network namespace before doing a connect
 type nsDialer struct {
@@ -24,27 +29,26 @@ type nsDialer struct {
 
 func (d *nsDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	log.Debugf("nsDialer: DialContext: %s", d.containerNetNsPath)
-	curThreadNsPath := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
 
 	// Make sure that this code executes only in this thread, since `Setns()` changes the thread's namespace
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	// Get the FD for the host namespace, so we can switch back into it after doing the connect
-	prevNsFile, err := os.Open(curThreadNsPath)
+	prevNsFd, err := unix.Open(curThreadNsPath, os.O_RDONLY, 0)
 	if err != nil {
-		return nil, fmt.Errorf("error opening ns file %v: %v", curThreadNsPath, err)
+		return nil, errors.Wrapf(err, "error opening ns file %s", curThreadNsPath)
 	}
-	defer prevNsFile.Close()
+	defer unix.Close(prevNsFd)
 
-	nsFile, err := os.Open(d.containerNetNsPath)
+	nsFd, err := unix.Open(d.containerNetNsPath, os.O_RDONLY, 0)
 	if err != nil {
-		return nil, fmt.Errorf("error opening ns file %v: %v", d.containerNetNsPath, err)
+		return nil, errors.Wrapf(err, "error opening ns %s", d.containerNetNsPath)
 	}
-	defer nsFile.Close()
+	defer unix.Close(nsFd)
 
-	if err = unix.Setns(int(nsFile.Fd()), unix.CLONE_NEWNET); err != nil {
-		return nil, fmt.Errorf("error switching to ns %v: %v", nsFile.Name(), err)
+	if err = unix.Setns(nsFd, unix.CLONE_NEWNET); err != nil {
+		return nil, errors.Wrapf(err, "error switching to ns %s", d.containerNetNsPath)
 	}
 
 	// Call the system dialer - since we're calling a single URL, the dial will run in this thread, and will
@@ -52,8 +56,8 @@ func (d *nsDialer) DialContext(ctx context.Context, network, address string) (ne
 	conn, connErr := d.systemDialer.DialContext(ctx, network, address)
 
 	// Switch back to the host namespace now that we're done
-	if err = unix.Setns(int(prevNsFile.Fd()), unix.CLONE_NEWNET); err != nil {
-		return nil, fmt.Errorf("error switching to ns %v: %v", prevNsFile.Name(), err)
+	if err = unix.Setns(prevNsFd, unix.CLONE_NEWNET); err != nil {
+		return nil, errors.Wrapf(err, "error switching to ns %s", curThreadNsPath)
 	}
 
 	return conn, connErr

--- a/logviewer/api/transport_linux.go
+++ b/logviewer/api/transport_linux.go
@@ -1,0 +1,81 @@
+// build +linux
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"net"
+	"os"
+	"runtime"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const titusInits = "/var/lib/titus-inits"
+
+// nsDialer is a net.Dialer that does a Setns() into a container's network namespace before doing a connect
+type nsDialer struct {
+	containerNetNsPath string
+	systemDialer       net.Dialer
+}
+
+func (d *nsDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	log.Debugf("nsDialer: DialContext: %s", d.containerNetNsPath)
+	curThreadNsPath := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
+
+	// Make sure that this code executes only in this thread, since `Setns()` changes the thread's namespace
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Get the FD for the host namespace, so we can switch back into it after doing the connect
+	prevNsFile, err := os.Open(curThreadNsPath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening ns file %v: %v", curThreadNsPath, err)
+	}
+	defer prevNsFile.Close()
+
+	nsFile, err := os.Open(d.containerNetNsPath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening ns file %v: %v", d.containerNetNsPath, err)
+	}
+	defer nsFile.Close()
+
+	if err = unix.Setns(int(nsFile.Fd()), unix.CLONE_NEWNET); err != nil {
+		return nil, fmt.Errorf("error switching to ns %v: %v", nsFile.Name(), err)
+	}
+
+	// Call the system dialer - since we're calling a single URL, the dial will run in this thread, and will
+	// therefore do the connect in the container's namespace
+	conn, connErr := d.systemDialer.DialContext(ctx, network, address)
+
+	// Switch back to the host namespace now that we're done
+	if err = unix.Setns(int(prevNsFile.Fd()), unix.CLONE_NEWNET); err != nil {
+		return nil, fmt.Errorf("error switching to ns %v: %v", prevNsFile.Name(), err)
+	}
+
+	return conn, connErr
+}
+
+func newDialer(containerID string) (*nsDialer, error) {
+	netNsPath := fmt.Sprintf("%s/%s/ns/net", titusInits, containerID)
+	_, err := os.Stat(netNsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errUnknownContainer
+		}
+
+		return nil, err
+	}
+
+	return &nsDialer{
+		containerNetNsPath: netNsPath,
+		systemDialer: net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: false,
+		},
+	}, nil
+}

--- a/logviewer/api/transport_unsupported.go
+++ b/logviewer/api/transport_unsupported.go
@@ -3,26 +3,13 @@
 package api
 
 import (
-	"context"
 	"net"
-	"time"
 )
 
-type nsDialer struct {
-	systemDialer net.Dialer
-}
-
-func (d *nsDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	// Use the system dialer - doing a Setns() is only doable on Linux
-	return d.systemDialer.DialContext(ctx, network, address)
-}
+// Non-Linux OSes can't do a Setns(), so use the system dialer instead
+type nsDialer = net.Dialer
 
 func newDialer(containerID string) (*nsDialer, error) {
-	return &nsDialer{
-		systemDialer: net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: false,
-		},
-	}, nil
+	var d nsDialer
+	return &d, nil
 }

--- a/logviewer/api/transport_unsupported.go
+++ b/logviewer/api/transport_unsupported.go
@@ -1,0 +1,28 @@
+// +build !linux
+
+package api
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+type nsDialer struct {
+	systemDialer net.Dialer
+}
+
+func (d *nsDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	// Use the system dialer - doing a Setns() is only doable on Linux
+	return d.systemDialer.DialContext(ctx, network, address)
+}
+
+func newDialer(containerID string) (*nsDialer, error) {
+	return &nsDialer{
+		systemDialer: net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: false,
+		},
+	}, nil
+}

--- a/logviewer/conf/conf.go
+++ b/logviewer/conf/conf.go
@@ -11,6 +11,7 @@ var (
 	ContainersHome     = "/var/lib/docker/containers/"
 	ContainerID        = ""
 	RunningInContainer = false
+	ProxyMode          = true
 )
 
 func init() {
@@ -26,5 +27,11 @@ func init() {
 		ContainerID = cID
 		RunningInContainer = true
 		ContainersHome = "/"
+	}
+
+	proxyMode := os.Getenv("DISABLE_PROXY_MODE")
+	if proxyMode != "" {
+		log.Println("DISABLE_PROXY_MODE set")
+		ProxyMode = false
 	}
 }


### PR DESCRIPTION
The proxy sits on the host, and does a `Setns()` into a container's network namespace before connecting to its logviewer.
