### PR TITLE
Add titusParameter.agent.log.finalUploadMatchRegexp

### DIFF
--- a/api/netflix/titus/titus_job_api.pb.go
+++ b/api/netflix/titus/titus_job_api.pb.go
@@ -1286,8 +1286,10 @@ type JobDisruptionBudget_RatePercentagePerHour struct {
 func (m *JobDisruptionBudget_RatePercentagePerHour) Reset() {
 	*m = JobDisruptionBudget_RatePercentagePerHour{}
 }
-func (m *JobDisruptionBudget_RatePercentagePerHour) String() string { return proto.CompactTextString(m) }
-func (*JobDisruptionBudget_RatePercentagePerHour) ProtoMessage()    {}
+func (m *JobDisruptionBudget_RatePercentagePerHour) String() string {
+	return proto.CompactTextString(m)
+}
+func (*JobDisruptionBudget_RatePercentagePerHour) ProtoMessage() {}
 func (*JobDisruptionBudget_RatePercentagePerHour) Descriptor() ([]byte, []int) {
 	return fileDescriptor_1c07f2bd2273ea55, []int{9, 5}
 }

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -368,7 +368,7 @@ func (r *Runner) maybeSetupExternalLogger(ctx context.Context, logDir string) er
 	}
 	logger.G(ctx).Info("Starting external logger")
 
-	wConf := filesystems.NewWatchConfig(logDir, r.container.UploadDir("logs"), r.container.LogUploadRegexp(), *r.container.LogUploadCheckInterval(), *r.container.LogUploadThresholdTime(), *r.container.LogStdioCheckInterval(), r.container.LogKeepLocalFileAfterUpload())
+	wConf := filesystems.NewWatchConfig(logDir, r.container.UploadDir("logs"), r.container.LogUploadRegexp(), *r.container.LogUploadCheckInterval(), *r.container.LogUploadThresholdTime(), *r.container.LogStdioCheckInterval(), r.container.LogKeepLocalFileAfterUpload(), r.container.FinalUploadMatchRegexp())
 	uploader, err := uploader.NewUploader(&r.config, r.container.LogUploaderConfig(), *r.container.IamRole(), r.container.TaskID(), r.metrics)
 	if err != nil {
 		return err

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -195,6 +195,10 @@ func (c *PodContainer) LogKeepLocalFileAfterUpload() bool {
 	return false
 }
 
+func (c *PodContainer) FinalUploadMatchRegexp() bool {
+	return false
+}
+
 func (c *PodContainer) LogStdioCheckInterval() *time.Duration {
 	return nil
 }

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -145,6 +145,7 @@ type Container interface {
 	KvmEnabled() bool
 	Labels() map[string]string
 	LogKeepLocalFileAfterUpload() bool
+	FinalUploadMatchRegexp() bool
 	LogStdioCheckInterval() *time.Duration
 	LogUploadCheckInterval() *time.Duration
 	LogUploaderConfig() *uploader.Config

--- a/filesystems/watcher_test.go
+++ b/filesystems/watcher_test.go
@@ -229,7 +229,7 @@ func TestRotateRegexp(t *testing.T) {
 	}
 
 	for _, td := range testData {
-		shouldRotate := CheckFileForRotation(td.filename, td.regexp)
+		shouldRotate := CheckRegexpMatch(td.filename, td.regexp)
 		if td.result {
 			assert.True(t, shouldRotate, "%s should rotate", td.filename)
 		} else {


### PR DESCRIPTION
This parameter allows the user to specify that only the files that
are watched and uploaded during rotation be picked up during final
upload.

