### PR TITLE
Don't start two IMDS assumerole goroutines

### DIFF
--- a/metadataserver/server.go
+++ b/metadataserver/server.go
@@ -408,9 +408,10 @@ func (ms *MetadataServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	/* Ensure no request lasts longer than 10 seconds */
 	ctx, cancel := context.WithTimeout(logging.WithConcurrentFields(r.Context()), 10*time.Second)
 	r2 := r.WithContext(ctx)
+	startTime := time.Now()
 	defer cancel()
 	defer func() {
-		log.WithFields(logging.Entry(ctx)).Infof("Request %s %s '%s' from %s", r2.Method, r2.RequestURI, r2.UserAgent(), r2.RemoteAddr)
+		log.WithFields(logging.Entry(ctx)).WithField("request-time", time.Since(startTime).Milliseconds()).Infof("Request %s %s '%s' from %s", r2.Method, r2.RequestURI, r2.UserAgent(), r2.RemoteAddr)
 	}()
 	logging.AddFields(ctx, log.Fields{
 		"method":        r.Method,

--- a/metadataserver/server_test.go
+++ b/metadataserver/server_test.go
@@ -255,6 +255,14 @@ func setupStubServer(t *testing.T) (*stubServer, error) {
 		_, _ = writer.Write([]byte("faketoken"))
 	})
 
+	// The two security-credentials handlers are so the metadata server client passed to the STS client can do its AssumeRole correctly
+	stubServerInstance.router.HandleFunc("/latest/meta-data/iam/security-credentials/", func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte("fakecreds"))
+	})
+	stubServerInstance.router.HandleFunc("/latest/meta-data/iam/security-credentials/fakecreds", func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(`{"Expiration":"2030-11-24T21:07:34Z","AccessKeyId":"fakeAccessKey","SecretAccessKey":"fakeSecretAccessKey","Type":"AWS-HMAC","LastUpdated":"2020-11-24T20:07:34Z","Code":"Success"}`))
+	})
+
 	stubServerInstance.router.PathPrefix("/").HandlerFunc(stubServerInstance.serveHTTP)
 
 	listener, err := net.Listen("tcp", "0.0.0.0:0") // nolint:gosec

--- a/metadataserver/server_test.go
+++ b/metadataserver/server_test.go
@@ -237,7 +237,9 @@ func (s *stubServer) serveHTTP(w http.ResponseWriter, req *http.Request) {
 
 // Leaks connections, but this is okay in the time of testing
 func setupStubServer(t *testing.T) (*stubServer, error) {
-	stsHandler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	stsHandler := http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		now := time.Now()
+		t.Logf("FakeSTSserver: %s: %s %s %s", now.Format(time.RFC3339), req.Method, req.Host, req.URL.String())
 		writer.Header().Set("Content-Type", "text/xml")
 		_, _ = writer.Write([]byte(assumeRoleResponse))
 	})

--- a/metadataserver/types/types.go
+++ b/metadataserver/types/types.go
@@ -25,6 +25,8 @@ type MetadataServerConfiguration struct {
 	Container                  *titus.ContainerInfo
 	Signer                     *identity.Signer
 	RequireToken               bool
+	STSEndpoint                string
+	DisableSTSEndpointSSL      bool
 	TokenKey                   string
 	XFordwardedForBlockingMode bool
 	NetflixAccountID           string

--- a/metadataserver/types/types.go
+++ b/metadataserver/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"net"
+	"net/http"
 	"net/url"
 
 	"github.com/Netflix/titus-executor/api/netflix/titus"
@@ -25,9 +26,10 @@ type MetadataServerConfiguration struct {
 	Container                  *titus.ContainerInfo
 	Signer                     *identity.Signer
 	RequireToken               bool
-	STSEndpoint                string
-	DisableSTSEndpointSSL      bool
 	TokenKey                   string
 	XFordwardedForBlockingMode bool
 	NetflixAccountID           string
+	// Both of these are used for mocking STS during testing
+	STSEndpoint   string
+	STSHTTPClient *http.Client
 }


### PR DESCRIPTION
Two fixes here:

1. Add times to request log lines: total request time, and time waiting for the assumerole lock
2. Only start one goroutine to do AssumeRoles in the background - the previous code was starting one per IAM router.

I also added a test for getting specific security credentials while I was in here.