### PR TITLE
titus-mount: Use new mount apis for newer kernels

### DIFF
--- a/mount/Makefile
+++ b/mount/Makefile
@@ -1,2 +1,4 @@
-titus-mount: mount.c
-	musl-gcc -std=gnu11 -Wall -static -g -o titus-mount mount.c
+titus-mount: mount.c scm_rights.c
+	# musl needs this extra path here
+	# so it can pick up our linux headers for syscalls
+	C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu/:/usr/include/:. musl-gcc -std=gnu11 -Wall -static -g -o titus-mount mount.c scm_rights.c

--- a/mount/mount.c
+++ b/mount/mount.c
@@ -1,34 +1,25 @@
 #define _GNU_SOURCE
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
-
 /* getaddrinfo */
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <string.h>
-
 /* setns */
 #include <sched.h>
-
-/* mount */
-#include <sys/mount.h>
-
+/* for mount syscalls */
+#include <asm-generic/unistd.h>
+#include <linux/mount.h>
 /* fcntl */
 #include <unistd.h>
 #include <fcntl.h>
+#include <assert.h>
+#include <sys/wait.h>
+#include "scm_rights.h"
 
 char nfs4[] = "nfs4";
-
-static char* get_fs_type() {
-	char *fs_type = getenv("MOUNT_FS_TYPE");
-
-	if (!fs_type)
-		return nfs4;
-	/* It's okay to return this since it points to something in the environmenty bits */
-	return fs_type;
-}
+#define E(x) do { if ((x) == -1) { perror(#x); exit(1); } } while(0)
 
 static int dns_lookup(const char *hostname, struct sockaddr_in *addr)
 {
@@ -54,30 +45,227 @@ static int dns_lookup(const char *hostname, struct sockaddr_in *addr)
 	return 0;
 }
 
