### PR TITLE
Refactor docker runtime to not be built around Mesos

### DIFF
--- a/cmd/virtual-kubelet-backend-titus-executor/main.go
+++ b/cmd/virtual-kubelet-backend-titus-executor/main.go
@@ -105,12 +105,12 @@ func mainWithError(podFileName string, statusPipe string, dockerCfg *docker.Conf
 
 	log.G(ctx).WithField("pod", pod.Name).Debugf("Getting uploaders from %+v", cfg.S3Uploaders)
 
-	dockerRunner, err := runner.New(ctx, m, *cfg, *dockerCfg)
+	rp, err := docker.NewDockerRuntime(ctx, m, *dockerCfg, *cfg)
 	if err != nil {
 		return errors.Wrap(err, "cannot create Titus executor")
 	}
 
-	err = backend.RunWithBackend(ctx, dockerRunner, pipe, pod)
+	err = backend.RunWithBackend(ctx, rp, m, pipe, pod, *cfg)
 	if err != nil {
 		log.G(ctx).WithError(err).Fatal("Could not run container")
 	}

--- a/executor/mock/jobrunner.go
+++ b/executor/mock/jobrunner.go
@@ -23,6 +23,7 @@ import (
 	metadataserverTypes "github.com/Netflix/titus-executor/metadataserver/types"
 	protobuf "github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
+	"gotest.tools/assert"
 )
 
 var errStatusChannelClosed = errors.New("Status channel closed")
@@ -86,6 +87,8 @@ type JobInput struct {
 // JobRunResponse returned from RunJob
 type JobRunResponse struct {
 	runner     *runner.Runner
+	ctx        context.Context
+	cancel     context.CancelFunc
 	TaskID     string
 	UpdateChan chan runner.Update
 }
@@ -221,14 +224,6 @@ func (jobRunResponse *JobRunResponse) logContainerStdErrOut() {
 
 }
 
-// JobRunner is the entrypoint struct to create an executor and run test jobs on it
-type JobRunner struct {
-	runner          *runner.Runner
-	ctx             context.Context
-	cancel          context.CancelFunc
-	shutdownChannel chan struct{}
-}
-
 // GenerateConfigs generates test configs
 func GenerateConfigs(jobInput *JobInput) (*config.Config, *docker.Config) {
 	configArgs := []string{"--copy-uploader", logUploadDir}
@@ -274,45 +269,28 @@ func GenerateConfigs(jobInput *JobInput) (*config.Config, *docker.Config) {
 	return cfg, dockerCfg
 }
 
-// NewJobRunner creates a new JobRunner with its executor started
-// in the background and the test driver configured to use it.
-func NewJobRunner(jobInput *JobInput) *JobRunner {
+var r = rand.New(rand.NewSource(999))
+
+// StopExecutor stops a currently running executor
+func (jobRunResponse *JobRunResponse) StopExecutor() {
+	jobRunResponse.cancel()
+	<-jobRunResponse.runner.StoppedChan
+}
+
+// StopExecutorAsync stops a currently running executor
+func (jobRunResponse *JobRunResponse) StopExecutorAsync() {
+	jobRunResponse.cancel()
+}
+
+// StartJob starts a job and returns once the job is started
+func StartJob(t *testing.T, ctx context.Context, jobInput *JobInput) (*JobRunResponse, error) { // nolint: gocyclo,golint
 	cfg, dockerCfg := GenerateConfigs(jobInput)
 
 	log.SetLevel(log.DebugLevel)
 	// Create an executor
-	ctx, cancel := context.WithCancel(context.Background())
-	// TODO: Replace this config mechanism
-	r, err := runner.New(ctx, metrics.Discard, *cfg, *dockerCfg)
-	if err != nil {
-		log.Fatalf("cannot create executor : %s", err)
-	}
+	ctx, cancel := context.WithCancel(ctx) // nolint:govet
+	// DO NOT CANCEL Context, this will stop the job.
 
-	jobRunner := &JobRunner{
-		ctx:             ctx,
-		cancel:          cancel,
-		runner:          r,
-		shutdownChannel: make(chan struct{}),
-	}
-
-	return jobRunner
-}
-
-var r = rand.New(rand.NewSource(999))
-
-// StopExecutor stops a currently running executor
-func (jobRunner *JobRunner) StopExecutor() {
-	jobRunner.cancel()
-	<-jobRunner.runner.StoppedChan
-}
-
-// StopExecutorAsync stops a currently running executor
-func (jobRunner *JobRunner) StopExecutorAsync() {
-	jobRunner.cancel()
-}
-
-// StartJob starts a job on an existing JobRunner and returns once the job is started
-func (jobRunner *JobRunner) StartJob(t *testing.T, jobInput *JobInput) *JobRunResponse { // nolint: gocyclo
 	// Define some stock job to run
 	var jobID string
 
@@ -414,54 +392,73 @@ func (jobRunner *JobRunner) StartJob(t *testing.T, jobInput *JobInput) *JobRunRe
 	diskMiB := uint64(100)
 	network := uint64(128)
 
-	// Get a reference to the executor and somewhere to stash results
-
-	// Start the task and wait for it to complete
-	err := jobRunner.runner.StartTask(taskID, ci, memMiB, cpu, gpu, diskMiB, network)
+	// TODO: Replace this config mechanism
+	task := runner.Task{
+		TaskID:    taskID,
+		TitusInfo: ci,
+		Mem:       memMiB,
+		CPU:       cpu,
+		Gpu:       gpu,
+		Disk:      diskMiB,
+		Network:   network,
+	}
+	runner, err := runner.StartTask(ctx, task, metrics.Discard, *cfg, *dockerCfg)
 	if err != nil {
-		log.Printf("Failed to start task %s: %s", taskID, err)
-	}
-	jrr := &JobRunResponse{
-		runner:     jobRunner.runner,
-		TaskID:     taskID,
-		UpdateChan: jobRunner.runner.UpdatesChan,
+		cancel()
+		return nil, fmt.Errorf("Cannot start task / runner: %w", err)
 	}
 
-	return jrr
+	jrr := &JobRunResponse{
+		ctx:        ctx,
+		cancel:     cancel,
+		runner:     runner,
+		TaskID:     taskID,
+		UpdateChan: runner.UpdatesChan,
+	}
+
+	return jrr, nil
 }
 
 // KillTask issues a kill task request to the executor. The kill
 // may be done in the background and the state change should occur
 // on the existing JobRunResponse channel.
-func (jobRunner *JobRunner) KillTask() error {
-	jobRunner.runner.Kill()
-	<-jobRunner.runner.StoppedChan
+func (jobRunResponse *JobRunResponse) KillTask() error {
+	jobRunResponse.runner.Kill()
+	<-jobRunResponse.runner.StoppedChan
 	return nil
 }
 
 // RunJobExpectingSuccess is similar to RunJob but returns true when the task completes successfully.
 func RunJobExpectingSuccess(t *testing.T, jobInput *JobInput) bool {
-	jobRunner := NewJobRunner(jobInput)
-	defer jobRunner.StopExecutor()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	jobResult := jobRunner.StartJob(t, jobInput)
+	jobResult, err := StartJob(t, ctx, jobInput)
+	assert.NilError(t, err)
+
+	defer jobResult.StopExecutor()
 	return jobResult.WaitForSuccess()
 }
 
 // RunJobExpectingFailure is similar to RunJob but returns true when the task completes successfully.
 func RunJobExpectingFailure(t *testing.T, jobInput *JobInput) bool {
-	jobRunner := NewJobRunner(jobInput)
-	defer jobRunner.StopExecutor()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	jobResult := jobRunner.StartJob(t, jobInput)
+	jobResult, err := StartJob(t, ctx, jobInput)
+	assert.NilError(t, err)
+
+	defer jobResult.StopExecutor()
 	return jobResult.WaitForFailure()
 }
 
 // RunJob runs a single Titus task based on provided JobInput
 func RunJob(t *testing.T, jobInput *JobInput) (string, error) {
-	jobRunner := NewJobRunner(jobInput)
-	defer jobRunner.StopExecutor()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	jobResult := jobRunner.StartJob(t, jobInput)
+	jobResult, err := StartJob(t, ctx, jobInput)
+	assert.NilError(t, err)
+
 	return jobResult.WaitForCompletion()
 }

--- a/executor/mock/standalone/standalone_test.go
+++ b/executor/mock/standalone/standalone_test.go
@@ -200,10 +200,15 @@ func dockerImageRemove(t *testing.T, imgName string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rt, err := docker.NewDockerRuntime(ctx, metrics.Discard, *dockerCfg, *cfg)
-	require.NoError(t, err, "No error creating docker runtime")
+	runtimeMaker, err := docker.NewDockerRuntime(ctx, metrics.Discard, *dockerCfg, *cfg)
+	require.NoError(t, err, "Error creating docker runtime maker")
+
+	rt, err := runtimeMaker(ctx, nil, time.Time{})
+	require.NoError(t, err, "Error creating docker runtime")
 
 	drt, ok := rt.(*docker.DockerRuntime)
+	require.True(t, ok, "DockerRuntime cast should succeed")
+
 	require.True(t, ok, "DockerRuntime cast should succeed")
 	err = drt.DockerImageRemove(ctx, imgName)
 	require.NoErrorf(t, err, "No error removing docker image %s: +%v", imgName, err)
@@ -215,8 +220,11 @@ func dockerPull(t *testing.T, imgName string, imgDigest string) (*dockerTypes.Im
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rt, err := docker.NewDockerRuntime(ctx, metrics.Discard, *dockerCfg, *cfg)
-	require.NoError(t, err, "No error creating docker runtime")
+	runtimeMaker, err := docker.NewDockerRuntime(ctx, metrics.Discard, *dockerCfg, *cfg)
+	require.NoError(t, err, "Error creating docker runtime maker")
+
+	rt, err := runtimeMaker(ctx, nil, time.Time{})
+	require.NoError(t, err, "Error creating docker runtime")
 
 	drt, ok := rt.(*docker.DockerRuntime)
 	require.True(t, ok, "DockerRuntime cast should succeed")
@@ -286,11 +294,10 @@ func testInvalidFlatStringAsCmd(t *testing.T, jobID string) {
 		},
 		JobID: jobID,
 	}
-	jobRunner := mock.NewJobRunner(nil)
-	defer jobRunner.StopExecutor()
-	jobResponse := jobRunner.StartJob(t, ji)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
+	jobResponse, err := mock.StartJob(t, ctx, ji)
+	require.NoError(t, err)
 	if err := jobResponse.WaitForFailureWithStatus(ctx, 127); err != nil {
 		t.Fatal(err)
 	}
@@ -320,11 +327,10 @@ func testEntrypointAndCmdFromImage(t *testing.T, jobID string) {
 		},
 		JobID: jobID,
 	}
-	jobRunner := mock.NewJobRunner(nil)
-	defer jobRunner.StopExecutor()
-	jobResponse := jobRunner.StartJob(t, ji)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
+	jobResponse, err := mock.StartJob(t, ctx, ji)
+	require.NoError(t, err)
 	if err := jobResponse.WaitForFailureWithStatus(ctx, 123); err != nil {
 		t.Fatal(err)
 	}
@@ -339,11 +345,10 @@ func testOverrideCmdFromImage(t *testing.T, jobID string) {
 		},
 		JobID: jobID,
 	}
-	jobRunner := mock.NewJobRunner(nil)
-	defer jobRunner.StopExecutor()
-	jobResponse := jobRunner.StartJob(t, ji)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
+	jobResponse, err := mock.StartJob(t, ctx, ji)
+	require.NoError(t, err)
 	if err := jobResponse.WaitForFailureWithStatus(ctx, 5); err != nil {
 		t.Fatal(err)
 	}
@@ -359,11 +364,11 @@ func testResetEntrypointFromImage(t *testing.T, jobID string) {
 		},
 		JobID: jobID,
 	}
-	jobRunner := mock.NewJobRunner(nil)
-	defer jobRunner.StopExecutor()
-	jobResponse := jobRunner.StartJob(t, ji)
+
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
+	jobResponse, err := mock.StartJob(t, ctx, ji)
+	require.NoError(t, err)
 	if err := jobResponse.WaitForFailureWithStatus(ctx, 6); err != nil {
 		t.Fatal(err)
 	}
@@ -549,16 +554,19 @@ func testImagePullError(t *testing.T, jobID string) {
 }
 
 func testCancelPullBigImage(t *testing.T, jobID string) { // nolint: gocyclo
-	jobRunner := mock.NewJobRunner(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	testResultBigImage := jobRunner.StartJob(t, &mock.JobInput{
+	jobResponse, err := mock.StartJob(t, ctx, &mock.JobInput{
 		JobID:     jobID,
 		ImageName: bigImage.name,
 		Version:   bigImage.tag,
 	})
 
+	require.NoError(t, err)
+
 	select {
-	case taskStatus := <-testResultBigImage.UpdateChan:
+	case taskStatus := <-jobResponse.UpdateChan:
 		if taskStatus.State.String() != "TASK_STARTING" {
 			t.Fatal("Task never observed in TASK_STARTING, instead: ", taskStatus)
 		}
@@ -566,19 +574,19 @@ func testCancelPullBigImage(t *testing.T, jobID string) { // nolint: gocyclo
 		t.Fatal("Spent too long waiting for task starting")
 	}
 
-	if err := jobRunner.KillTask(); err != nil {
+	if err := jobResponse.KillTask(); err != nil {
 		t.Fatal("Could not stop task: ", err)
 	}
 	timeOut := time.After(30 * time.Second)
 	for {
 		select {
-		case taskStatus := <-testResultBigImage.UpdateChan:
+		case taskStatus := <-jobResponse.UpdateChan:
 			//		t.Log("Observed task status: ", taskStatus)
 			if taskStatus.State == titusdriver.Running {
-				t.Fatalf("Task %s started after killTask %v", testResultBigImage.TaskID, taskStatus)
+				t.Fatalf("Task %s started after killTask %v", jobResponse.TaskID, taskStatus)
 			}
 			if taskStatus.State == titusdriver.Killed || taskStatus.State == titusdriver.Lost {
-				t.Logf("Task %s successfully terminated with status %s", testResultBigImage.TaskID, taskStatus.State.String())
+				t.Logf("Task %s successfully terminated with status %s", jobResponse.TaskID, taskStatus.State.String())
 				goto big_task_killed
 			}
 		case <-timeOut:
@@ -587,7 +595,7 @@ func testCancelPullBigImage(t *testing.T, jobID string) { // nolint: gocyclo
 	}
 big_task_killed:
 	// We do this here, otherwise  a stuck executor can prevent this from exiting.
-	jobRunner.StopExecutor()
+	jobResponse.StopExecutor()
 }
 
 func testBadEntrypoint(t *testing.T, jobID string) {
@@ -629,6 +637,13 @@ func testCanWriteInLogsAndSubDirs(t *testing.T, jobID string) {
 }
 
 func testShutdown(t *testing.T, jobID string) {
+	// This test changed from canceling the context to stop the container to calling killTask. The reason being
+	// is that now we plumb through a single context from the test -> jobRunner -> runtime. This is useful for
+	// things like tracing, but it makes it so that once the context is cancelled, we can no longer make calls
+	// to the backend.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
+	defer cancel()
+
 	ji := &mock.JobInput{
 		ImageName:     alpine.name,
 		Version:       alpine.tag,
@@ -636,33 +651,37 @@ func testShutdown(t *testing.T, jobID string) {
 		JobID:         jobID,
 	}
 
-	jobRunner := mock.NewJobRunner(nil)
-	testResult := jobRunner.StartJob(t, ji)
-	taskRunning := make(chan bool, 10)
-	go func() {
-		for {
-			select {
-			case status := <-testResult.UpdateChan:
-				if status.State == titusdriver.Running {
-					taskRunning <- true
-				} else if status.State.IsTerminalStatus() {
-					if status.State != titusdriver.Killed {
-						t.Errorf("Task %s not killed successfully, %s!", testResult.TaskID, status.State.String())
-					}
-					taskRunning <- false
-					return
+	jobRunner, err := mock.StartJob(t, ctx, ji)
+	require.NoError(t, err)
+	defer jobRunner.StopExecutor()
+
+	var taskRunning bool
+	for {
+		select {
+		case status := <-jobRunner.UpdateChan:
+			if status.State == titusdriver.Running {
+				if taskRunning == false {
+					taskRunning = true
+					t.Logf("Task is running, stopping executor")
+					go func() {
+						_ = jobRunner.KillTask()
+					}()
 				}
-			case <-time.After(defaultFailureTimeout):
-				t.Errorf("Task %s did not reach RUNNING - timed out", testResult.TaskID)
-				taskRunning <- false
+			}
+			if status.State.IsTerminalStatus() {
+				if status.State != titusdriver.Killed {
+					t.Errorf("Task %s not killed successfully, %s!", jobRunner.TaskID, status.State.String())
+				}
+				if !taskRunning {
+					t.Errorf("Task never went into running, and therefore killed for some other reason")
+				}
 				return
 			}
+		case <-ctx.Done():
+			t.Errorf("Task %s did not reach RUNNING - timed out: %s", jobRunner.TaskID, ctx.Err().Error())
+			return
 		}
-	}()
-
-	<-taskRunning
-	t.Logf("Task is running, stopping executor")
-	jobRunner.StopExecutor()
+	}
 }
 
 func testMetadataProxyInjection(t *testing.T, jobID string) {
@@ -690,9 +709,8 @@ func testMetdataProxyDefaultRoute(t *testing.T, jobID string) {
 }
 
 func testTerminateTimeoutWrapped(t *testing.T, jobID string, killWaitSeconds uint32) (*runner.Update, time.Duration) {
-	// Start the executor
-	jobRunner := mock.NewJobRunner(nil)
-	defer jobRunner.StopExecutorAsync()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
+	defer cancel()
 
 	// Submit a job that runs for a long time and does
 	// NOT exit on SIGTERM
@@ -702,7 +720,10 @@ func testTerminateTimeoutWrapped(t *testing.T, jobID string, killWaitSeconds uin
 		KillWaitSeconds: killWaitSeconds,
 		JobID:           jobID,
 	}
-	jobResponse := jobRunner.StartJob(t, ji)
+	// Start the executor
+	jobResponse, err := mock.StartJob(t, ctx, ji)
+	require.NoError(t, err)
+	defer jobResponse.StopExecutorAsync()
 
 	// Wait until the task is running
 	for status := range jobResponse.UpdateChan {
@@ -719,7 +740,7 @@ func testTerminateTimeoutWrapped(t *testing.T, jobID string, killWaitSeconds uin
 	// job does not exit on SIGTERM we expect the kill
 	// to take at least some seconds
 	killTime := time.Now()
-	if err := jobRunner.KillTask(); err != nil {
+	if err := jobResponse.KillTask(); err != nil {
 		t.Fail()
 	}
 
@@ -769,9 +790,8 @@ func testOOMAdj(t *testing.T, jobID string) {
 }
 
 func testOOMKill(t *testing.T, jobID string) {
-	// Start the executor
-	jobRunner := mock.NewJobRunner(nil)
-	defer jobRunner.StopExecutorAsync()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
+	defer cancel()
 
 	ji := &mock.JobInput{
 		ImageName:     ubuntu.name,
@@ -779,10 +799,13 @@ func testOOMKill(t *testing.T, jobID string) {
 		EntrypointOld: `stress --vm 100 --vm-keep --vm-hang 100`,
 		JobID:         jobID,
 	}
-	jobResponse := jobRunner.StartJob(t, ji)
+
+	// Start the executor
+	jobResponse, err := mock.StartJob(t, ctx, ji)
+	require.NoError(t, err)
+	defer jobResponse.StopExecutorAsync()
 
 	// Wait until the task is running
-
 	for status := range jobResponse.UpdateChan {
 		if status.State.IsTerminalStatus() {
 			if status.State.String() != "TASK_FAILED" {
@@ -984,6 +1007,9 @@ func testMetatron(t *testing.T, jobID string) {
 
 // Test that we return failure messages from services
 func testMetatronFailure(t *testing.T, jobID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
+	defer cancel()
+
 	ji := &mock.JobInput{
 		ImageName:       userSet.name,
 		Version:         userSet.tag,
@@ -997,11 +1023,9 @@ func testMetatronFailure(t *testing.T, jobID string) {
 		JobID: jobID,
 	}
 
-	jobRunner := mock.NewJobRunner(ji)
-	defer jobRunner.StopExecutor()
-	jobResponse := jobRunner.StartJob(t, ji)
-	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
-	defer cancel()
+	jobResponse, err := mock.StartJob(t, ctx, ji)
+	require.NoError(t, err)
+	defer jobResponse.StopExecutor()
 
 	status, err := jobResponse.WaitForFailureStatus(ctx)
 	assert.Nil(t, err)

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -3,6 +3,8 @@ package runner
 import (
 	"regexp"
 
+	"github.com/Netflix/titus-executor/logger"
+
 	"github.com/Netflix/metrics-client-go/metrics"
 	"github.com/Netflix/titus-executor/api/netflix/titus"
 	"github.com/Netflix/titus-executor/config"
@@ -17,47 +19,35 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"sync"
 	"time"
 )
 
-const waitForTaskTimeout = 5 * time.Minute
-
-var (
-	errorRunnerAlreadyStarted = errors.New("Runner already started task or not available")
-	errorTaskWaitTimeout      = errors.New("Runner timed out waiting for task")
-)
-
 // Config is runner config
 
-type task struct {
-	taskID    string
-	titusInfo *titus.ContainerInfo
-	mem       int64
-	cpu       int64
-	gpu       int64
-	disk      uint64
-	network   uint64
+type Task struct {
+	TaskID    string
+	TitusInfo *titus.ContainerInfo
+	Mem       int64
+	CPU       int64
+	Gpu       int64
+	Disk      uint64
+	Network   uint64
 }
 
-// Runner maintains in memory state for the task runner
+// Runner maintains in memory state for the Task runner
 type Runner struct {
 	// const:
 	metrics       metrics.Reporter
 	metricsTagger tagger // the presence of tagger indicates extra Atlas tag is enabled
 	runtime       runtimeTypes.Runtime
 	config        config.Config
-	logger        *logrus.Entry
 
 	container *runtimeTypes.Container
 	watcher   *filesystems.Watcher
 
-	sync.RWMutex
-	err      error
-	taskChan chan task
 	// Close this channel to start killing the container
 	killOnce    sync.Once
 	killChan    chan struct{}
@@ -65,128 +55,84 @@ type Runner struct {
 	UpdatesChan chan Update
 }
 
-// RuntimeProvider is a factory function for runtime implementations. It is called only once by WithRuntime
-type RuntimeProvider func(context.Context, config.Config) (runtimeTypes.Runtime, error)
-
-// New constructs a new Executor object with the default (docker) runtime
-func New(ctx context.Context, m metrics.Reporter, cfg config.Config, dockerCfg docker.Config) (*Runner, error) {
-	dockerRuntime := func(ctx context.Context, cfg config.Config) (runtimeTypes.Runtime, error) {
-		return docker.NewDockerRuntime(ctx, m, dockerCfg, cfg)
+// StartTask constructs a new Executor object with the default (docker) runtime, and starts the task
+func StartTask(ctx context.Context, task Task, m metrics.Reporter, cfg config.Config, dockerCfg docker.Config) (*Runner, error) {
+	dockerRuntime, err := docker.NewDockerRuntime(ctx, m, dockerCfg, cfg)
+	if err != nil {
+		return nil, err
 	}
-	return WithRuntime(ctx, m, dockerRuntime, cfg)
+	return StartTaskWithRuntime(ctx, task, m, dockerRuntime, cfg)
 }
 
-// WithRuntime builds an Executor using the provided Runtime factory func
-func WithRuntime(ctx context.Context, m metrics.Reporter, rp RuntimeProvider, cfg config.Config) (*Runner, error) {
+// StartTaskWithRuntime builds an Executor using the provided Runtime factory func, and starts the task
+func StartTaskWithRuntime(ctx context.Context, task Task, m metrics.Reporter, rp runtimeTypes.ContainerRuntimeProvider, cfg config.Config) (*Runner, error) {
+	ctx = logger.WithLogger(ctx, logrus.NewEntry(logrus.StandardLogger()).WithField("TaskID", task.TaskID))
+
 	metricsTagger, _ := m.(tagger) // metrics.Reporter may or may not implement tagger interface.  OK to be nil
+	labels := map[string]string{
+		models.ExecutorPidLabel: fmt.Sprintf("%d", os.Getpid()),
+		models.TaskIDLabel:      task.TaskID,
+	}
+
+	// Should we remove this?
+	if len(task.TitusInfo.GetIamProfile()) > 0 {
+		labels["ec2.iam.role"] = task.TitusInfo.GetIamProfile()
+	}
+
+	resources := &runtimeTypes.Resources{
+		Mem:     task.Mem,
+		CPU:     task.CPU,
+		GPU:     task.Gpu,
+		Disk:    task.Disk,
+		Network: task.Network,
+	}
+
+	startTime := time.Now()
 	runner := &Runner{
-		logger:        logrus.NewEntry(logrus.StandardLogger()),
 		metrics:       m,
 		metricsTagger: metricsTagger,
 		config:        cfg,
-		taskChan:      make(chan task, 1),
 		killChan:      make(chan struct{}),
 		UpdatesChan:   make(chan Update, 10),
 		StoppedChan:   make(chan struct{}),
+		container:     runtime.NewContainer(task.TaskID, task.TitusInfo, resources, labels, cfg),
 	}
-	setupCh := make(chan error)
-	go runner.startRunner(ctx, setupCh, rp)
+
+	rt, err := rp(ctx, runner.container, startTime)
+	if err != nil {
+		return nil, err
+	}
+	runner.runtime = rt
+
+	go runner.startRunner(ctx, startTime)
 	go func() {
 		<-ctx.Done()
 		// Kill the running container if there is one, shut it down
 		runner.Kill()
 	}()
 
-	if err := <-setupCh; err != nil {
-		return nil, err
-	}
-
 	return runner, nil
 }
 
-// StartTask can be called once to start a task, by a given Runner
-func (r *Runner) StartTask(taskID string, titusInfo *titus.ContainerInfo, mem int64, cpu int64, gpu int64, disk uint64, network uint64) error {
-	// This can only be called once!
-	t := task{
-		taskID:    taskID,
-		titusInfo: titusInfo,
-		mem:       mem,
-		cpu:       cpu,
-		gpu:       gpu,
-		disk:      disk,
-		network:   network,
-	}
-	select {
-	case r.taskChan <- t:
-		return nil
-	default:
-		r.RLock()
-		defer r.RUnlock()
-		if r.err != nil {
-			return r.err
-		}
-		return errorRunnerAlreadyStarted
-	}
-}
-
-// Kill is idempotent, and will either kill a task, or prevent a new one from being spawned
+// Kill is idempotent, and will either kill a Task, or prevent a new one from being spawned
 func (r *Runner) Kill() {
 	r.killOnce.Do(func() {
 		close(r.killChan)
 	})
 }
 
-func (r *Runner) startRunner(parentCtx context.Context, setupCh chan error, rp RuntimeProvider) {
+func (r *Runner) startRunner(ctx context.Context, startTime time.Time) {
 	defer close(r.UpdatesChan)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	defer close(r.StoppedChan)
-
-	// We must ensure that setupCh is closed, or returns an error.
-	if err := r.setupRunner(ctx, rp); err != nil {
-		setupCh <- err
-		return
-	}
-	close(setupCh)
-
-	// 1. Wait for task to come in for starting
-	taskConfig, err := r.waitForTask(parentCtx, ctx)
-	r.logger.Info("Received taskConfig to start: ", taskConfig)
-
-	r.logger = r.logger.WithField("taskID", taskConfig.taskID)
-	if err != nil {
-		r.Lock()
-		defer r.Unlock()
-		r.err = err
-		return
-	}
-
-	startTime := time.Now()
-	labels := map[string]string{
-		models.ExecutorPidLabel: fmt.Sprintf("%d", os.Getpid()),
-		models.TaskIDLabel:      taskConfig.taskID,
-	}
-
-	// Should we remove this?
-	if len(taskConfig.titusInfo.GetIamProfile()) > 0 {
-		labels["ec2.iam.role"] = taskConfig.titusInfo.GetIamProfile()
-	}
-
-	resources := &runtimeTypes.Resources{
-		Mem:     taskConfig.mem,
-		CPU:     taskConfig.cpu,
-		GPU:     taskConfig.gpu,
-		Disk:    taskConfig.disk,
-		Network: taskConfig.network,
-	}
-	r.container = runtime.NewContainer(taskConfig.taskID, taskConfig.titusInfo, resources, labels, r.config)
 
 	updateChan := make(chan update, 10)
 	go r.runContainer(ctx, startTime, updateChan)
 
 	var lastUpdate *update
 	for update := range updateChan {
-		r.logger.WithField("update", update).Debug("Processing update")
+		logger.G(ctx).WithField("update", update).Debug("Processing update")
 		// This is okay, because it only gets references _after_ loop termination.
 		lastUpdate = &update // nolint:scopelint
 		if update.status.IsTerminalStatus() {
@@ -203,7 +149,7 @@ func (r *Runner) startRunner(parentCtx context.Context, setupCh chan error, rp R
 	r.doShutdown(ctx, *lastUpdate)
 	badUpdate, ok := <-updateChan
 	if ok {
-		panic(fmt.Sprintf("Received update after task was in terminal status: %+v", badUpdate))
+		panic(fmt.Sprintf("Received update after Task was in terminal status: %+v", badUpdate))
 	}
 }
 
@@ -213,36 +159,34 @@ type update struct {
 	details *runtimeTypes.Details
 }
 
-func (r *Runner) prepareContainer(ctx context.Context, updateChan chan update, startTime time.Time) update {
-	r.logger.Debug("Running prepare")
+func (r *Runner) prepareContainer(ctx context.Context) update {
+	logger.G(ctx).Debug("Running prepare")
 	prepareCtx, prepareCancel := context.WithCancel(ctx)
 	defer prepareCancel()
 	go func() {
 		select {
 		case <-r.killChan:
-			r.logger.Debug("Got cancel in prepare")
+			logger.G(ctx).Debug("Got cancel in prepare")
 			prepareCancel()
 		case <-prepareCtx.Done():
 		}
 	}()
 	// When Create() returns the host may have been modified to create storage and pull the image.
 	// These steps may or may not have completed depending on if/where a failure occurred.
-	bindMounts := []string{}
-	if err := r.runtime.Prepare(prepareCtx, r.container, bindMounts, startTime); err != nil {
+	if err := r.runtime.Prepare(prepareCtx); err != nil {
 		r.metrics.Counter("titus.executor.launchTaskFailed", 1, nil)
-		r.logger.Error("task failed to create container: ", err)
+		logger.G(ctx).Error("Task failed to create container: ", err)
 		// Treat registry pull errors as LOST and non-existent images as FAILED.
 		switch err.(type) {
 		case *runtimeTypes.RegistryImageNotFoundError, *runtimeTypes.InvalidSecurityGroupError, *runtimeTypes.BadEntryPointError, *runtimeTypes.InvalidConfigurationError:
-			r.logger.Error("Returning TASK_FAILED for task: ", err)
+			logger.G(ctx).Error("Returning TASK_FAILED for Task: ", err)
 			return update{status: titusdriver.Failed, msg: err.Error()}
 		}
-		r.logger.Error("Returning TASK_LOST for task: ", err)
+		logger.G(ctx).Error("Returning TASK_LOST for Task: ", err)
 		return update{status: titusdriver.Lost, msg: err.Error()}
 	}
 
 	return update{status: titusdriver.Starting, msg: "starting"}
-
 }
 
 // This is just splitting the "run" part of the of the runner
@@ -250,54 +194,54 @@ func (r *Runner) runContainer(ctx context.Context, startTime time.Time, updateCh
 	defer close(updateChan)
 	select {
 	case <-r.killChan:
-		r.logger.Error("Task was killed before task was created")
+		logger.G(ctx).Error("Task was killed before Task was created")
 		return
 	case <-ctx.Done():
-		r.logger.Error("Task context was terminated before task was created")
+		logger.G(ctx).Error("Task context was terminated before Task was created")
 		return
 	default:
 	}
-	r.maybeSetDefaultTags() // initialize metrics.Reporter default tags
+	r.maybeSetDefaultTags(ctx) // initialize metrics.Reporter default tags
 	updateChan <- update{status: titusdriver.Starting, msg: "creating"}
 
-	prepareUpdate := r.prepareContainer(ctx, updateChan, startTime)
+	prepareUpdate := r.prepareContainer(ctx)
 	updateChan <- prepareUpdate
 	if prepareUpdate.status.IsTerminalStatus() {
-		r.logger.WithField("prepareUpdate", prepareUpdate).Debug("Prepare was terminal")
+		logger.G(ctx).WithField("prepareUpdate", prepareUpdate).Debug("Prepare was terminal")
 		return
 	}
 
-	logDir, details, statusChan, err := r.runtime.Start(ctx, r.container)
+	logDir, details, statusChan, err := r.runtime.Start(ctx)
 	if err != nil { // nolint: vetshadow
 		r.metrics.Counter("titus.executor.launchTaskFailed", 1, nil)
-		r.logger.Info("start container: ", err)
+		logger.G(ctx).Info("start container: ", err)
 
 		switch err.(type) {
 		case *runtimeTypes.BadEntryPointError:
-			r.logger.Info("Returning TaskState_TASK_FAILED for task: ", err)
+			logger.G(ctx).Info("Returning TaskState_TASK_FAILED for Task: ", err)
 			updateChan <- update{status: titusdriver.Failed, msg: err.Error(), details: details}
 		}
-		r.logger.Info("Returning TASK_LOST for task: ", err)
+		logger.G(ctx).Info("Returning TASK_LOST for Task: ", err)
 		updateChan <- update{status: titusdriver.Lost, msg: err.Error(), details: details}
 		return
 	}
 
 	err = r.maybeSetupExternalLogger(ctx, logDir)
 	if err != nil {
-		r.logger.Error("Unable to setup logging for container: ", err)
+		logger.G(ctx).Error("Unable to setup logging for container: ", err)
 		updateChan <- update{status: titusdriver.Lost, msg: err.Error(), details: details}
 		return
 	}
 
 	if details == nil {
-		r.logger.Fatal("Unable to fetch task details")
+		logger.G(ctx).Fatal("Unable to fetch Task details")
 	}
 	r.metrics.Counter("titus.executor.taskLaunched", 1, nil)
 
 	r.monitorContainer(ctx, startTime, statusChan, updateChan, details)
 }
 
-func (r *Runner) maybeSetDefaultTags() {
+func (r *Runner) maybeSetDefaultTags(ctx context.Context) {
 	// If extra Atlas tags is enabled, initialize metrics.Reporter with default tags t.jobId and t.taskId
 	jobID := r.container.TitusInfo.TitusProvidedEnv["TITUS_JOB_ID"]
 	if r.metricsTagger != nil && len(jobID) > 0 {
@@ -306,7 +250,7 @@ func (r *Runner) maybeSetDefaultTags() {
 			"t.taskId": r.container.TaskID,
 		}
 		r.metricsTagger.append(tags)
-		r.logger.Infof("Set Atlas default tags to: %s", tags)
+		logger.G(ctx).Infof("Set Atlas default tags to: %s", tags)
 	}
 }
 
@@ -322,7 +266,7 @@ func (r *Runner) monitorContainer(ctx context.Context, startTime time.Time, stat
 				return
 			}
 			msg := statusMessage.Msg
-			r.logger.WithField("statusMessage", statusMessage).Info("Processing msg")
+			logger.G(ctx).WithField("statusMessage", statusMessage).Info("Processing msg")
 
 			switch statusMessage.Status {
 			case runtimeTypes.StatusRunning:
@@ -342,7 +286,7 @@ func (r *Runner) monitorContainer(ctx context.Context, startTime time.Time, stat
 				return
 			}
 		case <-r.killChan:
-			r.logger.Info("Received kill signal")
+			logger.G(ctx).Info("Received kill signal")
 			return
 		case <-ctx.Done():
 			return
@@ -351,7 +295,7 @@ func (r *Runner) monitorContainer(ctx context.Context, startTime time.Time, stat
 }
 
 func (r *Runner) handleTaskRunningMessage(ctx context.Context, msg string, lastMessage *string, runningSent *bool, startTime time.Time, details *runtimeTypes.Details, updateChan chan update) {
-	// no need to Update the status if task is running and the message is the same as the last one
+	// no need to Update the status if Task is running and the message is the same as the last one
 	// The first time this is called *runningSent should be false, so it'll always trigger
 	if msg == *lastMessage && *runningSent {
 		return
@@ -372,16 +316,18 @@ func (r *Runner) handleTaskRunningMessage(ctx context.Context, msg string, lastM
 }
 
 func (r *Runner) doShutdown(ctx context.Context, lastUpdate update) { // nolint: gocyclo
-	r.logger.WithField("lastUpdate", lastUpdate).WithField("wasKilled", r.wasKilled()).Debug("Handling shutdown")
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	logger.G(ctx).WithField("lastUpdate", lastUpdate).WithField("wasKilled", r.wasKilled()).Debug("Handling shutdown")
 	var errs *multierror.Error
 
 	killStartTime := time.Now()
 	// Are we in a situation where the container exited gracefully, or less than gracefully?
 	// We need to stop the container
-	if err := r.runtime.Kill(r.container); err != nil {
+	if err := r.runtime.Kill(ctx); err != nil {
 		// TODO(Andrew L): There may be leaked resources that are not being
 		// accounted for. Consider forceful cleanup or tracking leaked resources.
-		r.logger.Error("Failed to fully complete primary kill actions: ", err)
+		logger.G(ctx).Error("Failed to fully complete primary kill actions: ", err)
 		switch lastUpdate.status {
 		case titusdriver.Finished:
 		case titusdriver.Failed:
@@ -392,13 +338,13 @@ func (r *Runner) doShutdown(ctx context.Context, lastUpdate update) { // nolint:
 
 	if r.watcher != nil {
 		if err := r.watcher.Stop(); err != nil {
-			r.logger.Error("Error while shutting down watcher for: ", err)
+			logger.G(ctx).Error("Error while shutting down watcher for: ", err)
 			errs = multierror.Append(errs, err)
 		}
 	}
 
-	if err := r.runtime.Cleanup(r.container); err != nil {
-		r.logger.Error("Cleanup failed: ", err)
+	if err := r.runtime.Cleanup(ctx); err != nil {
+		logger.G(ctx).Error("Cleanup failed: ", err)
 		errs = multierror.Append(errs, err)
 	}
 	r.metrics.Counter("titus.executor.taskCleanupDone", 1, nil)
@@ -411,16 +357,16 @@ func (r *Runner) doShutdown(ctx context.Context, lastUpdate update) { // nolint:
 	if lastUpdate.status == titusdriver.Finished {
 		// TODO(Andrew L): There may be leaked resources that are not being
 		// accounted for. Consider forceful cleanup or tracking leaked resources.
-		// If the task finished successfully, include any info about cleanup errors
+		// If the Task finished successfully, include any info about cleanup errors
 		r.updateStatusWithDetails(ctx, lastUpdate.status, msg, lastUpdate.details)
 	} else if r.wasKilled() {
-		// Funnily enough, we can end up in KILLED and FINISHED -- if the task exits, and then gets a KILL from the Titus / Mesos master
+		// Funnily enough, we can end up in KILLED and FINISHED -- if the Task exits, and then gets a KILL from the Titus / Mesos master
 		// while shutting down, it'll get stuck in weird world. Here, we will send a TASK_FINISHED result, over a TASK_KILLED.
 		// TODO(Sargun): Consider. Is this the right decision?
 		r.updateStatusWithDetails(ctx, titusdriver.Killed, msg, lastUpdate.details)
 	} else if !lastUpdate.status.IsTerminalStatus() {
 		r.updateStatusWithDetails(ctx, titusdriver.Lost, "Container lost -- Unknown", lastUpdate.details)
-		r.logger.Error("Container killed while non-terminal!")
+		logger.G(ctx).Error("Container killed while non-terminal!")
 	} else {
 		r.updateStatusWithDetails(ctx, lastUpdate.status, lastUpdate.msg, lastUpdate.details)
 	}
@@ -439,10 +385,10 @@ func (r *Runner) wasKilled() bool {
 
 func (r *Runner) maybeSetupExternalLogger(ctx context.Context, logDir string) error {
 	if logDir == "" {
-		r.logger.Info("Not starting external logger")
+		logger.G(ctx).Info("Not starting external logger")
 		return nil
 	}
-	r.logger.Info("Starting external logger")
+	logger.G(ctx).Info("Starting external logger")
 
 	uploadCheckInterval, err := r.container.GetLogUploadCheckInterval()
 	if err != nil {
@@ -489,31 +435,8 @@ func (r *Runner) maybeSetupExternalLogger(ctx context.Context, logDir string) er
 	return r.watcher.Watch(ctx)
 }
 
-func (r *Runner) waitForTask(parentCtx, ctx context.Context) (*task, error) {
-	timer := time.NewTimer(waitForTaskTimeout)
-	defer timer.Stop()
-	defer close(r.taskChan)
-	select {
-	case <-parentCtx.Done():
-		return nil, ctx.Err()
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case tsk := <-r.taskChan:
-		return &tsk, nil
-	case <-timer.C:
-		return nil, errorTaskWaitTimeout
-	}
-}
-
-func (r *Runner) setupRunner(ctx context.Context, rp RuntimeProvider) error {
-	var err error
-
-	r.runtime, err = rp(ctx, r.config)
-	return err
-}
-
 func (r *Runner) updateStatusWithDetails(ctx context.Context, status titusdriver.TitusTaskState, msg string, details *runtimeTypes.Details) {
-	l := r.logger.WithField("msg", msg).WithField("taskStatus", status)
+	l := logger.G(ctx).WithField("msg", msg).WithField("taskStatus", status)
 	select {
 	case r.UpdatesChan <- Update{
 		TaskID:  r.container.TaskID,
@@ -521,13 +444,13 @@ func (r *Runner) updateStatusWithDetails(ctx context.Context, status titusdriver
 		Mesg:    msg,
 		Details: details,
 	}:
-		l.Info("Updating task status")
+		l.Info("Updating Task status")
 	case <-ctx.Done():
 		l.Warn("Not sending update, because UpdatesChan Blocked, (or closed), and context completed")
 	}
 }
 
-// Update encapsulates information on the updatechan about task status updates
+// Update encapsulates information on the updatechan about Task status updates
 type Update struct {
 	TaskID  string
 	State   titusdriver.TitusTaskState

--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -32,6 +32,8 @@ const (
 
 // runtimeMock implements the Runtime interface
 type runtimeMock struct {
+	c *runtimeTypes.Container
+
 	t   *testing.T
 	ctx context.Context
 
@@ -49,16 +51,19 @@ type runtimeMock struct {
 	killCallback    func(c *runtimeTypes.Container) error
 }
 
-func (r *runtimeMock) Prepare(ctx context.Context, c *runtimeTypes.Container, bindMounts []string, startTime time.Time) error {
-	r.t.Log("runtimeMock.Prepare", c.TaskID)
+func (r *runtimeMock) Prepare(ctx context.Context) error {
+	if r.c == nil {
+		panic("Container is nil")
+	}
+	r.t.Log("runtimeMock.Prepare", r.c.TaskID)
 	if r.prepareCallback != nil {
 		return r.prepareCallback(ctx)
 	}
 	return nil
 }
 
-func (r *runtimeMock) Start(ctx context.Context, c *runtimeTypes.Container) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
-	r.t.Log("runtimeMock.Start", c.TaskID)
+func (r *runtimeMock) Start(ctx context.Context) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
+	r.t.Log("runtimeMock.Start", r.c.TaskID)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	close(r.startCalled)
@@ -80,13 +85,13 @@ func (r *runtimeMock) Start(ctx context.Context, c *runtimeTypes.Container) (str
 	return "", details, r.statusChan, nil
 }
 
-func (r *runtimeMock) Kill(c *runtimeTypes.Container) error {
-	logrus.Infof("runtimeMock.Kill (%v): %s", r.ctx, c.TaskID)
+func (r *runtimeMock) Kill(ctx context.Context) error {
+	logrus.Infof("runtimeMock.Kill (%v): %s", r.ctx, r.c.TaskID)
 	if r.killCallback != nil {
-		return r.killCallback(c)
+		return r.killCallback(r.c)
 	}
 	defer close(r.statusChan)
-	defer logrus.Info("runtimeMock.Killed: ", c.TaskID)
+	defer logrus.Info("runtimeMock.Killed: ", r.c.TaskID)
 	// send a kill request and wait for a grant
 	req := make(chan struct{}, 1)
 	select {
@@ -105,10 +110,10 @@ func (r *runtimeMock) Kill(c *runtimeTypes.Container) error {
 	return nil
 }
 
-func (r *runtimeMock) Cleanup(c *runtimeTypes.Container) error {
-	r.t.Log("runtimeMock.Cleanup", c.TaskID)
+func (r *runtimeMock) Cleanup(ctx context.Context) error {
+	r.t.Log("runtimeMock.Cleanup", r.c.TaskID)
 	if r.cleanupCallback != nil {
-		return r.cleanupCallback(c)
+		return r.cleanupCallback(r.c)
 	}
 	return nil
 }
@@ -148,12 +153,20 @@ func TestSendTerminalStatusUntilCleanup(t *testing.T) {
 		return nil
 	}
 
-	executor, err := WithRuntime(ctx, metrics.Discard, func(ctx context.Context, _cfg config.Config) (runtimeTypes.Runtime, error) {
+	task := Task{
+		TaskID:    taskID,
+		TitusInfo: taskInfo,
+		Mem:       1,
+		CPU:       1,
+		Gpu:       0,
+		Disk:      1,
+		Network:   1,
+	}
+	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c *runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
+		r.c = c
 		return r, nil
 	}, config.Config{})
-
 	require.NoError(t, err)
-	require.NoError(t, executor.StartTask(taskID, taskInfo, 1, 1, 0, 1, 1))
 
 	defer time.Sleep(1 * time.Second)
 	timeout := time.NewTimer(30 * time.Second)
@@ -219,12 +232,20 @@ func TestCancelDuringPrepare(t *testing.T) { // nolint: gocyclo
 		return c.Err()
 	}
 
-	executor, err := WithRuntime(ctx, metrics.Discard, func(ctx context.Context, _cfg config.Config) (runtimeTypes.Runtime, error) {
+	task := Task{
+		TaskID:    taskID,
+		TitusInfo: taskInfo,
+		Mem:       1,
+		CPU:       1,
+		Gpu:       0,
+		Disk:      1,
+		Network:   1,
+	}
+	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c *runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
+		r.c = c
 		return r, nil
 	}, config.Config{})
-
 	require.NoError(t, err)
-	require.NoError(t, executor.StartTask(taskID, taskInfo, 1, 1, 0, 1, 1))
 
 	testFailed := make(chan struct{})
 	time.AfterFunc(30*time.Second, func() {
@@ -242,9 +263,9 @@ func TestCancelDuringPrepare(t *testing.T) { // nolint: gocyclo
 			logrus.Debug("Got update: ", update)
 			switch update.State {
 			case titusdriver.Starting:
-				logrus.Debug("Killing task, now that it's entered starting")
+				logrus.Debug("Killing Task, now that it's entered starting")
 				executor.Kill()
-				logrus.Debug("Killed task, now that it's entered starting")
+				logrus.Debug("Killed Task, now that it's entered starting")
 			case titusdriver.Killed:
 				return
 			default:
@@ -302,12 +323,20 @@ func TestSendRedundantStatusMessage(t *testing.T) { // nolint: gocyclo
 		statusChan:  statusChan,
 	}
 
-	executor, err := WithRuntime(ctx, metrics.Discard, func(ctx context.Context, _cfg config.Config) (runtimeTypes.Runtime, error) {
+	task := Task{
+		TaskID:    taskID,
+		TitusInfo: taskInfo,
+		Mem:       1,
+		CPU:       1,
+		Gpu:       0,
+		Disk:      1,
+		Network:   1,
+	}
+	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c *runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
+		r.c = c
 		return r, nil
 	}, config.Config{})
-
 	require.NoError(t, err)
-	require.NoError(t, executor.StartTask(taskID, taskInfo, 1, 1, 0, 1, 1))
 
 	killTimeout := time.NewTimer(15 * time.Second)
 	defer killTimeout.Stop()
@@ -325,10 +354,10 @@ func TestSendRedundantStatusMessage(t *testing.T) { // nolint: gocyclo
 		}
 	}
 running:
-	// We'll kill the task after a few seconds
+	// We'll kill the Task after a few seconds
 	time.AfterFunc(5*time.Second, func() {
 		// This should be idempotent
-		t.Log("Killing task")
+		t.Log("Killing Task")
 		executor.Kill()
 		executor.Kill()
 		executor.Kill()

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Netflix/metrics-client-go/metrics"
@@ -39,6 +40,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
+)
+
+var (
+	_ runtimeTypes.Runtime = (*DockerRuntime)(nil)
 )
 
 // units
@@ -71,6 +76,9 @@ const (
 	systemdImageLabel       = "com.netflix.titus.systemd"
 )
 
+// cleanupFunc can be registered to be called on container teardown, errors are reported, but not acted upon
+type cleanupFunc func() error
+
 // NoEntrypointError indicates that the Titus job does not have an entrypoint, or command
 var NoEntrypointError = &runtimeTypes.BadEntryPointError{Reason: errors.New("Image, and job have no entrypoint, or command")}
 
@@ -95,6 +103,7 @@ type ucred struct {
 
 // DockerRuntime implements the Runtime interface calling Docker Engine APIs
 type DockerRuntime struct { // nolint: golint
+	// Following fields to be set when NewDockerRuntime is called
 	metrics           metrics.Reporter
 	registryAuthCfg   *types.AuthConfig
 	client            *docker.Client
@@ -105,10 +114,18 @@ type DockerRuntime struct { // nolint: golint
 	pidCgroupPath     string
 	cfg               config.Config
 	dockerCfg         Config
+
+	// cleanup callbacks that runtime implementations can register to do cleanup
+	cleanupFuncLock sync.Mutex
+	cleanup         []cleanupFunc
+
+	// To be set when a container
+	c         *runtimeTypes.Container
+	startTime time.Time
 }
 
-// NewDockerRuntime provides a Runtime implementation on Docker
-func NewDockerRuntime(executorCtx context.Context, m metrics.Reporter, dockerCfg Config, cfg config.Config) (runtimeTypes.Runtime, error) {
+// NewDockerRuntime provides a Runtime implementation on Docker.
+func NewDockerRuntime(ctx context.Context, m metrics.Reporter, dockerCfg Config, cfg config.Config) (runtimeTypes.ContainerRuntimeProvider, error) {
 	log.Info("New Docker client, to host ", cfg.DockerHost)
 	client, err := docker.NewClient(cfg.DockerHost, "1.26", nil, map[string]string{})
 
@@ -116,49 +133,58 @@ func NewDockerRuntime(executorCtx context.Context, m metrics.Reporter, dockerCfg
 		return nil, err
 	}
 
-	info, err := client.Info(executorCtx)
+	info, err := client.Info(ctx)
 
 	if err != nil {
 		return nil, err
 	}
 
-	dockerRuntime := &DockerRuntime{
-		metrics:         m,
-		registryAuthCfg: nil, // we don't need registry authentication yet
-		client:          client,
-		cfg:             cfg,
-		dockerCfg:       dockerCfg,
-	}
-
-	dockerRuntime.pidCgroupPath, err = getOwnCgroup("pids")
+	pidCgroupPath, err := getOwnCgroup("pids")
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO: Check
-	dockerRuntime.awsRegion = os.Getenv("EC2_REGION")
-	err = setupLoggingInfra(dockerRuntime)
-	if err != nil {
-		return nil, err
-	}
+	awsRegion := os.Getenv("EC2_REGION")
+	storageOptEnabled := shouldEnableStorageOpts(info)
 
-	go func() {
-		<-executorCtx.Done()
-		err = os.RemoveAll(dockerRuntime.tiniSocketDir)
-		if err != nil {
-			log.Errorf("Could not cleanup tini socket directory %s because: %v", dockerRuntime.tiniSocketDir, err)
+	runtimeFunc := func(ctx context.Context, c *runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
+		dockerRuntime := &DockerRuntime{
+			pidCgroupPath:     pidCgroupPath,
+			awsRegion:         awsRegion,
+			metrics:           m,
+			registryAuthCfg:   nil, // we don't need registry authentication yet
+			client:            client,
+			cfg:               cfg,
+			dockerCfg:         dockerCfg,
+			cleanup:           []cleanupFunc{},
+			c:                 c,
+			startTime:         startTime,
+			storageOptEnabled: storageOptEnabled,
 		}
-	}()
 
-	dockerRuntime.storageOptEnabled = shouldEnableStorageOpts(info)
+		if strings.Contains(info.InitBinary, "tini") {
+			dockerRuntime.tiniEnabled = true
+		} else {
+			log.WithField("initBinary", info.InitBinary).Warning("Docker runtime disabling Tini support")
+		}
 
-	if strings.Contains(info.InitBinary, "tini") {
-		dockerRuntime.tiniEnabled = true
-	} else {
-		log.WithField("initBinary", info.InitBinary).Warning("Docker runtime disabling Tini support")
+		err := setupLoggingInfra(dockerRuntime)
+		if err != nil {
+			return nil, err
+		}
+		dockerRuntime.registerRuntimeCleanup(func() error {
+			err = os.RemoveAll(dockerRuntime.tiniSocketDir)
+			if err != nil {
+				log.WithError(err).Errorf("Could not cleanup tini socket directory %s", dockerRuntime.tiniSocketDir)
+				return err
+			}
+			return nil
+		})
+		return dockerRuntime, nil
 	}
 
-	return dockerRuntime, nil
+	return runtimeFunc, nil
 }
 
 func shouldEnableStorageOpts(info types.Info) bool {
@@ -178,6 +204,13 @@ func shouldEnableStorageOpts(info types.Info) bool {
 		}
 	}
 	return false
+}
+
+// RegisterRuntimeCleanup calls registered functions whether or not the container successfully starts
+func (r *DockerRuntime) registerRuntimeCleanup(callback cleanupFunc) {
+	r.cleanupFuncLock.Lock()
+	defer r.cleanupFuncLock.Unlock()
+	r.cleanup = append(r.cleanup, callback)
 }
 
 func (r *DockerRuntime) validateEFSMounts(c *runtimeTypes.Container) error {
@@ -332,7 +365,7 @@ func (r *DockerRuntime) dockerConfig(c *runtimeTypes.Container, binds []string, 
 		hostCfg.VolumesFrom = append(hostCfg.VolumesFrom, fmt.Sprintf("%s:ro", containerName))
 	}
 	hostCfg.CgroupParent = r.pidCgroupPath
-	c.RegisterRuntimeCleanup(func() error {
+	r.registerRuntimeCleanup(func() error {
 		return cleanupCgroups(r.pidCgroupPath)
 	})
 
@@ -569,7 +602,7 @@ func setSystemdRunning(log *log.Entry, imageInfo types.ImageInspect, c *runtimeT
 }
 
 // This will setup c.Allocation
-func prepareNetworkDriver(parentCtx context.Context, cfg Config, c *runtimeTypes.Container) error { // nolint: gocyclo
+func prepareNetworkDriver(parentCtx context.Context, cfg Config, c *runtimeTypes.Container) (cleanupFunc, error) { // nolint: gocyclo
 	log.Printf("Configuring VPC network for %s", c.TaskID)
 
 	args := []string{
@@ -601,7 +634,7 @@ func prepareNetworkDriver(parentCtx context.Context, cfg Config, c *runtimeTypes
 
 	assignIPv6Address, err := c.AssignIPv6Address()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if assignIPv6Address {
 		args = append(args, "--assign-ipv6-address=true")
@@ -620,12 +653,12 @@ func prepareNetworkDriver(parentCtx context.Context, cfg Config, c *runtimeTypes
 	allocationCommand.Stderr = os.Stderr
 	stdoutPipe, err := allocationCommand.StdoutPipe()
 	if err != nil {
-		return errors.Wrap(err, "Could not setup stdout pipe for allocation command")
+		return nil, errors.Wrap(err, "Could not setup stdout pipe for allocation command")
 	}
 
 	err = allocationCommand.Start()
 	if err != nil {
-		return errors.Wrap(err, "Could not start allocation command")
+		return nil, errors.Wrap(err, "Could not start allocation command")
 	}
 
 	// errCh
@@ -674,13 +707,13 @@ func prepareNetworkDriver(parentCtx context.Context, cfg Config, c *runtimeTypes
 	err = json.NewDecoder(stdoutPipe).Decode(&c.Allocation)
 	if err != nil {
 		log.WithError(err).Error("Unable to read JSON from allocate command")
-		return fmt.Errorf("Unable to read json from pipe: %+v", err) // nolint: gosec
+		return nil, fmt.Errorf("Unable to read json from pipe: %+v", err) // nolint: gosec
 	}
 
 	if !killTimer.Stop() {
 		err = errors.New("Kill timer fired. Race condition")
 		log.WithError(err).Error("Accidentally killed the allocation command, leaving us in a 'unknown' state")
-		return err
+		return nil, err
 	}
 
 	if !c.Allocation.Success {
@@ -693,21 +726,21 @@ func prepareNetworkDriver(parentCtx context.Context, cfg Config, c *runtimeTypes
 				(strings.Contains(c.Allocation.Error, "Security groups not found"))) {
 			var invalidSg runtimeTypes.InvalidSecurityGroupError
 			invalidSg.Reason = errors.New(c.Allocation.Error)
-			return &invalidSg
+			return nil, &invalidSg
 		}
-		return fmt.Errorf("vpc network configuration error: %s", c.Allocation.Error)
+		return nil, fmt.Errorf("vpc network configuration error: %s", c.Allocation.Error)
 	}
 
 	if c.Allocation.Generation == nil {
 		err = errors.New("Unable to determine allocation generation")
 		log.WithError(err).Warn("Could not process allocation")
 		killCh <- struct{}{}
-		return err
+		return nil, err
 	}
 
 	switch g := (*c.Allocation.Generation); g {
 	case vpcTypes.V1:
-		c.RegisterRuntimeCleanup(func() error {
+		return func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 			defer cancel()
 
@@ -723,14 +756,13 @@ func prepareNetworkDriver(parentCtx context.Context, cfg Config, c *runtimeTypes
 				return errors.Wrap(err2, "Could not unassign task IP address")
 			}
 			return nil
-		})
-		return nil
+		}, nil
 	case vpcTypes.V3:
 		err = <-errCh
 		if err != nil {
-			return errors.Wrap(err, "Error experienced when running V3 allocate command")
+			return nil, errors.Wrap(err, "Error experienced when running V3 allocate command")
 		}
-		c.RegisterRuntimeCleanup(func() error {
+		return func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 			defer cancel()
 			unassignCommand := exec.CommandContext(ctx, vpcToolPath(), "unassign", "--task-id", c.TaskID) // nolint: gosec
@@ -740,13 +772,12 @@ func prepareNetworkDriver(parentCtx context.Context, cfg Config, c *runtimeTypes
 				return errors.Wrap(err2, "Could not unassign task IP address")
 			}
 			return nil
-		})
-		return nil
+		}, nil
 	default:
 		err = fmt.Errorf("Unknown generation: %s", g)
 		killCh <- struct{}{}
 		log.WithError(err).Error("Received allocation with unknown generation")
-		return err
+		return nil, err
 	}
 }
 
@@ -851,7 +882,7 @@ func (r *DockerRuntime) createVolumeContainer(ctx context.Context, l *log.Entry,
 }
 
 // Prepare host state (pull image, create fs, create container, etc...) for the container
-func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Container, binds []string, startTime time.Time) error { // nolint: gocyclo
+func (r *DockerRuntime) Prepare(parentCtx context.Context) error { // nolint: gocyclo
 	var logViewerContainerName string
 	var abmetrixContainerName string
 	var metatronContainerName string
@@ -859,7 +890,7 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 	var sshdContainerName string
 	var volumeContainers []string
 
-	l := log.WithField("taskID", c.TaskID)
+	l := log.WithField("taskID", r.c.TaskID)
 	l.WithField("prepareTimeout", r.dockerCfg.prepareTimeout).Info("Preparing container")
 
 	ctx, cancel := context.WithTimeout(parentCtx, r.dockerCfg.prepareTimeout)
@@ -874,28 +905,28 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 	)
 	dockerCreateStartTime := time.Now()
 	group, errGroupCtx := errgroup.WithContext(ctx)
-	err := r.validateEFSMounts(c)
+	err := r.validateEFSMounts(r.c)
 	if err != nil {
 		goto error
 	}
 
 	group.Go(func() error {
-		imageInfo, pullErr := r.DockerPull(errGroupCtx, c)
+		imageInfo, pullErr := r.DockerPull(errGroupCtx, r.c)
 		if pullErr != nil {
 			return pullErr
 		}
 
 		if imageInfo == nil {
-			inspected, _, inspectErr := r.client.ImageInspectWithRaw(ctx, c.QualifiedImageName())
+			inspected, _, inspectErr := r.client.ImageInspectWithRaw(ctx, r.c.QualifiedImageName())
 			if inspectErr != nil {
-				l.WithField("imageName", c.QualifiedImageName()).WithError(inspectErr).Errorf("Error inspecting docker image")
+				l.WithField("imageName", r.c.QualifiedImageName()).WithError(inspectErr).Errorf("Error inspecting docker image")
 				return inspectErr
 			}
 			imageInfo = &inspected
 		}
 
-		size = r.reportDockerImageSizeMetric(c, imageInfo)
-		if !r.hasEntrypointOrCmd(imageInfo, c) {
+		size = r.reportDockerImageSizeMetric(r.c, imageInfo)
+		if !r.hasEntrypointOrCmd(imageInfo, r.c) {
 			return NoEntrypointError
 		}
 
@@ -903,10 +934,10 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 		return nil
 	})
 
-	if shouldStartMetatronSync(&r.cfg, c) {
+	if shouldStartMetatronSync(&r.cfg, r.c) {
 		group.Go(r.createVolumeContainerFunc(ctx, l, &volumeContainerConfig{
 			serviceName:   "metatron",
-			image:         path.Join(c.Config.DockerRegistry, c.Config.MetatronServiceImage),
+			image:         path.Join(r.c.Config.DockerRegistry, r.c.Config.MetatronServiceImage),
 			containerName: &metatronContainerName,
 			volumes: map[string]struct{}{
 				"/titus/metatron": {},
@@ -916,7 +947,7 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 	if r.cfg.ContainerSSHD {
 		group.Go(r.createVolumeContainerFunc(ctx, l, &volumeContainerConfig{
 			serviceName:   "sshd",
-			image:         path.Join(c.Config.DockerRegistry, c.Config.SSHDServiceImage),
+			image:         path.Join(r.c.Config.DockerRegistry, r.c.Config.SSHDServiceImage),
 			containerName: &sshdContainerName,
 			volumes: map[string]struct{}{
 				"/titus/sshd": {},
@@ -926,7 +957,7 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 	if r.cfg.ContainerLogViewer {
 		group.Go(r.createVolumeContainerFunc(ctx, l, &volumeContainerConfig{
 			serviceName:   "logviewer",
-			image:         path.Join(c.Config.DockerRegistry, c.Config.LogViewerServiceImage),
+			image:         path.Join(r.c.Config.DockerRegistry, r.c.Config.LogViewerServiceImage),
 			containerName: &logViewerContainerName,
 			volumes: map[string]struct{}{
 				"/titus/adminlogs": {},
@@ -934,11 +965,11 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 		}))
 	}
 
-	if shouldStartServiceMesh(&r.cfg, c) {
+	if shouldStartServiceMesh(&r.cfg, r.c) {
 		group.Go(r.createVolumeContainerFunc(ctx, l, &volumeContainerConfig{
 			serviceName: "servicemesh",
 			image: func() string {
-				cimage, _ := c.GetServiceMeshImage()
+				cimage, _ := r.c.GetServiceMeshImage()
 				return cimage
 			}(),
 			containerName: &serviceMeshContainerName,
@@ -948,10 +979,10 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 		}))
 	}
 
-	if shouldStartAbmetrix(&r.cfg, c) {
+	if shouldStartAbmetrix(&r.cfg, r.c) {
 		group.Go(r.createVolumeContainerFunc(ctx, l, &volumeContainerConfig{
 			serviceName:   "abmetrix",
-			image:         path.Join(c.Config.DockerRegistry, c.Config.AbmetrixServiceImage),
+			image:         path.Join(r.c.Config.DockerRegistry, r.c.Config.AbmetrixServiceImage),
 			containerName: &abmetrixContainerName,
 			volumes: map[string]struct{}{
 				"/titus/abmetrix": {},
@@ -962,15 +993,16 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 	if r.cfg.UseNewNetworkDriver {
 		group.Go(func() error {
 			prepareNetworkStartTime := time.Now()
-			netErr := prepareNetworkDriver(errGroupCtx, r.dockerCfg, c)
+			cf, netErr := prepareNetworkDriver(errGroupCtx, r.dockerCfg, r.c)
 			if netErr == nil {
 				r.metrics.Timer("titus.executor.prepareNetworkTime", time.Since(prepareNetworkStartTime), nil)
+				r.registerRuntimeCleanup(cf)
 			}
 			return netErr
 		})
 	} else {
 		// Don't call out to network driver for local development
-		c.Allocation = vpcTypes.HybridAllocation{
+		r.c.Allocation = vpcTypes.HybridAllocation{
 			IPV4Address: &vpcapi.UsableAddress{
 				Address: &vpcapi.Address{
 					Address: "1.2.3.4",
@@ -982,7 +1014,7 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 			Error:       "",
 			BranchENIID: "eni-cat-dog",
 		}
-		l.Info("Mocking networking configuration in dev mode to IP: ", c.Allocation)
+		l.Info("Mocking networking configuration in dev mode to IP: ", r.c.Allocation)
 	}
 
 	err = group.Wait()
@@ -990,10 +1022,9 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 		goto error
 	}
 
-	if err = setSystemdRunning(l, *myImageInfo, c); err != nil {
+	if err = setSystemdRunning(l, *myImageInfo, r.c); err != nil {
 		goto error
 	}
-	binds = append(binds, getLXCFsBindMounts()...)
 
 	if metatronContainerName != "" {
 		volumeContainers = append(volumeContainers, metatronContainerName)
@@ -1011,13 +1042,13 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 		volumeContainers = append(volumeContainers, abmetrixContainerName)
 	}
 
-	dockerCfg, hostCfg, err = r.dockerConfig(c, binds, size, volumeContainers)
+	dockerCfg, hostCfg, err = r.dockerConfig(r.c, getLXCFsBindMounts(), size, volumeContainers)
 	if err != nil {
 		goto error
 	}
 
-	if c.Resources.GPU > 0 {
-		err = r.setupGPU(ctx, c, dockerCfg, hostCfg)
+	if r.c.Resources.GPU > 0 {
+		err = r.setupGPU(ctx, r.c, dockerCfg, hostCfg)
 		if err != nil {
 			goto error
 		}
@@ -1025,32 +1056,32 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context, c *runtimeTypes.Conta
 
 	l.Infof("create with Docker config %#v and Host config: %#v", *dockerCfg, *hostCfg)
 
-	containerCreateBody, err = r.client.ContainerCreate(ctx, dockerCfg, hostCfg, nil, c.TaskID)
-	c.SetID(containerCreateBody.ID)
+	containerCreateBody, err = r.client.ContainerCreate(ctx, dockerCfg, hostCfg, nil, r.c.TaskID)
+	r.c.SetID(containerCreateBody.ID)
 
-	r.metrics.Timer("titus.executor.dockerCreateTime", time.Since(dockerCreateStartTime), c.ImageTagForMetrics())
+	r.metrics.Timer("titus.executor.dockerCreateTime", time.Since(dockerCreateStartTime), r.c.ImageTagForMetrics())
 	if docker.IsErrNotFound(err) {
 		return &runtimeTypes.RegistryImageNotFoundError{Reason: err}
 	}
 	if err != nil {
 		goto error
 	}
-	l = l.WithField("containerID", c.ID)
+	l = l.WithField("containerID", r.c.ID)
 	l.Info("Container successfully created")
 
-	err = r.createTitusEnvironmentFile(c)
+	err = r.createTitusEnvironmentFile(r.c)
 	if err != nil {
 		goto error
 	}
 	l.Info("Titus environment pushed")
 
-	err = r.createTitusContainerConfigFile(c, startTime)
+	err = r.createTitusContainerConfigFile(r.c, r.startTime)
 	if err != nil {
 		goto error
 	}
 	l.Info("Titus Configuration pushed")
 
-	err = r.pushEnvironment(c, myImageInfo)
+	err = r.pushEnvironment(r.c, myImageInfo)
 	if err != nil {
 		goto error
 	}
@@ -1079,7 +1110,7 @@ func (r *DockerRuntime) createTitusContainerConfigFile(c *runtimeTypes.Container
 		return err
 	}
 	defer shouldClose(f)
-	c.RegisterRuntimeCleanup(func() error {
+	r.registerRuntimeCleanup(func() error {
 		return os.Remove(containerConfigFile)
 	})
 
@@ -1094,7 +1125,7 @@ func (r *DockerRuntime) createTitusEnvironmentFile(c *runtimeTypes.Container) er
 		return err
 	}
 	defer shouldClose(f)
-	c.RegisterRuntimeCleanup(func() error {
+	r.registerRuntimeCleanup(func() error {
 		return os.Remove(envFile)
 	})
 
@@ -1297,7 +1328,7 @@ func (r *DockerRuntime) waitForTini(ctx context.Context, listener *net.UnixListe
 
 // Start runs an already created container. A watcher is created that monitors container state. The Status Message Channel is ONLY
 // valid if err == nil, otherwise it will block indefinitely.
-func (r *DockerRuntime) Start(parentCtx context.Context, c *runtimeTypes.Container) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
+func (r *DockerRuntime) Start(parentCtx context.Context) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
 	ctx, cancel := context.WithTimeout(parentCtx, r.dockerCfg.startTimeout)
 	defer cancel()
 	var err error
@@ -1305,16 +1336,16 @@ func (r *DockerRuntime) Start(parentCtx context.Context, c *runtimeTypes.Contain
 	var details *runtimeTypes.Details
 	statusMessageChan := make(chan runtimeTypes.StatusMessage, 10)
 
-	entry := log.WithField("taskID", c.TaskID)
+	entry := log.WithField("taskID", r.c.TaskID)
 	entry.Info("Starting")
-	efsMountInfos, err := r.processEFSMounts(c)
+	efsMountInfos, err := r.processEFSMounts(r.c)
 	if err != nil {
 		return "", nil, statusMessageChan, err
 	}
 
 	// This sets up the tini listener. It will autoclose whenever the
 	if r.tiniEnabled {
-		listener, err = r.setupPreStartTini(ctx, c)
+		listener, err = r.setupPreStartTini(ctx, r.c)
 		if err != nil {
 			return "", nil, statusMessageChan, err
 		}
@@ -1328,7 +1359,7 @@ func (r *DockerRuntime) Start(parentCtx context.Context, c *runtimeTypes.Contain
 	dockerStartStartTime := time.Now()
 	eventCtx, eventCancel := context.WithCancel(context.Background())
 	filters := filters.NewArgs()
-	filters.Add("container", c.ID)
+	filters.Add("container", r.c.ID)
 	filters.Add("type", "container")
 
 	eventOptions := types.EventsOptions{
@@ -1338,7 +1369,7 @@ func (r *DockerRuntime) Start(parentCtx context.Context, c *runtimeTypes.Contain
 	// 1. We need to establish a event channel
 	eventChan, eventErrChan := r.client.Events(eventCtx, eventOptions)
 
-	err = r.client.ContainerStart(ctx, c.ID, types.ContainerStartOptions{})
+	err = r.client.ContainerStart(ctx, r.c.ID, types.ContainerStartOptions{})
 	if err != nil {
 		entry.Error("Error starting: ", err)
 		r.metrics.Counter("titus.executor.dockerStartContainerError", 1, nil)
@@ -1347,43 +1378,43 @@ func (r *DockerRuntime) Start(parentCtx context.Context, c *runtimeTypes.Contain
 		return "", nil, statusMessageChan, maybeConvertIntoBadEntryPointError(err)
 	}
 
-	r.metrics.Timer("titus.executor.dockerStartTime", time.Since(dockerStartStartTime), c.ImageTagForMetrics())
+	r.metrics.Timer("titus.executor.dockerStartTime", time.Since(dockerStartStartTime), r.c.ImageTagForMetrics())
 
-	if c.Allocation.IPV4Address == nil {
+	if r.c.Allocation.IPV4Address == nil {
 		log.Fatal("IP allocation unset")
 	}
-	eniID := c.Allocation.BranchENIID
+	eniID := r.c.Allocation.BranchENIID
 	if eniID == "" {
-		eniID = c.Allocation.ENI
+		eniID = r.c.Allocation.ENI
 	}
 	details = &runtimeTypes.Details{
 		IPAddresses: map[string]string{
-			"nfvpc": c.Allocation.IPV4Address.Address.Address,
+			"nfvpc": r.c.Allocation.IPV4Address.Address.Address,
 		},
 		NetworkConfiguration: &runtimeTypes.NetworkConfigurationDetails{
 			IsRoutableIP: true,
-			IPAddress:    c.Allocation.IPV4Address.Address.Address,
-			EniIPAddress: c.Allocation.IPV4Address.Address.Address,
-			ResourceID:   fmt.Sprintf("resource-eni-%d", c.Allocation.DeviceIndex-1),
+			IPAddress:    r.c.Allocation.IPV4Address.Address.Address,
+			EniIPAddress: r.c.Allocation.IPV4Address.Address.Address,
+			ResourceID:   fmt.Sprintf("resource-eni-%d", r.c.Allocation.DeviceIndex-1),
 			EniID:        eniID,
 		},
 	}
 
-	if c.Allocation.IPV6Address != nil && c.Allocation.IPV6Address.Address != nil {
-		details.NetworkConfiguration.EniIPv6Address = c.Allocation.IPV6Address.Address.Address
+	if r.c.Allocation.IPV6Address != nil && r.c.Allocation.IPV6Address.Address != nil {
+		details.NetworkConfiguration.EniIPv6Address = r.c.Allocation.IPV6Address.Address.Address
 	}
 
 	if r.tiniEnabled {
-		logDir, err := r.waitForTini(ctx, listener, efsMountInfos, c)
+		logDir, err := r.waitForTini(ctx, listener, efsMountInfos, r.c)
 		if err != nil {
 			eventCancel()
 		} else {
-			go r.statusMonitor(eventCancel, c, eventChan, eventErrChan, statusMessageChan)
+			go r.statusMonitor(eventCancel, r.c, eventChan, eventErrChan, statusMessageChan)
 		}
 		return logDir, details, statusMessageChan, err
 	}
 
-	go r.statusMonitor(eventCancel, c, eventChan, eventErrChan, statusMessageChan)
+	go r.statusMonitor(eventCancel, r.c, eventChan, eventErrChan, statusMessageChan)
 	// We already logged above that we aren't using Tini
 	// This means that the log watcher is not started
 	return "", details, statusMessageChan, nil
@@ -1632,7 +1663,7 @@ func (r *DockerRuntime) setupPostStartLogDirTiniHandleConnection(parentCtx conte
 		return "", nil, nil, errors.New("Timed out waiting for file desciptors")
 	}
 
-	c.RegisterRuntimeCleanup(func() error {
+	r.registerRuntimeCleanup(func() error {
 		shouldClose(unixConn)
 		return nil
 	})
@@ -1642,7 +1673,7 @@ func (r *DockerRuntime) setupPostStartLogDirTiniHandleConnection(parentCtx conte
 	}
 
 	rootFile := files[0]
-	c.RegisterRuntimeCleanup(rootFile.Close)
+	r.registerRuntimeCleanup(rootFile.Close)
 
 	// r.logDir(c), &cred, rootFile, nil
 	err = r.setupPostStartLogDirTiniHandleConnection2(parentCtx, c, cred, rootFile)
@@ -1653,7 +1684,7 @@ func (r *DockerRuntime) setupPostStartLogDirTiniHandleConnection2(parentCtx cont
 	group, errGroupCtx := errgroup.WithContext(parentCtx)
 
 	// This required (write) access to c.RegisterRuntimeCleanup
-	if err := mountContainerProcPid1InTitusInits(parentCtx, c, cred); err != nil {
+	if err := r.mountContainerProcPid1InTitusInits(parentCtx, c, cred); err != nil {
 		return err
 	}
 
@@ -1663,7 +1694,11 @@ func (r *DockerRuntime) setupPostStartLogDirTiniHandleConnection2(parentCtx cont
 
 		// afaik, since this is the only one *modifying* data in the container object, we should be okay
 		group.Go(func() error {
-			return setupNetworking(r.dockerCfg.burst, c, cred)
+			cf, err := setupNetworking(r.dockerCfg.burst, c, cred)
+			if err == nil {
+				r.registerRuntimeCleanup(cf)
+			}
+			return err
 		})
 	}
 
@@ -1702,7 +1737,7 @@ func (r *DockerRuntime) setupPostStartLogDirTiniHandleConnection2(parentCtx cont
 		return err
 	}
 
-	c.RegisterRuntimeCleanup(func() error {
+	r.registerRuntimeCleanup(func() error {
 		return os.Remove(logviewerRoot)
 	})
 
@@ -1735,25 +1770,25 @@ func setupNetworkingArgs(burst bool, c *runtimeTypes.Container) []string {
 	return args
 }
 
-func setupNetworking(burst bool, c *runtimeTypes.Container, cred ucred) error { // nolint: gocyclo
+func setupNetworking(burst bool, c *runtimeTypes.Container, cred ucred) (cleanupFunc, error) { // nolint: gocyclo
 	log.Info("Setting up container network")
 	var result vpcTypes.WiringStatus
 
 	netnsPath := filepath.Join("/proc/", strconv.Itoa(int(cred.pid)), "ns", "net")
 	netnsFile, err := os.Open(netnsPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer shouldClose(netnsFile)
 
 	setupCommand := exec.Command(vpcToolPath(), setupNetworkingArgs(burst, c)...) // nolint: gosec
 	stdin, err := setupCommand.StdinPipe()
 	if err != nil {
-		return err // nolint: vet
+		return nil, err // nolint: vet
 	}
 	stdout, err := setupCommand.StdoutPipe()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	setupCommand.Stderr = os.Stderr
@@ -1761,7 +1796,7 @@ func setupNetworking(burst bool, c *runtimeTypes.Container, cred ucred) error { 
 
 	err = setupCommand.Start()
 	if err != nil {
-		return errors.Wrap(err, "Could not start setup command")
+		return nil, errors.Wrap(err, "Could not start setup command")
 	}
 	// errCh
 	errCh := make(chan error, 1)
@@ -1811,12 +1846,12 @@ func setupNetworking(burst bool, c *runtimeTypes.Container, cred ucred) error { 
 	if err := json.NewEncoder(stdin).Encode(c.Allocation); err != nil {
 		go waitForKill()
 		killCh <- struct{}{}
-		return err
+		return nil, err
 	}
 	if err := json.NewDecoder(stdout).Decode(&result); err != nil {
 		go waitForKill()
 		killCh <- struct{}{}
-		return fmt.Errorf("Unable to read json from pipe during setup-container: %+v", err)
+		return nil, fmt.Errorf("Unable to read json from pipe during setup-container: %+v", err)
 	}
 
 	go waitForKill()
@@ -1824,17 +1859,17 @@ func setupNetworking(burst bool, c *runtimeTypes.Container, cred ucred) error { 
 	if !killTimer.Stop() {
 		err = errors.New("Kill timer fired. Race condition")
 		log.WithError(err).Error("Accidentally killed the setup command, leaving us in a 'unknown' state")
-		return err
+		return nil, err
 	}
 
 	if !result.Success {
 		killCh <- struct{}{}
-		return fmt.Errorf("Network setup error: %s", result.Error)
+		return nil, fmt.Errorf("Network setup error: %s", result.Error)
 	}
 
 	switch g := (*c.Allocation.Generation); g {
 	case vpcTypes.V1:
-		c.RegisterRuntimeCleanup(func() error {
+		return func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 			defer cancel()
 
@@ -1850,28 +1885,26 @@ func setupNetworking(burst bool, c *runtimeTypes.Container, cred ucred) error { 
 				return errors.Wrap(err2, "Could not teardown container networking")
 			}
 			return nil
-		})
-		return nil
+		}, nil
 	case vpcTypes.V3:
 		// No one should have read off errCh before us.
 		err = <-errCh
 		if err != nil {
 			killCh <- struct{}{}
-			return errors.Wrap(err, "Error experienced when running V3 setup command")
+			return nil, errors.Wrap(err, "Error experienced when running V3 setup command")
 		}
 		f2, err := os.Open(netnsPath)
 		if err != nil {
-			return errors.Wrap(err, "Unable to open container network namespace file")
+			return nil, errors.Wrap(err, "Unable to open container network namespace file")
 		}
-		c.RegisterRuntimeCleanup(func() error {
+		return func() error {
 			return teardownCommand(f2, c.Allocation)
-		})
-		return nil
+		}, nil
 	default:
 		err = fmt.Errorf("Unknown generation: %s", g)
 		killCh <- struct{}{}
 		log.WithError(err).Error("Received allocation with unknown generation")
-		return err
+		return nil, err
 	}
 
 }
@@ -1935,17 +1968,17 @@ func (r *DockerRuntime) setupGPU(ctx context.Context, c *runtimeTypes.Container,
 }
 
 // Kill uses the Docker API to terminate a container and notifies the VPC driver to tear down its networking
-func (r *DockerRuntime) Kill(c *runtimeTypes.Container) error { // nolint: gocyclo
-	log.Infof("Killing %s", c.TaskID)
+func (r *DockerRuntime) Kill(ctx context.Context) error { // nolint: gocyclo
+	log.Infof("Killing %s", r.c.TaskID)
 
 	var errs *multierror.Error
 
-	containerStopTimeout := time.Second * time.Duration(c.TitusInfo.GetKillWaitSeconds())
+	containerStopTimeout := time.Second * time.Duration(r.c.TitusInfo.GetKillWaitSeconds())
 	if containerStopTimeout == 0 {
 		containerStopTimeout = defaultKillWait
 	}
 
-	if containerJSON, err := r.client.ContainerInspect(context.TODO(), c.ID); docker.IsErrNotFound(err) {
+	if containerJSON, err := r.client.ContainerInspect(context.TODO(), r.c.ID); docker.IsErrNotFound(err) {
 		goto stopped
 	} else if err != nil {
 		log.Error("Failed to inspect container: ", err)
@@ -1955,32 +1988,32 @@ func (r *DockerRuntime) Kill(c *runtimeTypes.Container) error { // nolint: gocyc
 		goto stopped
 	}
 
-	if err := r.client.ContainerStop(context.TODO(), c.ID, &containerStopTimeout); err != nil {
+	if err := r.client.ContainerStop(context.TODO(), r.c.ID, &containerStopTimeout); err != nil {
 		r.metrics.Counter("titus.executor.dockerStopContainerError", 1, nil)
-		log.Errorf("container %s : stop %v", c.TaskID, err)
+		log.Errorf("container %s : stop %v", r.c.TaskID, err)
 		errs = multierror.Append(errs, err)
 	} else {
 		goto stopped
 	}
 
-	if err := r.client.ContainerKill(context.TODO(), c.ID, "SIGKILL"); err != nil {
+	if err := r.client.ContainerKill(context.TODO(), r.c.ID, "SIGKILL"); err != nil {
 		r.metrics.Counter("titus.executor.dockerKillContainerError", 1, nil)
-		log.Errorf("container %s : kill %v", c.TaskID, err)
+		log.Errorf("container %s : kill %v", r.c.TaskID, err)
 		errs = multierror.Append(errs, err)
 	}
 
 stopped:
 
-	if c.TitusInfo.GetNumGpus() > 0 && c.GPUInfo != nil {
-		numDealloc := c.GPUInfo.Deallocate()
-		log.Infof("Deallocated %d GPU devices for task %s", numDealloc, c.TaskID)
+	if r.c.TitusInfo.GetNumGpus() > 0 && r.c.GPUInfo != nil {
+		numDealloc := r.c.GPUInfo.Deallocate()
+		log.Infof("Deallocated %d GPU devices for task %s", numDealloc, r.c.TaskID)
 	}
 
 	return errs.ErrorOrNil()
 }
 
 // Cleanup runs the registered callbacks for a container
-func (r *DockerRuntime) Cleanup(c *runtimeTypes.Container) error {
+func (r *DockerRuntime) Cleanup(ctx context.Context) error {
 	var errs *multierror.Error
 
 	cro := types.ContainerRemoveOptions{
@@ -1989,13 +2022,17 @@ func (r *DockerRuntime) Cleanup(c *runtimeTypes.Container) error {
 		Force:         true,
 	}
 
-	if err := r.client.ContainerRemove(context.TODO(), c.ID, cro); err != nil {
+	if err := r.client.ContainerRemove(context.TODO(), r.c.ID, cro); err != nil {
 		r.metrics.Counter("titus.executor.dockerRemoveContainerError", 1, nil)
-		log.Errorf("Failed to remove container '%s' with ID: %s: %v", c.TaskID, c.ID, err)
+		log.Errorf("Failed to remove container '%s' with ID: %s: %v", r.c.TaskID, r.c.ID, err)
 		errs = multierror.Append(errs, err)
 	}
 
-	errs = multierror.Append(errs, c.RuntimeCleanup()...)
+	r.cleanupFuncLock.Lock()
+	defer r.cleanupFuncLock.Unlock()
+	for i := len(r.cleanup) - 1; i >= 0; i-- {
+		errs = multierror.Append(errs, r.cleanup[i]())
+	}
 
 	return errs.ErrorOrNil()
 }

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -142,19 +142,19 @@ func setupScheduler(cred ucred) error {
 }
 
 // This mounts /proc/${PID1}/ to /var/lib/titus-inits for the container
-func mountContainerProcPid1InTitusInits(parentCtx context.Context, c *runtimeTypes.Container, cred ucred) error {
+func (r *DockerRuntime) mountContainerProcPid1InTitusInits(parentCtx context.Context, c *runtimeTypes.Container, cred ucred) error {
 	pidpath := filepath.Join("/proc/", strconv.FormatInt(int64(cred.pid), 10))
 	path := filepath.Join(titusInits, c.TaskID)
 	if err := os.Mkdir(path, 0755); err != nil { // nolint: gosec
 		return err
 	}
-	c.RegisterRuntimeCleanup(func() error {
+	r.registerRuntimeCleanup(func() error {
 		return os.Remove(path)
 	})
 	if err := unix.Mount(pidpath, path, "", unix.MS_BIND, ""); err != nil {
 		return err
 	}
-	c.RegisterRuntimeCleanup(func() error {
+	r.registerRuntimeCleanup(func() error {
 		// 0x8 is
 		return unix.Unmount(path, unix.MNT_DETACH|umountNoFollow)
 	})

--- a/executor/runtime/docker/docker_unsupported.go
+++ b/executor/runtime/docker/docker_unsupported.go
@@ -31,7 +31,7 @@ func setupSystemServices(parentCtx context.Context, c *runtimeTypes.Container, c
 	return nil
 }
 
-func mountContainerProcPid1InTitusInits(parentCtx context.Context, c *runtimeTypes.Container, cred ucred) error {
+func (r *DockerRuntime) mountContainerProcPid1InTitusInits(parentCtx context.Context, c *runtimeTypes.Container, cred ucred) error {
 	return nil
 }
 

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -114,9 +114,6 @@ func (e *InvalidConfigurationError) Error() string {
 	return fmt.Sprintf("Invalid configuration: %s", e.Reason)
 }
 
-// CleanupFunc can be registered to be called on container teardown, errors are reported, but not acted upon
-type CleanupFunc func() error
-
 // GPUContainer manages the GPUs for a container, and frees them
 type GPUContainer interface {
 	Devices() []string
@@ -133,10 +130,6 @@ type Container struct {
 	Labels    map[string]string
 	TitusInfo *titus.ContainerInfo
 	Resources *Resources
-
-	// cleanup callbacks that runtime implementations can register to do cleanup
-	// after a launchGuard on the taskID has been lifted
-	cleanup []CleanupFunc
 
 	// VPC driver fields
 	SecurityGroupIDs   []string
@@ -177,23 +170,6 @@ func (c *Container) QualifiedImageName() string {
 		return baseRef + "@" + c.TitusInfo.GetImageDigest()
 	}
 	return baseRef + ":" + c.TitusInfo.GetVersion()
-}
-
-// RegisterRuntimeCleanup calls registered functions whether or not the container successfully starts
-func (c *Container) RegisterRuntimeCleanup(callback CleanupFunc) {
-	c.cleanup = append(c.cleanup, callback)
-}
-
-// RuntimeCleanup runs cleanup callbacks registered by runtime implementations
-func (c *Container) RuntimeCleanup() []error {
-	var errs []error
-	for idx := range c.cleanup {
-		fn := c.cleanup[len(c.cleanup)-idx-1]
-		if err := fn(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errs
 }
 
 // ImageTagForMetrics returns a map with the image name
@@ -565,6 +541,8 @@ type Details struct {
 	NetworkConfiguration *NetworkConfigurationDetails
 }
 
+type ContainerRuntimeProvider func(ctx context.Context, c *Container, startTime time.Time) (Runtime, error)
+
 // Runtime is the containerization engine
 type Runtime interface {
 	// Prepare the host to run a Container: download images, prepare filesystems, etc.
@@ -573,13 +551,14 @@ type Runtime interface {
 	// TODO(fabio): better (non-Docker specific) abstraction for binds
 	// The context passed to the Prepare, and Start function is valid over the lifetime of the container,
 	// NOT per-operation
-	Prepare(containerCtx context.Context, c *Container, bindMounts []string, startTime time.Time) error
+	Prepare(containerCtx context.Context) error
 	// Start a container -- Returns an optional Log Directory if an external Logger is desired
-	Start(containerCtx context.Context, c *Container) (string, *Details, <-chan StatusMessage, error)
+	Start(containerCtx context.Context) (string, *Details, <-chan StatusMessage, error)
 	// Kill a container
-	Kill(*Container) error
-	// Cleanup can be called to tear down resources after a container has been Killed
-	Cleanup(*Container) error
+	Kill(ctx context.Context) error
+	// Cleanup can be called to tear down resources after a container has been Killed or has naturally
+	// stopped. Must always be called.
+	Cleanup(ctx context.Context) error
 }
 
 // Status represent a containers state

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -11,9 +11,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Netflix/metrics-client-go/metrics"
 	"github.com/Netflix/titus-executor/api/netflix/titus"
+	"github.com/Netflix/titus-executor/config"
 	titusdriver "github.com/Netflix/titus-executor/executor/drivers"
 	"github.com/Netflix/titus-executor/executor/runner"
+	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
 	units "github.com/docker/go-units"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
@@ -123,7 +126,7 @@ func state2containerState(prevState *v1.ContainerState, currState titusdriver.Ti
 	}
 }
 
-func RunWithBackend(ctx context.Context, runner *runner.Runner, statuses *os.File, pod *v1.Pod) error { // nolint: gocyclo
+func RunWithBackend(ctx context.Context, rp runtimeTypes.ContainerRuntimeProvider, m metrics.Reporter, statuses *os.File, pod *v1.Pod, cfg config.Config) error { // nolint: gocyclo
 	containerInfoStr, ok := pod.GetAnnotations()["containerInfo"]
 	if !ok {
 		return errContainerInfo
@@ -187,14 +190,15 @@ func RunWithBackend(ctx context.Context, runner *runner.Runner, statuses *os.Fil
 		}
 	}
 
-	err = runner.StartTask(
-		pod.GetName(),
-		&containerInfo,
-		memory.Value(),
-		cpu.Value(),
-		gpu.Value(),
-		uint64(disk.Value()),
-		uint64(network.Value()))
+	runner, err := runner.StartTaskWithRuntime(ctx, runner.Task{
+		TaskID:    pod.GetName(),
+		TitusInfo: &containerInfo,
+		Mem:       memory.Value(),
+		CPU:       cpu.Value(),
+		Gpu:       gpu.Value(),
+		Disk:      uint64(disk.Value()),
+		Network:   uint64(network.Value()),
+	}, m, rp, cfg)
 	if err != nil {
 		return errors.Wrap(err, "Could not start task")
 	}


### PR DESCRIPTION
    Refactor docker runtime to have an API which isn't designed around legacy mesos
    
    This change is mostly just cleanup. It's basically moving the Docker runtime
    logic to be purely Prepare/Start/Stop, and not getting into the idea that
    one given runner, or runtime can run multiple containers. This design
    originally stemmed from Mesos, where one executor would actuate multiple
    containers.
    
    We don't have Mesos anymore. :).