### PR TITLE
Consider subnets not found error as non-fatal, NotFound

### DIFF
--- a/vpc/service/assign_addresses_v3.go
+++ b/vpc/service/assign_addresses_v3.go
@@ -158,11 +158,11 @@ LIMIT 1
 	err = row.Scan(&ret.az, &ret.vpcID, &ret.accountID, &ret.subnetID, &ret.cidr, &ret.region)
 	if err == sql.ErrNoRows {
 		if len(subnetIDs) == 0 {
-			err = fmt.Errorf("No subnet found matching IDs %s in az %s", subnetIDs, az)
+			err = newNotFoundError(fmt.Errorf("No subnet found matching IDs %s in az %s", subnetIDs, az))
 		} else {
-			err = fmt.Errorf("No subnet found in account %s in az %s", accountID, az)
+			err = newNotFoundError(fmt.Errorf("No subnet found in account %s in az %s", accountID, az))
 		}
-		span.SetStatus(traceStatusFromError(err))
+		tracehelpers.SetStatus(err, span)
 		// explicitly not returning stale subnet here
 		return nil, err
 	}
@@ -570,7 +570,7 @@ func (vpcService *vpcService) AssignIPV3(ctx context.Context, req *vpcapi.Assign
 
 	subnet, err := vpcService.getSubnet(ctx, aws.StringValue(instance.Placement.AvailabilityZone), accountID, req.Subnets)
 	if err != nil {
-		span.SetStatus(traceStatusFromError(err))
+		tracehelpers.SetStatus(err, span)
 		return nil, err
 	}
 	span.AddAttributes(trace.StringAttribute("subnet", subnet.subnetID))

--- a/vpc/service/errors.go
+++ b/vpc/service/errors.go
@@ -104,3 +104,31 @@ func isSerializationFailure(err error) bool {
 	}
 	return pqErr.Code.Name() == "serialization_failure"
 }
+
+type notFoundError struct {
+	err error
+}
+
+func newNotFoundError(err error) error {
+	if err == nil {
+		panic("err is nil")
+	}
+	return &notFoundError{err: err}
+}
+
+func (e *notFoundError) Unwrap() error {
+	return e.err
+}
+
+func (e *notFoundError) Error() string {
+	return e.err.Error()
+}
+
+func (e *notFoundError) Is(target error) bool {
+	_, ok := target.(*notFoundError)
+	return ok
+}
+
+func (e *notFoundError) GRPCStatus() *status.Status {
+	return status.New(codes.NotFound, e.err.Error())
+}

--- a/vpc/service/service.go
+++ b/vpc/service/service.go
@@ -119,6 +119,8 @@ func unaryMetricsHandler(ctx context.Context, req interface{}, info *grpc.UnaryS
 	start := time.Now()
 	result, err := handler(ctx, req)
 
+	// TODO: Implement error unwrapping here to catch wrapped errors, so try to unwrap
+	// into an error which implements `GRPCStatus` before setting status From error
 	st, _ := status.FromError(err)
 	duration := time.Since(start)
 	l := logger.G(ctx).WithField("method", info.FullMethod).WithField("statusCode", st.Code().String()).WithField("duration", duration.String())


### PR DESCRIPTION
This error can happen in one of three conditions:
1. The agent's account / task's account / az being asked for has
   no subnets configured for it. This would be either caused
   by a misconfiguration on the Titus team's part, or the
   user's part
2. The data we fetch from AWS around subnets is wrong,
   and we've lost track of the subnets which we launch
   in.
3. Misconfiguration - Either the control plane, or the
   agent have misconfigured the default account / AZ / subnets
   for tasks.

Recently, we've seen an uptick in cases where the inputs
-Agent account
-Task requested account [optional]
-Task requested subnets [optional]

Have not aligned. We haven't seen grave misconfiguration of
our services, or the EC2 APIs return bad data lately.

We can alert on notfound as a % of total launches at a
much higher percentage if we want to keep track of
these errors still.

### Description of the Change

**FIXME**: please add at least one sentence explaining why changes here are being made.
