### PR TITLE
Write the pod's network namespace path to a file

### DIFF
--- a/cmd/titus-imds-cni/cni_linux.go
+++ b/cmd/titus-imds-cni/cni_linux.go
@@ -256,6 +256,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 		goto failMount
 	}
 
+	err = writeNetworkNamespaceFile(pod, args.Netns)
+	if err != nil {
+		logrus.Errorf("writeNetworkNamespaceFile %s", err)
+		goto failMount
+	}
+
 	err = startUnit(pod.Name)
 	if err != nil {
 		logrus.Errorf("startUnit %s", err)


### PR DESCRIPTION
This is required for the open telemetry exporter to contact the
spectatord sidecar
