### PR TITLE
Use a more generic EC2_ACCOUNT_ID variable for ec2-account-id

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,7 +52,7 @@ type Config struct {
 
 	ContainerSSHDCAFile string
 	ContainerSSHDUsers  cli.StringSlice
-	EC2AccountID        string
+	SSHAccountID        string
 
 	// CopiedFromHost indicates which environment variables to lift from the current config
 	copiedFromHostEnv cli.StringSlice
@@ -197,9 +197,9 @@ func NewConfig() (*Config, []cli.Flag) {
 			Value: &cfg.ContainerSSHDUsers,
 		},
 		cli.StringFlag{
-			Name:        "ec2-account-id",
-			Destination: &cfg.EC2AccountID,
-			EnvVar:      "EC2_OWNER_ID",
+			Name:        "ssh-account-id",
+			Destination: &cfg.SSHAccountID,
+			EnvVar:      "SSH_ACCOUNT_ID",
 		},
 		cli.StringSliceFlag{
 			Name:  "copied-from-host-env",

--- a/executor/runtime/docker/docker_ssh.go
+++ b/executor/runtime/docker/docker_ssh.go
@@ -99,7 +99,7 @@ func addContainerSSHDConfig(c *runtimeTypes.Container, tw *tar.Writer, cfg confi
 	if err != nil {
 		return err
 	}
-	return addContainerSSHDConfigWithData(c, tw, caData, iamProfile.AccountID, cfg.EC2AccountID)
+	return addContainerSSHDConfigWithData(c, tw, caData, iamProfile.AccountID, cfg.SSHAccountID)
 }
 
 func addContainerSSHDConfigWithData(c *runtimeTypes.Container, tw *tar.Writer, caData []byte, accountIDs ...string) error {

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -174,7 +174,7 @@ func (c *Container) VPCAccountID() string {
 	}
 
 	// If the param wasn't passed via pass through attributes, then fall back to pulling it from the host env
-	return c.Config.EC2AccountID
+	return c.Config.SSHAccountID
 }
 
 // combineAppStackDetails is a port of the method with the same name from frigga.


### PR DESCRIPTION
The `EC2_OWNER_ID` variable is a netflixism that represents the aws account id that controls the underlying ec2 instance.

This number is changing as we change accounts, which is breaking ssh (the only thing that uses this config setting.

To fix it, I would like to being consuming the very generic `EC2_OWNER_ID` variable, and we can set that "correctly" in our netflix init scripts.
(specifically, I'll set it to the expected prod/test settings)