### PR TITLE
Run golint with GOOS=linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ fmt: $(GOBIN_TOOL)
 
 .PHONY: golangci-lint
 golangci-lint: $(GOBIN_TOOL)
-	$(GOBIN_TOOL) -m -run github.com/golangci/golangci-lint/cmd/golangci-lint run $(GOLANGCI_LINT_ARGS)
+	GOOS=linux $(GOBIN_TOOL) -m -run github.com/golangci/golangci-lint/cmd/golangci-lint run $(GOLANGCI_LINT_ARGS)
 
 .PHONY: lint
 lint: golangci-lint


### PR DESCRIPTION
This makes it so that golint will lint the package as if the platform
was Linux. It maeans for those of us who develop on Mac, it makes
the CI iteration loop slightly "cleaner"
