### PR TITLE
Refactor around the locations of packages

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Netflix/titus-executor/api/netflix/titus"
 	"github.com/Netflix/titus-executor/config"
 	titusdriver "github.com/Netflix/titus-executor/executor/drivers"
-	"github.com/Netflix/titus-executor/executor/runtime"
 	"github.com/Netflix/titus-executor/executor/runtime/docker"
 	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
 	"github.com/Netflix/titus-executor/filesystems"
@@ -95,7 +94,7 @@ func StartTaskWithRuntime(ctx context.Context, task Task, m metrics.Reporter, rp
 		killChan:      make(chan struct{}),
 		UpdatesChan:   make(chan Update, 10),
 		StoppedChan:   make(chan struct{}),
-		container:     runtime.NewContainer(task.TaskID, task.TitusInfo, resources, labels, cfg),
+		container:     runtimeTypes.NewContainer(task.TaskID, task.TitusInfo, resources, labels, cfg),
 	}
 
 	rt, err := rp(ctx, runner.container, startTime)

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -1,4 +1,4 @@
-package runtime
+package types
 
 import (
 	"strconv"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Netflix/titus-executor/api/netflix/titus"
 	"github.com/Netflix/titus-executor/config"
-	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
 )
 
 const (
@@ -42,7 +41,7 @@ const (
 )
 
 // NewContainer allocates and initializes a new container struct object
-func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources *runtimeTypes.Resources, labels map[string]string, cfg config.Config) *runtimeTypes.Container {
+func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources *Resources, labels map[string]string, cfg config.Config) *Container {
 	networkCfgParams := titusInfo.GetNetworkConfigInfo()
 
 	strCPU := strconv.FormatInt(resources.CPU, 10)
@@ -52,7 +51,7 @@ func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources *runt
 
 	env := cfg.GetNetflixEnvForTask(titusInfo, strMem, strCPU, strDisk, strNetwork)
 	// System service systemd units need this to be set in order to run with the right runtime path
-	env[runtimeTypes.TitusRuntimeEnvVariableName] = runtimeTypes.DefaultOciRuntime
+	env[TitusRuntimeEnvVariableName] = DefaultOciRuntime
 	labels[titusTaskInstanceIDKey] = env[titusTaskInstanceIDKey]
 	labels[cpuLabelKey] = strCPU
 	labels[memLabelKey] = strMem
@@ -60,7 +59,7 @@ func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources *runt
 	labels[networkLabelKey] = strNetwork
 	addLabels(titusInfo, labels)
 
-	c := &runtimeTypes.Container{
+	c := &Container{
 		TaskID:             taskID,
 		TitusInfo:          titusInfo,
 		Resources:          resources,

--- a/executor/runtime/types/container_test.go
+++ b/executor/runtime/types/container_test.go
@@ -1,4 +1,4 @@
-package runtime
+package types
 
 import (
 	"strconv"
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Netflix/titus-executor/api/netflix/titus"
 	"github.com/Netflix/titus-executor/config"
-	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
 	protobuf "github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,7 +16,7 @@ func TestImageNameWithTag(t *testing.T) {
 	cfg, err := config.GenerateConfiguration(nil)
 	assert.NoError(t, err)
 	expected := "docker.io/titusoss/alpine:latest"
-	c := &runtimeTypes.Container{
+	c := &Container{
 		Config: *cfg,
 		TitusInfo: &titus.ContainerInfo{
 			ImageName: protobuf.String("titusoss/alpine"),
@@ -34,7 +33,7 @@ func TestImageTagLatestByDefault(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := "docker.io/titusoss/alpine:latest"
-	c := &runtimeTypes.Container{
+	c := &Container{
 		Config: *cfg,
 		TitusInfo: &titus.ContainerInfo{
 			ImageName: protobuf.String("titusoss/alpine"),
@@ -51,7 +50,7 @@ func TestImageByDigest(t *testing.T) {
 
 	expected := "docker.io/" +
 		"titusoss/alpine@sha256:58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4"
-	c := &runtimeTypes.Container{
+	c := &Container{
 		Config: *cfg,
 		TitusInfo: &titus.ContainerInfo{
 			ImageName:   protobuf.String("titusoss/alpine"),
@@ -69,7 +68,7 @@ func TestImageByDigestIgnoresTag(t *testing.T) {
 
 	expected := "docker.io/" +
 		"titusoss/alpine@sha256:58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4"
-	c := &runtimeTypes.Container{
+	c := &Container{
 		Config: *cfg,
 		TitusInfo: &titus.ContainerInfo{
 			ImageName:   protobuf.String("titusoss/alpine"),
@@ -129,7 +128,7 @@ func TestNewContainer(t *testing.T) {
 		},
 	}
 
-	resources := &runtimeTypes.Resources{
+	resources := &Resources{
 		CPU:     expectedCPU,
 		Mem:     expectedMem,
 		Disk:    expectedDisk,
@@ -198,7 +197,7 @@ func TestMetatronEnabled(t *testing.T) {
 		AllowCpuBursting: &batch,
 	}
 
-	resources := &runtimeTypes.Resources{
+	resources := &Resources{
 		CPU:  int64(2),
 		Mem:  int64(1024),
 		Disk: uint64(15000),

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -120,8 +120,7 @@ type GPUContainer interface {
 	Deallocate() int
 }
 
-// Container contains config state for a container.
-// It is not safe to be used concurrently, synchronization and locking needs to be handled externally.
+// Container contains config state for a container. It should be Read Only.
 type Container struct {
 	// nolint: maligned
 	ID        string


### PR DESCRIPTION

Specifically, this moves the files:
executor/runtime/container.go -> executor/runtime/types/container.go
executor/runtime/container_test.go -> executor/runtime/types/container_test.go

The job of initializing the Container object should be done not in a different
package as where the Container type is declarared, but the same one.
