### PR TITLE
Do dns resolution lookups for NFS mounts at mount time

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1346,19 +1346,6 @@ func maybeConvertIntoBadEntryPointError(err error) error {
 	return err
 }
 
-func inferLocalIP(remoteIP *net.UDPAddr) (net.IP, error) {
-	addr, err := net.DialUDP("udp4", nil, remoteIP)
-	if err != nil {
-		return nil, err
-	}
-	host, _, err := net.SplitHostPort(addr.LocalAddr().String())
-	if err != nil {
-		return nil, err
-	}
-
-	return net.ParseIP(host), nil
-}
-
 type readWriteMode int
 
 const (
@@ -1378,9 +1365,6 @@ type efsMountInfo struct {
 	// Derived fields
 	// Derived from taking the DNS name of: ${efsFsID}.efs.${REGION}.amazonaws.com
 	hostname string
-	remoteIP net.IP
-	// What's the route to that? Eventually, we can do multiple IPs in order to QoS EFS access, but let's do that later.
-	localIP net.IP
 }
 
 func (r *DockerRuntime) processEFSMounts(c *runtimeTypes.Container) ([]efsMountInfo, error) {
@@ -1411,22 +1395,7 @@ func (r *DockerRuntime) processEFSMounts(c *runtimeTypes.Container) ([]efsMountI
 			// We don't validate at client creation time, because we don't get this during testing.
 			return nil, errors.New("Could not retrieve EC2 region")
 		}
-		// Get the remote IP. -- Is this really the best way how? Go doesn't have a simpler API for this?
 		emi.hostname = fmt.Sprintf("%s.efs.%s.amazonaws.com", emi.efsFsID, r.awsRegion)
-		// According to go's documentation:
-		// Resolving a hostname is not recommended because this returns at most one of its IP addresses.
-		// It just takes the first IP the resolver returns
-		addr, err := net.ResolveUDPAddr("udp4", emi.hostname+":1")
-		if err != nil {
-			return nil, err
-		}
-
-		// In the "official" go code, they use the first IP returned, but not sure what to do here.
-		emi.remoteIP = addr.IP
-		emi.localIP, err = inferLocalIP(addr)
-		if err != nil {
-			return nil, err
-		}
 		efsMountInfos = append(efsMountInfos, emi)
 	}
 
@@ -1687,8 +1656,6 @@ func (r *DockerRuntime) setupEFSMounts(parentCtx context.Context, c *runtimeType
 
 		mountOptions := append(
 			baseMountOptions,
-			fmt.Sprintf("addr=%s", efsMountInfo.remoteIP.String()),
-			fmt.Sprintf("clientaddr=%s", efsMountInfo.localIP.String()),
 			fmt.Sprintf("fsc=%s", c.TaskID),
 		)
 		cmd.Env = []string{
@@ -1698,6 +1665,7 @@ func (r *DockerRuntime) setupEFSMounts(parentCtx context.Context, c *runtimeType
 			"MOUNT_NS=3",
 			"NET_NS=4",
 			fmt.Sprintf("MOUNT_TARGET=%s", efsMountInfo.cleanMountPoint),
+			fmt.Sprintf("MOUNT_NFS_HOSTNAME=%s", efsMountInfo.hostname),
 			fmt.Sprintf("MOUNT_SOURCE=%s:%s", efsMountInfo.hostname, efsMountInfo.cleanEfsFsRelativeMntPoint),
 			fmt.Sprintf("MOUNT_FLAGS=%d", flags),
 			fmt.Sprintf("MOUNT_OPTIONS=%s", strings.Join(mountOptions, ",")),

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     apt-get install -y build-essential make cmake g++ gcc libc6-dev pkg-config \
-        libattr1-dev git curl wget jq ruby ruby-dev rubygems lintian unzip bison flex clang llvm && \
+        libattr1-dev git curl wget jq ruby ruby-dev rubygems lintian unzip bison flex clang llvm musl-tools && \
     rm -rf /var/lib/apt/lists/*
 
 RUN gem install --no-ri --no-rdoc fpm

--- a/mount/Dockerfile
+++ b/mount/Dockerfile
@@ -1,0 +1,6 @@
+FROM scratch
+ADD resolv.conf /etc/resolv.conf
+ADD titus-mount titus-mount
+ENV MOUNT_OPTIONS=foo,bar
+ENV MOUNT_FLAGS=""
+ENV MOUNT_NFS_HOSTNAME=example.com

--- a/mount/Makefile
+++ b/mount/Makefile
@@ -1,3 +1,2 @@
 titus-mount: mount.c
-	gcc -D_GNU_SOURCE=1 -std=gnu11 -Wall -Werror -static -g -o titus-mount mount.c
-
+	musl-gcc -std=gnu11 -Wall -static -g -o titus-mount mount.c

--- a/mount/resolv.conf
+++ b/mount/resolv.conf
@@ -1,0 +1,1 @@
+nameserver 1.1.1.1

--- a/mount/test.sh
+++ b/mount/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# This is a test harness for experimenting with
+# the statically-linked titus-mount command
+# in a scratch container.
+set -vxeu
+make
+sudo docker run $(sudo docker build -q . ) ./titus-mount


### PR DESCRIPTION
Previously, the titus-executor would do the dns lookup
for an NFS mount on behalf of a container, and pass
that addr into the mount syscall.

However, sometimes the dns name for an EFS (Amazon NFS)
endpoint won't even resolve unless you are in the
correct network namespace.

This change defers the lookup of the IP for NFS
until the last second, while we are inside the network
namespace of the container.

To get around the limitations of statically linked binaries
and glibc+libnss, we switch to use musl-gcc, which is fine
for such a small binary.

----

I would like to test this end-to-end on a real stack and real mount to verify it actually does what we expect.
I copy/pasted getaddr functions from mount.nfs4 directly, so they should match the status quo behavior of what normal tools would do if you just had this in fstab or whatever. 