-int main() {
-	int mnt_ns_fd, net_ns_fd;
+static void compose_final_options(const char *nfs_mount_hostname, char *final_options) {
+	/* For NFS, we must do the dns resolution *here* while we are inside net ns */
+	struct sockaddr_in server_addr;
+	char *ip_string;
+
+	if (dns_lookup(nfs_mount_hostname, &server_addr)) {
+		fprintf(stderr, "titus-mount: DNS lookup failed for %s", nfs_mount_hostname);
+		exit(1);
+	}
+	ip_string = inet_ntoa(server_addr.sin_addr);
+	strcat(final_options, ",addr=");
+	strcat(final_options, ip_string);
+	fprintf(stderr, "titus-mount: using these nfs mount options: %s\n", final_options);
+}
+
+static void check_messages(int fd)
+{
+	char buf[4096];
+	int err, n;
+	err = errno;
+	for (;;) {
+		n = read(fd, buf, sizeof(buf));
+		if (n < 0)
+			break;
+		n -= 2;
+		switch (buf[0]) {
+		case 'e':
+			fprintf(stderr, "Error: %*.*s\n", n, n, buf + 2);
+			break;
+		case 'w':
+			fprintf(stderr, "Warning: %*.*s\n", n, n, buf + 2);
+			break;
+		case 'i':
+			fprintf(stderr, "Info: %*.*s\n", n, n, buf + 2);
+			break;
+		}
+	}
+	errno = err;
+}
+
+static __attribute__((noreturn))
+void mount_error(int fd, const char *s)
+{
+	check_messages(fd);
+	fprintf(stderr, "titus-mount mount error on '%s': %m\n", s);
+	exit(1);
+}
+
+static inline int pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(__NR_pidfd_open, pid, flags);
+}
+
+static inline int fsopen(const char *fs_name, unsigned int flags)
+{
+	return syscall(__NR_fsopen, fs_name, flags);
+}
+
+static inline int fsmount(int fsfd, unsigned int flags, unsigned int ms_flags)
+{
+	return syscall(__NR_fsmount, fsfd, flags, ms_flags);
+}
+
+static inline int fsconfig(int fsfd, unsigned int cmd,
+			   const char *key, const void *val, int aux)
+{
+	return syscall(__NR_fsconfig, fsfd, cmd, key, val, aux);
+}
+
+static inline int move_mount(int from_dfd, const char *from_pathname,
+			     int to_dfd, const char *to_pathname,
+			     unsigned int flags)
+{
+	return syscall(__NR_move_mount,
+		       from_dfd, from_pathname,
+		       to_dfd, to_pathname, flags);
+}
+
+#define E_fsconfig(fd, cmd, key, val, aux)                              \
+        do {                                                            \
+                if (fsconfig(fd, cmd, key, val, aux) == -1)             \
+                        mount_error(fd, key ?: "create");               \
+        } while (0)
+
+
+static void process_option(char* option, int fsfd) {
+	/* Splits up a k=v string and runs fsconfig on it.
+           We supply all the inputs here, so it is safe, but parsing things
+           like this is a little dangerous */
+	char *key, *value, *saveptr;
+	key = strtok_r (option, "=", &saveptr);
+	option = NULL;
+	value = strtok_r (option, "=", &saveptr);
+	fprintf(stderr, "titus-mount: Setting filesystem mount option %s=%s\n", key, value);
+	E_fsconfig(fsfd, FSCONFIG_SET_STRING, key, value, 0);
+}
+
+static void do_fsconfigs(int fsfd, char *options) {
+	char *str1, *token, *saveptr;
+	/* Mount options come in in the classic comma-separated key=value pairs
+	   we need to split them up and pass them in for fsconfig to handle one at a time */
+	for (str1 = options; ;str1 = NULL) {
+		token = strtok_r(str1, ",", &saveptr);
+		if (token == NULL)
+			break;
+		process_option(token, fsfd);
+	}
+	/* This last FSCONFIG_CMD_CREATE fsconfig call actually creates the superblock */
+	E_fsconfig(fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0);
+}
+
+
+static int setup_fsfd_in_namespaces(int sk, int pidfd) {
+	int fsfd, ret;
+	ret = setns(pidfd, CLONE_NEWUSER);
+	if (ret == -1) {
+		perror("setns user");
+		return 1;
+	}
+	ret = setns(pidfd, CLONE_NEWNET);
+	if (ret == -1) {
+		perror("setns net");
+		return 1;
+	}
+	ret = setns(pidfd, CLONE_NEWNS);
+	if (ret == -1) {
+		perror("setns mnt");
+		return 1;
+	}
+	fsfd = fsopen("nfs4", 0);
+	if (fsfd == -1) {
+		perror("fsopen");
+		return 1;
+	}
+	assert(send_fd(sk, fsfd) == 0);
+	return 0;
+}
+
+static int fork_and_get_fsfd(long int pidfd) {
+	int  sk_pair[2], ret, fsfd, status;
+	pid_t worker;
+
+	if (socketpair(PF_LOCAL, SOCK_SEQPACKET, 0, sk_pair) < 0) {
+		perror("socketpair");
+		exit(1);
+	}
+	worker = fork();
+	if (worker < 0) {
+		perror("fork");
+		exit(1);
+	}
+	if (worker == 0) {
+		close(sk_pair[0]);
+		ret = setup_fsfd_in_namespaces(sk_pair[1], pidfd);
+		close(sk_pair[1]);
+		exit(ret);
+	}
+	close(sk_pair[1]);
+	fsfd = recv_fd(sk_pair[0]);
+	assert(fsfd >= 0);
+	if (waitpid(worker, &status, 0) != worker) {
+		perror("waitpid");
+		exit(1);
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status)) {
+		fprintf(stderr, "worker exited nonzero\n");
+		exit(1);
+	}
+	close(sk_pair[0]);
+	return fsfd;
+}
+
+static void switch_namespaces(int pidfd) {
+	int ret;
+	ret = setns(pidfd, CLONE_NEWNET | CLONE_NEWNS);
+	if (ret == -1) {
+		perror("setns net / mount");
+		exit(1);
+	}
+}
+
+static void mount_and_move(int fsfd, const char* target, int pidfd, unsigned long flags) {
+	int mfd = fsmount(fsfd, 0, flags);
+	if (mfd < 0) {
+		mount_error(fsfd, "fsmount");
+		E(close(fsfd));
+	}
+	E(move_mount(mfd, "", AT_FDCWD, target, MOVE_MOUNT_F_EMPTY_PATH));
+	E(close(mfd));
+}
+
+int main(int argc, char *argv[]) {
+	int pidfd, fsfd;
+	long int container_pid;
 	unsigned long flags_ul;
-	int rc;
 	/*
 	 * We do this because parsing args is a bigger pain than passing
 	 * via environment variable, although passing via environment
 	 * variable has a "cost" in that they are limited in size
 	 */
-	const char *mnt_ns = getenv("MOUNT_NS");
-	const char *net_ns = getenv("NET_NS");
-	const char *source = getenv("MOUNT_SOURCE");
 	const char *nfs_mount_hostname = getenv("MOUNT_NFS_HOSTNAME");
 	const char *target = getenv("MOUNT_TARGET");
 	const char *flags = getenv("MOUNT_FLAGS");
 	const char *options = getenv("MOUNT_OPTIONS");
-	const char *fs_type = get_fs_type();
+
+	if (argc != 2) {
+		printf("Usage: %s container_pid", argv[0]);
+		return 1;
+	}
+	errno = 0;
+	container_pid = strtol(argv[1], NULL, 10);
+	assert(errno == 0);
 
 	int buf_size = sysconf(_SC_PAGESIZE);
 	char final_options [buf_size];
 	strcpy(final_options, options);
 
-	if (!(source && target && flags && options))
+	if (!(target && flags && options)) {
+		fprintf(stderr, "Usage: must provide MOUNT_TARGET, MOUNT_FLAGS, and MOUNT_OPTIONS env vars");
 		return 1;
+	}
 
 	errno = 0;
 	flags_ul = strtoul(flags, NULL, 10);
@@ -85,76 +273,25 @@ int main() {
 		perror("flags");
 		return 1;
 	}
-	if (!flags_ul) {
-		fprintf(stderr, "Invalid flags\n");
+	pidfd = pidfd_open(container_pid, 0);
+	if (pidfd == -1) {
+		perror("pidfd_open");
 		return 1;
 	}
 
-	if (net_ns) {
-		net_ns_fd = strtol(net_ns, NULL, 10);
-		if (errno) {
-			perror("net_ns");
-			return 1;
-		}
-		if (net_ns_fd == 0) {
-			fprintf(stderr, "Unable to get net NS fd\n");
-			return 1;
-		}
-		/* Validate that we have this file descriptor */
-		if (fcntl(net_ns_fd, F_GETFD) == -1) {
-			perror("net_ns: f_getfd");
-			return 1;
-		}
-		rc = setns(net_ns_fd, CLONE_NEWNET);
-		if (rc) {
-			perror("netns");
-			return 1;
-		}
-	}
+	/* First we need to get a fsfd, but it must be created inside the user namespace */
+	fsfd = fork_and_get_fsfd(pidfd);
 
-	if (mnt_ns) {
-		mnt_ns_fd = strtol(mnt_ns, NULL, 10);
-		if (errno) {
-			perror("mnt_ns");
-			return 1;
-		}
-		if (mnt_ns_fd == 0) {
-			fprintf(stderr, "Unable to get mount NS fd\n");
-			return 1;
-		}
-		/* Validate that we have this file descriptor */
-		if (fcntl(mnt_ns_fd, F_GETFD) == -1) {
-			perror("mnt_ns: f_getfd");
-			return 1;
-		}
-		rc = setns(mnt_ns_fd, CLONE_NEWNS);
-		if (rc) {
-			perror("setns");
-			return 1;
-		}
-	}
+	/* Now we can switch net/mount namespaces so we can lookup the ip and eventually mount */
+	switch_namespaces(pidfd);
+	fprintf(stderr, "titus-mount: user-inputed options: %s\n", options);
+	compose_final_options(nfs_mount_hostname, final_options);
+	fprintf(stderr, "titus-mount: computed final_options: %s\n", final_options);
 
-	/* For NFS, we must do the dns resolution *here* while we are inside net ns */
-	if (nfs_mount_hostname) {
-		static struct sockaddr_in server_addr;
-		char *ip_string;
+	/* Now we can do the fs_config calls and actual mount */
+	do_fsconfigs(fsfd, final_options);
+	mount_and_move(fsfd, target, pidfd, flags_ul);
 
-		if (dns_lookup(nfs_mount_hostname, &server_addr)) {
-			fprintf(stderr, "titus-mount: DNS lookup failed for %s. Exiting 1.\n", nfs_mount_hostname);
-			return 1;
-		}
-		ip_string = inet_ntoa(server_addr.sin_addr);
-		strcat(final_options, ",addr=");
-		strcat(final_options, ip_string);
-		fprintf(stderr, "titus-mount: using these nfs mount options: %s\n", final_options);
-	}
-
-	/* We don't check for overflow */
-	rc = mount(source, target, fs_type, flags_ul, final_options);
-	if (rc) {
-		perror("mount");
-		return 1;
-	}
-
+	fprintf(stderr, "titus-mount: All done, mounted on %s\n", target);
 	return 0;
 }

--- a/mount/scm_rights.c
+++ b/mount/scm_rights.c
@@ -1,0 +1,54 @@
+#define _GNU_SOURCE
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include "scm_rights.h"
+
+int send_fd(int sock, int fd)
+{
+	struct msghdr msg = {};
+	struct cmsghdr *cmsg;
+	char buf[CMSG_SPACE(sizeof(int))] = {0}, c = 'c';
+	struct iovec io = {
+		.iov_base = &c,
+		.iov_len = 1,
+	};
+	msg.msg_iov = &io;
+	msg.msg_iovlen = 1;
+	msg.msg_control = buf;
+	msg.msg_controllen = sizeof(buf);
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	*((int *)CMSG_DATA(cmsg)) = fd;
+	msg.msg_controllen = cmsg->cmsg_len;
+	if (sendmsg(sock, &msg, 0) < 0) {
+		perror("sendmsg");
+		return -1;
+	}
+	return 0;
+}
+
+int recv_fd(int sock)
+{
+	struct msghdr msg = {};
+	struct cmsghdr *cmsg;
+	char buf[CMSG_SPACE(sizeof(int))] = {0}, c = 'c';
+	struct iovec io = {
+		.iov_base = &c,
+		.iov_len = 1,
+	};
+	msg.msg_iov = &io;
+	msg.msg_iovlen = 1;
+	msg.msg_control = buf;
+	msg.msg_controllen = sizeof(buf);
+	if (recvmsg(sock, &msg, 0) < 0) {
+		perror("recvmsg");
+		return -1;
+	}
+	cmsg = CMSG_FIRSTHDR(&msg);
+	return *((int *)CMSG_DATA(cmsg));
+}

--- a/mount/scm_rights.h
+++ b/mount/scm_rights.h
@@ -1,0 +1,2 @@
+int send_fd(int sock, int fd);
+int recv_fd(int sock);


### PR DESCRIPTION
This changes the titus-mount command to use the newer
kernel mounting APIs on newer linux kernels:
https://lwn.net/Articles/753473/

On the plus side, this removes the need to have a patched
kernel to get NFS mounts to work with user namespaces
(only a tiny patch is required).

On the down side, the titus-mount command needs to be more
complex, initializing a fsfd in the user namespace, and then
passing that back for the parent titus-mount command to
configure and actually mount.

----

I had considered splitting the command up into parts:
1. titus-resolve (just to do the dns resolution in the net ns
2. titus-create-fsfd (just to get in the namespace to create the fsfd and ... get it back somehow
3. Let the titus executor go code handle the rest

In the end I decided that the 'monolithic' C binary was going to be easier
to live with in the longer term, because you can run it standalone,
at the cost of having to do string parsing in C.

----

Once we upgrade this, we cannot go back. This must be run on a >5.4 kernel only.
So it will need to be deployed in lock-step with a kernel upgrade.