### PR TITLE
Use DAD for IPv6 address assignment

### DIFF
--- a/vpc/tool/container2/setup_container_linux.go
+++ b/vpc/tool/container2/setup_container_linux.go
@@ -282,7 +282,7 @@ func addIPv6AddressAndRoutes(ctx context.Context, allocation types.Allocation, n
 		}
 
 		for _, addr := range addrs {
-			if (addr.Scope == unix.RT_SCOPE_LINK) && (addr.Flags&(unix.IFA_F_TENTATIVE|unix.IFA_F_PERMANENT) == unix.IFA_F_PERMANENT) {
+			if addr.Scope == unix.RT_SCOPE_LINK {
 				linkLocalAddr = addr
 				goto out
 			}


### PR DESCRIPTION
Use DAD, but now we're on a newer kernel we can use optimistic addresses while the kernel is settling.

This should make IPv6 networking available / come up faster.