### PR TITLE
Add agent parameter to enable requiring of imdsv2 token

### DIFF
--- a/cmd/titus-metadata-service/main.go
+++ b/cmd/titus-metadata-service/main.go
@@ -219,7 +219,7 @@ func main() {
 		cli.BoolFlag{
 			Name:        "require-token",
 			Usage:       "Set to true to require a token",
-			EnvVar:      "REQUIRE_TOKEN",
+			EnvVar:      "TITUS_IMDS_REQUIRE_TOKEN",
 			Destination: &requireToken,
 		},
 		cli.StringFlag{

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -69,6 +69,7 @@ const (
 	subnets                 = "titusParameter.agent.subnets"
 	elasticIPPool           = "titusParameter.agent.elasticIPPool"
 	elasticIPs              = "titusParameter.agent.elasticIPs"
+	imdsRequireToken        = "titusParameter.agent.imds.requireToken"
 	systemdImageLabel       = "com.netflix.titus.systemd"
 )
 
@@ -572,6 +573,10 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 
 	if vpcAccountID, ok := c.TitusInfo.GetPassthroughAttributes()[accountID]; ok {
 		c.Env["EC2_OWNER_ID"] = vpcAccountID
+	}
+
+	if requireToken, ok := c.TitusInfo.GetPassthroughAttributes()[imdsRequireToken]; ok {
+		c.Env["REQUIRE_TOKEN"] = requireToken
 	}
 
 	// This must got after all setup

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -576,7 +576,7 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 	}
 
 	if requireToken, ok := c.TitusInfo.GetPassthroughAttributes()[imdsRequireToken]; ok {
-		c.Env["REQUIRE_TOKEN"] = requireToken
+		c.Env["TITUS_IMDS_REQUIRE_TOKEN"] = requireToken
 	}
 
 	// This must got after all setup


### PR DESCRIPTION
This PR adds an agent parameter that allows a container to specify if the IMDSv2 token is required to access the metadata service. 