### PR TITLE
If an EIP is allocated to a task, return that IP from the IMDS proxy's public-ipv4 endpoint

### DIFF
--- a/cmd/titus-metadata-service/main.go
+++ b/cmd/titus-metadata-service/main.go
@@ -122,6 +122,7 @@ func main() {
 		iamARN                     string
 		titusTaskInstanceID        string
 		ipv4Address                string
+		publicIpv4Address          string
 		ipv6Addresses              string
 		xFordwardedForBlockingMode bool
 		peerNs                     string
@@ -179,6 +180,11 @@ func main() {
 			Name:        "ipv4-address",
 			EnvVar:      types.EC2IPv4EnvVarName,
 			Destination: &ipv4Address,
+		},
+		cli.StringFlag{
+			Name:        "public-ipv4-address",
+			EnvVar:      types.EC2PublicIPv4EnvVarName,
+			Destination: &publicIpv4Address,
 		},
 		cli.BoolFlag{
 			Name:        "metatron",
@@ -247,6 +253,7 @@ func main() {
 			IAMARN:                     iamARN,
 			TitusTaskInstanceID:        titusTaskInstanceID,
 			Ipv4Address:                net.ParseIP(ipv4Address),
+			PublicIpv4Address:          net.ParseIP(publicIpv4Address),
 			Region:                     region,
 			RequireToken:               requireToken,
 			TokenKey:                   titusTaskInstanceID + tokenSalt,

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -986,6 +986,9 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context) error { // nolint: go
 			Success:     true,
 			Error:       "",
 			BranchENIID: "eni-cat-dog",
+			ElasticAddress: &vpcapi.ElasticAddress{
+				Ip: "203.0.113.11",
+			},
 		}
 		r.c.SetVPCAllocation(allocation)
 		logger.G(ctx).Info("Mocking networking configuration in dev mode to IP: ", allocation)

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -650,7 +650,12 @@ func (c *TitusInfoContainer) Env() map[string]string {
 	}
 
 	if c.vpcAllocation.IPV6Address != nil {
-		env["EC2_IPV6S"] = c.vpcAllocation.IPV6Address.Address.Address
+		env[metadataserverTypes.EC2IPv6sEnvVarName] = c.vpcAllocation.IPV6Address.Address.Address
+	}
+
+	if c.vpcAllocation.ElasticAddress != nil {
+		env[metadataserverTypes.EC2PublicIPv4EnvVarName] = c.vpcAllocation.ElasticAddress.Ip
+		env[metadataserverTypes.EC2PublicIPv4sEnvVarName] = c.vpcAllocation.ElasticAddress.Ip
 	}
 
 	// Heads up, this doesn't work in generation v1 instances of VPC Service

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -131,6 +131,7 @@ func TestStandalone(t *testing.T) {
 		testCancelPullBigImage,
 		testMetadataProxyInjection,
 		testMetdataProxyDefaultRoute,
+		testMetadataProxyPublicIP,
 		testTerminateTimeout,
 		testMakesPTY,
 		testTerminateTimeoutNotTooSlow,
@@ -701,6 +702,18 @@ func testMetdataProxyDefaultRoute(t *testing.T, jobID string) {
 		ImageName:     ubuntu.name,
 		Version:       ubuntu.tag,
 		EntrypointOld: `/bin/bash -c 'curl -sf --interface $(ip route get 4.2.2.2|grep -E -o "src [0-9.]+"|cut -f2 -d" ") http://169.254.169.254/latest/meta-data/local-ipv4'`,
+		JobID:         jobID,
+	}
+	if !RunJobExpectingSuccess(t, ji) {
+		t.Fail()
+	}
+}
+
+func testMetadataProxyPublicIP(t *testing.T, jobID string) {
+	ji := &JobInput{
+		ImageName:     ubuntu.name,
+		Version:       ubuntu.tag,
+		EntrypointOld: "/bin/bash -c 'curl -sf http://169.254.169.254/latest/meta-data/public-ipv4 | grep 203.0.113.11",
 		JobID:         jobID,
 	}
 	if !RunJobExpectingSuccess(t, ji) {

--- a/metadataserver/types/types.go
+++ b/metadataserver/types/types.go
@@ -13,6 +13,9 @@ const (
 	// TitusMetatronVariableName is the name of the environment variable that indicates if metatron is enabled for a container
 	TitusMetatronVariableName = "TITUS_METATRON_ENABLED"
 	EC2IPv4EnvVarName         = "EC2_LOCAL_IPV4"
+	EC2PublicIPv4EnvVarName   = "EC2_PUBLIC_IPV4"
+	EC2PublicIPv4sEnvVarName  = "EC2_PUBLIC_IPV4S"
+	EC2IPv6sEnvVarName        = "EC2_IPV6S"
 )
 
 // MetadataServerConfiguration is a configuration for metadata service + IAM Proxy
@@ -22,6 +25,7 @@ type MetadataServerConfiguration struct {
 	IAMARN                     string
 	TitusTaskInstanceID        string
 	Ipv4Address                net.IP
+	PublicIpv4Address          net.IP
 	Ipv6Address                *net.IP
 	Region                     string
 	Container                  *titus.ContainerInfo

--- a/vpc/types/conversions.go
+++ b/vpc/types/conversions.go
@@ -27,5 +27,9 @@ func AssignmentToAllocation(assignment *vpcapi.AssignIPResponseV3) Allocation {
 		alloc.IPV4Address = assignment.Ipv4Address
 	}
 
+	if assignment.ElasticAddress != nil {
+		alloc.ElasticAddress = assignment.ElasticAddress
+	}
+
 	return alloc
 }

--- a/vpc/types/types.go
+++ b/vpc/types/types.go
@@ -58,6 +58,7 @@ func GenerationPointer(g Generation) *Generation {
 type Allocation struct {
 	IPV4Address     *vpcapi.UsableAddress              `json:"ipv4Address"`
 	IPV6Address     *vpcapi.UsableAddress              `json:"ipv6Address"`
+	ElasticAddress  *vpcapi.ElasticAddress             `json:"elasticAddress"`
 	Routes          []*vpcapi.AssignIPResponseV3_Route `json:"routes"`
 	DeviceIndex     int                                `json:"deviceIndex"`
 	Success         bool                               `json:"success"`
@@ -99,6 +100,7 @@ type LegacyAllocation struct {
 type HybridAllocation struct {
 	IPV4Address     *vpcapi.UsableAddress              `json:"ipv4Address"`
 	IPV6Address     *vpcapi.UsableAddress              `json:"ipv6Address"`
+	ElasticAddress  *vpcapi.ElasticAddress             `json:"elasticAddress"`
 	Routes          []*vpcapi.AssignIPResponseV3_Route `json:"routes"`
 	DeviceIndex     int                                `json:"deviceIndex"`
 	Success         bool                               `json:"success"`


### PR DESCRIPTION
Now hitting http://169.254.169.254/latest/meta-data/public-ipv4 on a task with an EIP associated will return the EIP's address, not the task's IPv4 address.

According to [the AWS docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html):
> The public IPv4 address. If an Elastic IP address is associated with the instance, the value returned is the Elastic IP address.

Note that this also changes the behaviour to match the actual AWS IMDS - if there's no EIP attached, then the endpoint returns 404.

I didn't implement this in the CNI, since elastic IP support isn't present there, yet.