### PR TITLE
DEL re-enters. This is as per spec.

### DIFF
--- a/cmd/titus-imds-cni/cni_linux.go
+++ b/cmd/titus-imds-cni/cni_linux.go
@@ -366,10 +366,9 @@ func cmdDel(args *skel.CmdArgs) error {
 		if os.IsNotExist(err) {
 			logrus.Warnf("peerNS %s does not exist. NOOP.", peerNsPath)
 			return nil
-		} else {
-			logrus.Errorf("Cannot find peer namespace %s", err)
-			return err
 		}
+		logrus.Errorf("Cannot find peer namespace %s", err)
+		return err
 	}
 	logrus.Debugf("peerNs %s %#v", peerNsPath, fi)
 

--- a/cmd/titus-imds-cni/cni_linux.go
+++ b/cmd/titus-imds-cni/cni_linux.go
@@ -361,9 +361,15 @@ func cmdDel(args *skel.CmdArgs) error {
 	peerNsPath := getPeerNsPath(podName)
 
 	fi, err := os.Stat(peerNsPath)
+
 	if err != nil {
-		logrus.Errorf("Cannot find peer namespace %s", err)
-		return err
+		if os.IsNotExist(err) {
+			logrus.Warnf("peerNS %s does not exist. NOOP.", peerNsPath)
+			return nil
+		} else {
+			logrus.Errorf("Cannot find peer namespace %s", err)
+			return err
+		}
 	}
 	logrus.Debugf("peerNs %s %#v", peerNsPath, fi)
 


### PR DESCRIPTION
DEL re-enters when the teardown takes time. This re-entry was not idempotent and used to fail.

There should not be a leak of namespaces if this fix is correct. I am monitoring this in the dev stacks separately.