### PR TITLE
Make it so that an ENI must not already have an existing cross account permission

### DIFF
--- a/vpc/service/branch_enis.go
+++ b/vpc/service/branch_enis.go
@@ -550,6 +550,11 @@ func (vpcService *vpcService) ensureBranchENIPermissionV3(ctx context.Context, t
 	ctx, span := trace.StartSpan(ctx, "ensureBranchENIPermissionV3")
 	defer span.End()
 
+	span.AddAttributes(
+		trace.StringAttribute("branch", eni.id),
+		trace.StringAttribute("branchAccount", eni.accountID),
+		trace.StringAttribute("trunkAccount", trunkENIAccountID),
+	)
 	if eni.accountID == trunkENIAccountID {
 		return nil
 	}


### PR DESCRIPTION
This is added because now in a given region, we have two pools of agents being managed. When CreateNetworkInterfacePermission is used, it cannot be used to give multiple accounts permissions. This helps us deal with that... 