### PR TITLE
Move to relying on Titus VPC Service to send us routes

### DIFF
--- a/cmd/titus-vpc-tool/assign.go
+++ b/cmd/titus-vpc-tool/assign.go
@@ -48,6 +48,7 @@ func assignNetworkCommand(ctx context.Context, v *pkgviper.Viper, iipGetter inst
 						ElasticIPPool:      v.GetString("elastic-ip-pool"),
 						ElasticIPs:         v.GetStringSlice("elastic-ips"),
 						Idempotent:         v.GetBool("idempotent"),
+						Jumbo:              v.GetBool("jumbo"),
 					},
 				)
 			default:
@@ -66,6 +67,7 @@ func assignNetworkCommand(ctx context.Context, v *pkgviper.Viper, iipGetter inst
 	cmd.Flags().StringSlice("elastic-ips", []string{}, "One of the elastic IPs to use for attachment to the interface")
 	cmd.Flags().String("elastic-ip-pool", "", "The elastic IP pool to allocate from")
 	cmd.Flags().Bool("idempotent", false, "Try to allocate the assignment idempotently")
+	cmd.Flags().Bool("jumbo", false, "Container needs jumbo frames")
 
 	addSharedFlags(cmd.Flags())
 

--- a/cmd/titus-vpc-tool/setup_container.go
+++ b/cmd/titus-vpc-tool/setup_container.go
@@ -25,7 +25,7 @@ func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter ins
 			case "v1":
 				return container.SetupContainer(ctx, iipGetter(), netns, uint64(bandwidth), burst, jumbo)
 			case "v2", "v3":
-				return container2.SetupContainer(ctx, iipGetter(), netns, uint64(bandwidth), burst, jumbo)
+				return container2.SetupContainer(ctx, iipGetter(), netns, uint64(bandwidth), burst)
 			default:
 				return fmt.Errorf("Version %q not recognized", v.GetString(generationFlagName))
 			}

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -32,6 +32,8 @@ const (
 	serviceMeshContainerParam    = "titusParameter.agent.service.serviceMesh.container"
 	ttyEnabledParam              = "titusParameter.agent.ttyEnabled"
 	optimisticIAMTokenFetchParam = "titusParameter.agent.optimisticIAMTokenFetch"
+	jumboFrameParam              = "titusParameter.agent.allowNetworkJumbo"
+
 	// TitusEnvironmentsDir is the directory we write Titus environment files and JSON configs to
 	TitusEnvironmentsDir            = "/var/lib/titus-environments"
 	titusContainerIDEnvVariableName = "TITUS_CONTAINER_ID"
@@ -327,6 +329,21 @@ func (c *Container) AssignIPv6Address() (bool, error) {
 	}
 
 	return val, nil
+}
+
+// Jumbo determines whether the container should get jumbo frames
+func (c *Container) Jumbo() (bool, error) {
+	val, ok := c.TitusInfo.GetPassthroughAttributes()[jumboFrameParam]
+	if !ok {
+		return false, nil
+	}
+	allowJumbo, err := strconv.ParseBool(val)
+	if err != nil {
+		err = fmt.Errorf("Cannot parse value %q of: %s: %w", val, jumboFrameParam, err)
+		return false, err
+	}
+
+	return allowJumbo, nil
 }
 
 // GetServiceMeshEnabled should the service mesh system service be enabled?

--- a/vpc/tool/assign3/assign_network.go
+++ b/vpc/tool/assign3/assign_network.go
@@ -30,6 +30,7 @@ type Arguments struct {
 	ElasticIPPool      string
 	ElasticIPs         []string
 	Idempotent         bool
+	Jumbo              bool
 }
 
 func Assign(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, conn *grpc.ClientConn, args Arguments) error {
@@ -111,6 +112,7 @@ func doAllocateNetwork(ctx context.Context, instanceIdentityProvider identity.In
 		InstanceIdentity: instanceIdentity,
 		AccountID:        args.InterfaceAccount,
 		Idempotent:       args.Idempotent,
+		Jumbo:            args.Jumbo,
 	}
 
 	if args.ElasticIPPool != "" {

--- a/vpc/tool/container2/setup_container.go
+++ b/vpc/tool/container2/setup_container.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns int, bandwidth uint64, burst, jumbo bool) error {
+func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns int, bandwidth uint64, burst bool) error {
 	var allocation types.Allocation
 	err := json.NewDecoder(os.Stdin).Decode(&allocation)
 	if err != nil {
@@ -30,7 +30,7 @@ func SetupContainer(ctx context.Context, instanceIdentityProvider identity.Insta
 			return errors.Wrap(err, "Cannot get max network bps, and burst is set")
 		}
 	}
-	err = DoSetupContainer(ctx, netns, bandwidth, ceil, jumbo, allocation)
+	err = DoSetupContainer(ctx, netns, bandwidth, ceil, allocation)
 	if err != nil {
 		// warning: Errors unhandled.,LOW,HIGH (gosec)
 		_ = json.NewEncoder(os.Stdout).Encode(types.WiringStatus{Success: false, Error: err.Error()}) // nolint: gosec

--- a/vpc/tool/container2/setup_container_unsupported.go
+++ b/vpc/tool/container2/setup_container_unsupported.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Netflix/titus-executor/vpc/types"
 )
 
-func DoSetupContainer(ctx context.Context, netnsfd int, bandwidth, ceil uint64, jumbo bool, allocation types.Allocation) error {
+func DoSetupContainer(ctx context.Context, netnsfd int, bandwidth, ceil uint64, allocation types.Allocation) error {
 	return types.ErrUnsupported
 }
 


### PR DESCRIPTION
This finishes wiring up jumbo frames end-to-end, but it means that
it relies on the Titus VPC Service to send down routes to the
agent with MTU-per-route.
