### PR TITLE
Allow an agent parameter to override default service mesh image.

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -28,6 +28,7 @@ const (
 	KvmEnabledParam              = "titusParameter.agent.kvmEnabled"
 	assignIPv6AddressParam       = "titusParameter.agent.assignIPv6Address"
 	serviceMeshEnabledParam      = "titusParameter.agent.service.serviceMesh.enabled"
+	serviceMeshContainerParam    = "titusParameter.agent.service.serviceMesh.container"
 	ttyEnabledParam              = "titusParameter.agent.ttyEnabled"
 	optimisticIAMTokenFetchParam = "titusParameter.agent.optimisticIAMTokenFetch"
 	// TitusEnvironmentsDir is the directory we write Titus environment files and JSON configs to
@@ -339,6 +340,19 @@ func (c *Container) GetServiceMeshEnabled() (bool, error) {
 	}
 
 	return val, nil
+}
+
+func (c *Container) GetServiceMeshImage() (string, error) {
+	image, ok := c.TitusInfo.GetPassthroughAttributes()[serviceMeshContainerParam]
+	if ok && len(image) > 0 {
+		return image, nil
+	}
+
+	if len(c.Config.ContainerServiceMeshImage) > 0 {
+		return c.Config.ContainerServiceMeshImage, nil
+	}
+
+	return "no-image", errors.New("Unable to determine service mesh container")
 }
 
 // GetShmSize should the container's /dev/shm size be set?

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"fmt"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -344,15 +345,17 @@ func (c *Container) GetServiceMeshEnabled() (bool, error) {
 
 func (c *Container) GetServiceMeshImage() (string, error) {
 	image, ok := c.TitusInfo.GetPassthroughAttributes()[serviceMeshContainerParam]
-	if ok && len(image) > 0 {
-		return image, nil
+	if ok {
+		return path.Join(c.Config.DockerRegistry, image), nil
+	} else {
+		image = c.Config.ContainerServiceMeshImage
 	}
 
-	if len(c.Config.ContainerServiceMeshImage) > 0 {
-		return c.Config.ContainerServiceMeshImage, nil
+	if  image == "" {
+		return "no-image", errors.New("Could not find service mesh image")
 	}
 
-	return "no-image", errors.New("Unable to determine service mesh container")
+	return path.Join(c.Config.DockerRegistry, image), nil
 }
 
 // GetShmSize should the container's /dev/shm size be set?


### PR DESCRIPTION
This allows the service mesh team to roll out canaries on select applications by overriding the global service mesh image with an agent parameter.