### PR TITLE
Metadata Proxy Token Key Salt 

### DIFF
--- a/root/apps/titus-executor/bin/run-titus-metadata-proxy.sh
+++ b/root/apps/titus-executor/bin/run-titus-metadata-proxy.sh
@@ -13,5 +13,4 @@ if [[ -e /etc/titus-executor/metadata-proxy-config.sh ]]; then
   set +o allexport
 fi
 
-export TOKEN_KEY_SALT=$(hostname)
 exec /apps/titus-executor/bin/titus-inject-metadataproxy /apps/titus-executor/bin/titus-metadata-service --listener-fd=169

--- a/root/apps/titus-executor/bin/run-titus-metadata-proxy.sh
+++ b/root/apps/titus-executor/bin/run-titus-metadata-proxy.sh
@@ -13,4 +13,5 @@ if [[ -e /etc/titus-executor/metadata-proxy-config.sh ]]; then
   set +o allexport
 fi
 
+export TOKEN_KEY_SALT=$(hostname)
 exec /apps/titus-executor/bin/titus-inject-metadataproxy /apps/titus-executor/bin/titus-metadata-service --listener-fd=169

--- a/root/lib/systemd/system/titus-metadata-proxy@.service
+++ b/root/lib/systemd/system/titus-metadata-proxy@.service
@@ -15,7 +15,7 @@ NotifyAccess=all
 WatchdogSec=30
 
 Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
-EnvironmentFile=/run/titus-metadata-proxy.salt
+EnvironmentFile=-/run/titus-metadata-proxy.salt
 EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/apps/titus-executor/bin/run-titus-metadata-proxy.sh
 LimitNOFILE=65535

--- a/root/lib/systemd/system/titus-metadata-proxy@.service
+++ b/root/lib/systemd/system/titus-metadata-proxy@.service
@@ -6,12 +6,16 @@ ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 StartLimitIntervalSec=30
 StartLimitBurst=10
 
+After=titus-salt-generator.service
+Wants=titus-salt-generator.service
+
 [Service]
 Type=notify
 NotifyAccess=all
 WatchdogSec=30
 
 Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
+EnvironmentFile=/run/titus-metadata-proxy.salt
 EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/apps/titus-executor/bin/run-titus-metadata-proxy.sh
 LimitNOFILE=65535

--- a/root/lib/systemd/system/titus-salt-generator.service
+++ b/root/lib/systemd/system/titus-salt-generator.service
@@ -4,7 +4,7 @@ Description=Write salt for Titus IMDS
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/bin/bash -cx 'echo -n TOKEN_KEY_SALT=\" > /run/titus-metadata-proxy.salt && /bin/cat /proc/sys/kernel/random/uuid | tr -d "\n" >> /run/titus-metdata-proxy.salt && echo \" >> /run/titus-metdata-proxy.salt'
+ExecStart=/bin/bash -xc 'echo -n TOKEN_KEY_SALT= > /run/titus-metadata-proxy.salt && /bin/cat /proc/sys/kernel/random/uuid >> /run/titus-metadata-proxy.salt'
 LimitCORE=infinity
 
 [Install]

--- a/root/lib/systemd/system/titus-salt-generator.service
+++ b/root/lib/systemd/system/titus-salt-generator.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Write salt for Titus IMDS
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/bin/bash -cx 'echo -n TOKEN_KEY_SALT=\" > /run/titus-metadata-proxy.salt && /bin/cat /proc/sys/kernel/random/uuid | tr -d "\n" >> /run/titus-metdata-proxy.salt && echo \" >> /run/titus-metdata-proxy.salt'
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Set the token key salt for the metadata proxy to node's hostname. 

As I was testing this, I realized that the running container already knows one part of the key (the task ID) so the salt should be something the container has no knowledge of or else it could mint tokens. I _think_ the hostname of the node satisfies that constraint but I'd love some feedback on that. That being said, I think the worst it could do with minting abilities is to create a token that exceeds the max TTL. 