### PR TITLE
Use ENI allocated in webhook

### DIFF
--- a/api/netflix/titus/titus_job_api.pb.go
+++ b/api/netflix/titus/titus_job_api.pb.go
@@ -1286,8 +1286,10 @@ type JobDisruptionBudget_RatePercentagePerHour struct {
 func (m *JobDisruptionBudget_RatePercentagePerHour) Reset() {
 	*m = JobDisruptionBudget_RatePercentagePerHour{}
 }
-func (m *JobDisruptionBudget_RatePercentagePerHour) String() string { return proto.CompactTextString(m) }
-func (*JobDisruptionBudget_RatePercentagePerHour) ProtoMessage()    {}
+func (m *JobDisruptionBudget_RatePercentagePerHour) String() string {
+	return proto.CompactTextString(m)
+}
+func (*JobDisruptionBudget_RatePercentagePerHour) ProtoMessage() {}
 func (*JobDisruptionBudget_RatePercentagePerHour) Descriptor() ([]byte, []int) {
 	return fileDescriptor_1c07f2bd2273ea55, []int{9, 5}
 }

--- a/vpc/api/vpc.pb.go
+++ b/vpc/api/vpc.pb.go
@@ -2147,8 +2147,10 @@ type DisassociateTrunkNetworkInterfaceResponse struct {
 func (m *DisassociateTrunkNetworkInterfaceResponse) Reset() {
 	*m = DisassociateTrunkNetworkInterfaceResponse{}
 }
-func (m *DisassociateTrunkNetworkInterfaceResponse) String() string { return proto.CompactTextString(m) }
-func (*DisassociateTrunkNetworkInterfaceResponse) ProtoMessage()    {}
+func (m *DisassociateTrunkNetworkInterfaceResponse) String() string {
+	return proto.CompactTextString(m)
+}
+func (*DisassociateTrunkNetworkInterfaceResponse) ProtoMessage() {}
 func (*DisassociateTrunkNetworkInterfaceResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_95d23e4d548ba1d7, []int{37}
 }

--- a/vpc/types/types.go
+++ b/vpc/types/types.go
@@ -13,6 +13,28 @@ const (
 	SecurityGroupsAnnotation   = "network.titus.netflix.com/securityGroups"
 	IngressBandwidthAnnotation = "kubernetes.io/ingress-bandwidth"
 	EgressBandwidthAnnotation  = "kubernetes.io/egress-bandwidth"
+
+	IPv4AddressAnnotation      = "network.titus.netflix.com/address-ipv4"
+	IPv4PrefixLengthAnnotation = "network.titus.netflix.com/prefixlen-ipv4"
+	IPv6AddressAnnotation      = "network.titus.netflix.com/address-ipv6"
+	IPv6PrefixLengthAnnotation = "network.titus.netflix.com/prefixlen-ipv6"
+
+	BranchEniIDAnnotation     = "network.titus.netflix.com/branch-eni-id"
+	BranchEniMacAnnotation    = "network.titus.netflix.com/branch-eni-mac"
+	BranchEniVpcAnnotation    = "network.titus.netflix.com/branch-eni-vpc"
+	BranchEniSubnetAnnotation = "network.titus.netflix.com/branch-eni-subnet"
+
+	TrunkEniIDAnnotation  = "network.titus.netflix.com/trunk-eni-id"
+	TrunkEniMacAnnotation = "network.titus.netflix.com/trunk-eni-mac"
+	TrunkEniVpcAnnotation = "network.titus.netflix.com/trunk-eni-vpc"
+
+	VlanIDAnnotation        = "network.titus.netflix.com/vlan-id"
+	AllocationIdxAnnotation = "network.titus.netflix.com/allocation-idx"
+
+	AgentStackAnnotation  = "com.netflix.titus.agent.attribute/stack"
+	AgentRegionAnnotation = "com.netflix.titus.agent.attribute/region"
+	AgentZoneAnnotation   = "com.netflix.titus.agent.attribute/zone"
+	AgentITypeAnnotation  = " com.netflix.titus.agent.attribute/itype"
 )
 
 type Generation string


### PR DESCRIPTION
Use the annotations set by the pods/binding webhook which allocates ENIs in lieu of calling the VPC service from the CNI.