### PR TITLE
IMDS: Delete existing Server header when proxying

### DIFF
--- a/metadataserver/server.go
+++ b/metadataserver/server.go
@@ -261,6 +261,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.Header.Del("x-aws-ec2-metadata-token")
+	w.Header().Del("Server")
 	metrics.PublishIncrementCounter("api.proxy_request.success.count")
 	p.reverseProxy.ServeHTTP(w, r)
 


### PR DESCRIPTION
### Description of the Change

Delete existing Server header when proxying to prevent doubling.
