### PR TITLE
fix panic in doDeleteExcessBranches

### DIFF
--- a/vpc/service/delete_excess_branches.go
+++ b/vpc/service/delete_excess_branches.go
@@ -133,15 +133,14 @@ get_eni:
 		Isolation: sql.LevelSerializable,
 		ReadOnly:  true,
 	})
-	defer func(tx *sql.Tx) {
-		_ = tx.Rollback()
-	}(fastTx)
-
 	if err != nil {
 		err = errors.Wrap(err, "Cannot start serialized, readonly database transaction")
 		span.SetStatus(traceStatusFromError(err))
 		return false, err
 	}
+	defer func(tx *sql.Tx) {
+		_ = tx.Rollback()
+	}(fastTx)
 
 	row := fastTx.QueryRowContext(ctx, `
      SELECT branch_eni


### PR DESCRIPTION
### Description of the Change

fix a panic that happens when BeginTx returns an error:

```
Jul 24 16:30:49 titusvpcservice-i-0449c6d8b90a6b799 titus-vpc-servi[11379]: finished unary call with code NotFound
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: panic: runtime error: invalid memory address or nil pointer dereference
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xa0a46d]
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: goroutine 40317 [running]:
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: database/sql.(*Tx).rollback(0x0, 0x1283c00, 0xc00cc3f130, 0xc0020b78b8)
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]:         /usr/local/go/src/database/sql/sql.go:2107 +0x2d
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: database/sql.(*Tx).Rollback(...)
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]:         /usr/local/go/src/database/sql/sql.go:2126
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: github.com/Netflix/titus-executor/vpc/service.(*vpcService).doDeleteExcessBranches.func1(0x0)
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]:         /var/lib/buildkite-agent/builds/ip-192-168-0-113-1/netflix/titus-executor/vpc/service/delete_excess_branches.go:137 +0x30
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: github.com/Netflix/titus-executor/vpc/service.(*vpcService).doDeleteExcessBranches(0xc00042a500, 0x1477c00, 0xc00f019050, 0xc0000d5440, 0xc00ee15c00, 0x1459960, 0xc00124
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]:         /var/lib/buildkite-agent/builds/ip-192-168-0-113-1/netflix/titus-executor/vpc/service/delete_excess_branches.go:143 +0x19a0
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: github.com/Netflix/titus-executor/vpc/service.(*vpcService).deleteExccessBranchesLoop(0xc00042a500, 0x1477b40, 0xc00b596d00, 0x14660e0, 0xc0000d5440, 0x0, 0x0)
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]:         /var/lib/buildkite-agent/builds/ip-192-168-0-113-1/netflix/titus-executor/vpc/service/delete_excess_branches.go:85 +0xed
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: github.com/Netflix/titus-executor/vpc/service.(*vpcService).runFunctionUnderLongLivedLock.func1(0x1477b40, 0xc00b596c80, 0x1285a18, 0x0)
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]:         /var/lib/buildkite-agent/builds/ip-192-168-0-113-1/netflix/titus-executor/vpc/service/long_lived_lock.go:192 +0x102
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: github.com/Netflix/titus-executor/vpc/service.(*vpcService).holdLock.func1(0xc00e7683c0, 0xc000a01660, 0x1477b40, 0xc00b596c80)
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]:         /var/lib/buildkite-agent/builds/ip-192-168-0-113-1/netflix/titus-executor/vpc/service/long_lived_lock.go:336 +0x3a
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]: created by github.com/Netflix/titus-executor/vpc/service.(*vpcService).holdLock
Jul 24 16:30:50 titusvpcservice-i-0449c6d8b90a6b799 run-titus-vpc-service.sh[11379]:         /var/lib/buildkite-agent/builds/ip-192-168-0-113-1/netflix/titus-executor/vpc/service/long_lived_lock.go:335 +0x10b
```
