### PR TITLE
Fix blocked describe channel

### DIFF
--- a/vpc/service/gc_v3.go
+++ b/vpc/service/gc_v3.go
@@ -390,6 +390,8 @@ func (vpcService *vpcService) doGCENIs(ctx context.Context, item *regionAccount)
 	defer cancel()
 
 	defer time.AfterFunc(11*time.Minute, func() {
+		// TODO: Consider panicing if we hit this condition
+		// TODO: Consider adding such a watchdog to all of these functions
 		logger.G(ctx).Warning("Function running too long")
 	}).Stop()
 

--- a/vpc/service/gc_v3.go
+++ b/vpc/service/gc_v3.go
@@ -498,7 +498,13 @@ ORDER BY RANDOM()
 			span.SetStatus(traceStatusFromError(err))
 			return err
 		}
-		ch <- eni
+		select {
+		case ch <- eni:
+		case <-ctx.Done():
+			err = fmt.Errorf("Context done while trying to write to gc-able ENIs: %w", ctx.Err())
+			tracehelpers.SetStatus(err, span)
+			return err
+		}
 	}
 
 	err = tx.Commit()


### PR DESCRIPTION
    getGCableENIs now checks context, and exits when it's done
    
    getGCableENIs previously would iterate over all ENIs, and then and
    write them to a channel. This was a buffered channel that had a
    depth of 10,000. Simultaneously, there was a context that was used
    by the describeENIsFoGCWorker that read off this channel to
    abort reading off the channel. If the context was cancelled,
    the describeENIsFoGCWorker would stop reading off of the
    (describe) channel.
    
    This was previously never a problem because the size of the buffer
    was 10,000, and we never had more than 10,000 ENIs. Now that we have
    more than 10,000 ENIs, it means that this describe loop can stall
    out.
    
    I wish that Go channels were more like Erlang, and that they were
    unbounded, and if they made memory run out, they would panic,
    or you could get an error on write. That seems far more sane.
