### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/hack/agent/Dockerfile
+++ b/hack/agent/Dockerfile
@@ -6,15 +6,15 @@
 # systemd pieces were inspired by solita/docker-systemd (MIT License)
 FROM ubuntu:bionic
 
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y apt-transport-https ca-certificates
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get --no-install-recommends install -y apt-transport-https ca-certificates
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update &&\
-    apt-get install -y build-essential curl make cmake libattr1-dev dbus systemd
+    apt-get --no-install-recommends install -y build-essential curl make cmake libattr1-dev dbus systemd
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update &&\
-    apt-get install -y docker-ce=5:18.09.7~3-0~ubuntu-bionic
+    apt-get --no-install-recommends install -y docker-ce=5:18.09.7~3-0~ubuntu-bionic
 
 ### systemd
 ENV container docker

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
-    apt-get install -y build-essential make cmake g++ gcc libc6-dev pkg-config \
+    apt-get --no-install-recommends install -y build-essential make cmake g++ gcc libc6-dev pkg-config \
         libattr1-dev git curl wget jq ruby ruby-dev rubygems lintian unzip bison flex clang llvm && \
     rm -rf /var/lib/apt/lists/*
 

--- a/hack/ci-builder/Dockerfile
+++ b/hack/ci-builder/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:bionic
 
 
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common && apt-get clean
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get --no-install-recommends install -y apt-transport-https ca-certificates curl software-properties-common gpg-agent git && apt-get clean
 COPY docker-repo.gpg /tmp
 RUN apt-key add /tmp/docker-repo.gpg
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y wget build-essential docker-ce ruby ruby-dev ruby-bundler gcc g++ make pkg-config && apt-get clean
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get --no-install-recommends install -y wget build-essential docker-ce ruby ruby-dev ruby-bundler gcc g++ make pkg-config && apt-get clean
 COPY --from=golang:1.13-stretch /usr/local/go /usr/local/go
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH

--- a/hack/test-images/metatron/Dockerfile
+++ b/hack/test-images/metatron/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic as builder
 
 COPY --from=golang:1.13-stretch /usr/local/go /usr/local/go
-RUN apt-get update && apt-get install busybox-static
+RUN apt-get update && apt-get --no-install-recommends install -y busybox-static
 ENV GOPATH /go
 ENV EXECUTOR_DIR "$GOPATH/src/github.com/Netflix/titus-executor"
 ENV DESTDIR "$EXECUTOR_DIR/hack/test-images/metatron"

--- a/hack/test-images/metatron/Dockerfile-e
+++ b/hack/test-images/metatron/Dockerfile-e
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic as builder
 
 COPY --from=golang:1.13-stretch /usr/local/go /usr/local/go
-RUN apt-get update && apt-get install busybox-static
+RUN apt-get update && apt-get --no-install-recommends install -y busybox-static
 ENV GOPATH /go
 ENV EXECUTOR_DIR "$GOPATH/src/github.com/Netflix/titus-executor"
 ENV DESTDIR "$EXECUTOR_DIR/hack/test-images/metatron"

--- a/hack/test-images/pty/Dockerfile
+++ b/hack/test-images/pty/Dockerfile
@@ -1,2 +1,2 @@
 FROM ubuntu:xenial
-RUN apt-get update && apt-get install -y expect coreutils
+RUN apt-get update && apt-get --no-install-recommends install -y expect coreutils

--- a/hack/test-images/ubuntu-systemd-bionic/Dockerfile
+++ b/hack/test-images/ubuntu-systemd-bionic/Dockerfile
@@ -5,7 +5,7 @@ ENV container docker
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -y dbus systemd locales curl && \
+    apt-get --no-install-recommends install -y dbus systemd locales curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/hack/test-images/ubuntu/Dockerfile
+++ b/hack/test-images/ubuntu/Dockerfile
@@ -1,2 +1,2 @@
 FROM ubuntu:xenial
-RUN apt-get update && apt-get install -y curl libcap2-bin grep iproute2 httpie iputils-ping stress schedtool
+RUN apt-get update && apt-get --no-install-recommends install -y curl libcap2-bin grep iproute2 httpie iputils-ping stress schedtool


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>