### PR TITLE
Rotate .out files to S3, so Tomcat apps don't run out of disk space

### DIFF
--- a/filesystems/watcher.go
+++ b/filesystems/watcher.go
@@ -63,6 +63,7 @@ var defaultUploadRegexpList = []*regexp.Regexp{
 	regexp.MustCompile(`stdout.[\d_\.]+$`),
 	regexp.MustCompile(`stderr.[\d_\.]+$`),
 	regexp.MustCompile(`[\d-_]+.log`),
+	regexp.MustCompile(`[\d-_]+.out`),
 	regexp.MustCompile(`[\S]+\.core\.[\d]+\.[\d]+`),
 }
 

--- a/filesystems/watcher_test.go
+++ b/filesystems/watcher_test.go
@@ -206,73 +206,49 @@ func TestDoubleUpload(t *testing.T) { // nolint: gocyclo
 
 func TestRotateRegexp(t *testing.T) { // nolint: gocyclo
 	shouldRotate := CheckFileForRotation("stdout", nil)
-	if shouldRotate {
-		t.Fatal("stdout should not rotate")
-	}
+	assert.False(t, shouldRotate, "stdout should not rotate")
 
 	shouldRotate = CheckFileForRotation("stdout.2", nil)
-	if !shouldRotate {
-		t.Fatal("stdout.2 should rotate")
-	}
+	assert.True(t, shouldRotate, "stdout.2 should rotate")
 
 	shouldRotate = CheckFileForRotation("stout.2", nil)
-	if shouldRotate {
-		t.Fatal("stout.2 should not rotate")
-	}
+	assert.False(t, shouldRotate, "stout.2 should not rotate")
 
 	shouldRotate = CheckFileForRotation("stdout.30092016_151555.073", nil)
-	if !shouldRotate {
-		t.Fatal("stdout.30092016_151555.073 should rotate")
-	}
+	assert.True(t, shouldRotate, "stdout.30092016_151555.073 should rotate")
 
 	shouldRotate = CheckFileForRotation("stderr.70092016_151555.07888", nil)
-	if !shouldRotate {
-		t.Fatal("stderr.70092016_151555.07888 should rotate")
-	}
+	assert.True(t, shouldRotate, "stderr.70092016_151555.07888 should rotate")
 
 	shouldRotate = CheckFileForRotation("stderr.foobar.4555.", nil)
-	if shouldRotate {
-		t.Fatal("stderr.foobar.4555 should not rotate")
-	}
+	assert.False(t, shouldRotate, "stderr.foobar.4555 should not rotate")
 
 	shouldRotate = CheckFileForRotation("stderr.70092016_151555.07888.backup", nil)
-	if shouldRotate {
-		t.Fatal("stderr.70092016_151555.07888.backup should not rotate")
-	}
+	assert.False(t, shouldRotate, "stderr.70092016_151555.07888.backup should not rotate")
 
 	allLogsRegexp := regexp.MustCompile(`^[\w \d \. _ -]*log$`)
 	shouldRotate = CheckFileForRotation("propsapi_i-4a7ec3d1_tomcat_catalina.out_20160329_1352.log", allLogsRegexp)
-
-	if !shouldRotate {
-		t.Fatal("propsapi_i-4a7ec3d1_tomcat_catalina.out_20160329_1352.log should rotate")
-	}
+	assert.True(t, shouldRotate, "propsapi_i-4a7ec3d1_tomcat_catalina.out_20160329_1352.log should rotate")
 
 	shouldRotate = CheckFileForRotation("stderr.20", allLogsRegexp)
-	if !shouldRotate {
-		t.Fatal("stderr.20 should rotate")
-	}
+	assert.True(t, shouldRotate, "stderr.20 should rotate")
 
 	shouldRotate = CheckFileForRotation("propsapi_i-0827338c_tomcat_catalina.out_20160414_0124.log", nil)
-	if !shouldRotate {
-		t.Fatal("propsapi_i-0827338c_tomcat_catalina.out_20160414_0124.log should rotate")
-	}
+	assert.True(t, shouldRotate, "propsapi_i-0827338c_tomcat_catalina.out_20160414_0124.log should rotate")
 
 	shouldRotate = CheckFileForRotation("tomcat-startup.log", nil)
-	if shouldRotate {
-		t.Fatal("tomcat-startup should not rotate")
-	}
+	assert.False(t, shouldRotate, "tomcat-startup should not rotate")
 
 	nqCore := "nodequark.core.13213.3213"
 	shouldRotate = CheckFileForRotation(nqCore, nil)
-	if !shouldRotate {
-		t.Fatalf("%s should rotate", nqCore)
-	}
+	assert.True(t, shouldRotate, "%s should rotate", nqCore)
 
 	nqBadCore := "nodequark.core.13213.abb.3213"
 	shouldRotate = CheckFileForRotation(nqBadCore, nil)
-	if shouldRotate {
-		t.Fatalf("%s should not rotate", nqBadCore)
-	}
+	assert.False(t, shouldRotate, "%s should not rotate", nqBadCore)
+
+	shouldRotate = CheckFileForRotation("catalina_20200330_21.out", nil)
+	assert.True(t, shouldRotate, "catalina_20200330_21.out should rotate")
 }
 
 // The logfile to use during the testing of log rotate code


### PR DESCRIPTION
Tomcat writes files named like `catalina_20200331_00.out`. We're currently not rotating / uploading these, which causes long-running Java apps to run out of disk space.
