### PR TITLE
Revert "Run golint with GOOS=linux"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ fmt: $(GOBIN_TOOL)
 
 .PHONY: golangci-lint
 golangci-lint: $(GOBIN_TOOL)
-	GOOS=linux $(GOBIN_TOOL) -m -run github.com/golangci/golangci-lint/cmd/golangci-lint run $(GOLANGCI_LINT_ARGS)
+	$(GOBIN_TOOL) -m -run github.com/golangci/golangci-lint/cmd/golangci-lint run $(GOLANGCI_LINT_ARGS)
 
 .PHONY: lint
 lint: golangci-lint


### PR DESCRIPTION
Apparently this breaks under go 1.14+
This reverts commit 926adcb9e41cdf04556907cf5d7367df85995711.
