### PR TITLE
Added db migrations to remove leftover v2 titusvpcservice database tables

### DIFF
--- a/vpc/service/branch_enis.go
+++ b/vpc/service/branch_enis.go
@@ -660,7 +660,7 @@ retry:
 		goto retry
 	}
 	if err != nil {
-		err = errors.Wrap(err, "Could not query branch_eni_actions_disassociate for existing requests to disassociate")
+		err = errors.Wrap(err, "Could not query branch_eni_attachments for existing requests to disassociate")
 		tracehelpers.SetStatus(err, span)
 		return 0, err
 	}
@@ -876,7 +876,7 @@ WHERE branch_eni_attachments.id = $1
 				goto restart
 			}
 			if err2 != nil {
-				err2 = errors.Wrap(err2, "Unable to update branch_eni_actions_disassociate table to mark action as failed")
+				err2 = errors.Wrap(err2, "Unable to update branch_eni_attachments table to mark action as failed")
 				logger.G(ctx).WithError(err2).Error()
 				tracehelpers.SetStatus(err2, span)
 				return err2
@@ -887,7 +887,7 @@ WHERE branch_eni_attachments.id = $1
 				goto restart
 			}
 			if err2 != nil {
-				err2 = errors.Wrap(err2, "Unable to commit to branch_eni_actions_disassociate table to mark action as failed")
+				err2 = errors.Wrap(err2, "Unable to commit to branch_eni_attachments table to mark action as failed")
 				logger.G(ctx).WithError(err2).Error()
 				tracehelpers.SetStatus(err2, span)
 				return err2
@@ -968,7 +968,7 @@ retry_update:
 		goto retry_update
 	}
 	if err != nil {
-		err = errors.Wrap(err, "Cannot update branch_eni_actions_disassociate table to mark action as completed")
+		err = errors.Wrap(err, "Cannot update branch_eni_attachments table to mark action as completed")
 		tracehelpers.SetStatus(err, span)
 		return err
 	}

--- a/vpc/service/db/migrations/23_deprecate_v2.down.sql
+++ b/vpc/service/db/migrations/23_deprecate_v2.down.sql
@@ -1,0 +1,7 @@
+START TRANSACTION ;
+
+ALTER TABLE branch_eni_actions_associate_DEPRECATED RENAME TO branch_eni_actions_associate;
+ALTER TABLE branch_eni_actions_disassociate_DEPRECATED RENAME TO branch_eni_actions_disassociate;
+ALTER TABLE trunk_eni_accounts_DEPRECATED RENAME TO trunk_eni_accounts;
+
+COMMIT;

--- a/vpc/service/db/migrations/23_deprecate_v2.up.sql
+++ b/vpc/service/db/migrations/23_deprecate_v2.up.sql
@@ -1,0 +1,7 @@
+START TRANSACTION ;
+
+ALTER TABLE branch_eni_actions_associate RENAME TO branch_eni_actions_associate_DEPRECATED;
+ALTER TABLE branch_eni_actions_disassociate RENAME TO branch_eni_actions_disassociate_DEPRECATED;
+ALTER TABLE trunk_eni_accounts RENAME TO trunk_eni_accounts_DEPRECATED;
+
+COMMIT;

--- a/vpc/service/db/migrations/24_remove_v2.down.sql
+++ b/vpc/service/db/migrations/24_remove_v2.down.sql
@@ -1,0 +1,1 @@
+-- There is no down from here to restore the deprecated tables

--- a/vpc/service/db/migrations/24_remove_v2.up.sql
+++ b/vpc/service/db/migrations/24_remove_v2.up.sql
@@ -1,0 +1,10 @@
+START TRANSACTION ;
+
+DROP TABLE IF EXISTS branch_eni_actions_associate_DEPRECATED;
+DROP TABLE IF EXISTS branch_eni_actions_disassociate_DEPRECATED;
+DROP TYPE IF EXISTS association_action;
+DROP TYPE IF EXISTS action_state;
+
+DROP TABLE IF EXISTS trunk_eni_accounts_DEPRECATED;
+
+COMMIT;


### PR DESCRIPTION
These tables are leftover from the v2 era of the titusvpcservice.

I couldn't figure how to actually "raise" with postgres, but I didn't think it was too big of a deal.
