### PR TITLE
Added titus-oci-hook, with prestart hook in place for more stuff

### DIFF
--- a/cmd/titus-oci-hook/main.go
+++ b/cmd/titus-oci-hook/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/wercker/journalhook"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func doPrestart() error {
+	journalhook.Enable()
+	bundleDirPath, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+
+	logrus.Infof("Using bundle file: %s\n", bundleDirPath+"/config.json")
+	jsonFile, err := os.OpenFile(bundleDirPath+"/config.json", os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("Couldn't open OCI spec file: %w", err)
+	}
+	defer jsonFile.Close()
+
+	jsonContent, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return fmt.Errorf("Couldn't read OCI spec file: %w", err)
+	}
+	var spec specs.Spec
+	err = json.Unmarshal(jsonContent, &spec)
+	if err != nil {
+		return fmt.Errorf("Couldn't unmarshal OCI spec file: %w", err)
+	}
+
+	// TODO: Add stuff
+
+	jsonOutput, err := json.Marshal(spec)
+	if err != nil {
+		return fmt.Errorf("Couldn't marshal OCI spec file: %w", err)
+	}
+	_, err = jsonFile.WriteAt(jsonOutput, 0)
+	if err != nil {
+		return fmt.Errorf("Couldn't write OCI spec file: %w", err)
+	}
+
+	return nil
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+	flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\nCommands:\n")
+	fmt.Fprintf(os.Stderr, "  prestart\n        run the prestart hook\n")
+	fmt.Fprintf(os.Stderr, "  poststart\n       run the poststart hook\n")
+	fmt.Fprintf(os.Stderr, "  poststop\n        run the poststop hook\n")
+}
+
+func main() {
+	flag.Usage = usage
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) == 0 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	switch args[0] {
+	case "prestart":
+		err := doPrestart()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		os.Exit(0)
+	case "poststart":
+		os.Exit(0)
+	case "poststop":
+		os.Exit(0)
+	default:
+		flag.Usage()
+		os.Exit(2)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/myitcv/gobin v0.0.9
 	github.com/netflix-skunkworks/opencensus-go-exporter-datadog v0.0.0-20190911150647-ef71dde58796
 	github.com/opencontainers/runc v1.0.0-rc10
-	github.com/opencontainers/runtime-spec v1.0.1 // indirect
+	github.com/opencontainers/runtime-spec v1.0.1
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
This scaffolding is for my intermediate project: Getting sshd working on kubelet again.

To do this, I want to re-use as much as the titus-executor code as I can.
Previously I didn't do that, and it broke, and and it drifted in behavior (see https://github.com/Netflix/titus-executor/pull/487).

So my new goal is to implement ssh in such a way that, as we improve/change ssh on VK, it automatically applies to RK, and we don't have to continuously play catchup.


To do that, I propose this oci hook binary to use in https://github.com/Netflix-Skunkworks/titus-kubelet/pull/39. A single hook for all the things, to reduce the burden of making different binaries for all the things, and in theory no additional changes to titus-containerd or any other hook configuration to implement new stuff.