### PR TITLE
Fixed CreatedAt timestamp on doDescribeTrunkNetworkInterface

### DIFF
--- a/vpc/service/internal_apis.go
+++ b/vpc/service/internal_apis.go
@@ -324,7 +324,7 @@ WHERE trunk_eni = $1
 			return nil, err
 		}
 		branchENI.SecurityGroupIds = securityGroups
-		branchENI.CreatedAt, _ = ptypes.TimestampProto(lastAssignedTo)
+		branchENI.CreatedAt, _ = ptypes.TimestampProto(createdAt)
 		branchENI.ModifiedAt, _ = ptypes.TimestampProto(modifiedAt)
 		branchENI.LastAssignedTo, _ = ptypes.TimestampProto(lastAssignedTo)
 		association.BranchENI = &branchENI


### PR DESCRIPTION
### Fixed CreatedAt timestamp on doDescribeTrunkNetworkInterface

It looks like this is just a typo? This originates from the `branch_enis.created_at` column in the db.

If it isn't a typo, let me know and I can add a comment explaining why.