### PR TITLE
Add hook to CNI to create symlink to netns mount

### DIFF
--- a/vpc/tool/cni/cni.go
+++ b/vpc/tool/cni/cni.go
@@ -278,6 +278,12 @@ func (c *Command) Add(args *skel.CmdArgs) error {
 		return err
 	}
 
+	err = createNetNSAlias(pod.Name, args.Netns)
+	if err != nil {
+		logger.G(ctx).WithError(err).Error("Could not create symlink for network nameespace")
+		// Do not return
+	}
+
 	result := current.Result{
 		CNIVersion: "0.3.1",
 		Interfaces: []*current.Interface{
@@ -368,6 +374,11 @@ func (c *Command) Del(args *skel.CmdArgs) (e error) {
 		err = errors.Wrap(err, "Could not tear down container state")
 		tracehelpers.SetStatus(err, span)
 		return err
+	}
+
+	err = deleteNetNSAlias(string(cfg.k8sArgs.K8S_POD_NAME))
+	if err != nil {
+		logger.G(ctx).WithError(err).Error("Could not delete symlink to network namespace")
 	}
 
 	logger.G(ctx).Info("Successfully tore down networking")

--- a/vpc/tool/cni/namespace_linux.go
+++ b/vpc/tool/cni/namespace_linux.go
@@ -1,0 +1,40 @@
+// +build linux
+
+package cni
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+const namespacePath string = "/var/run/pods/"
+
+func getNSAlias(podName string) string {
+	return filepath.Join(namespacePath, "netns-"+podName)
+}
+
+func createNetNSAlias(podName string, netnsPath string) error {
+	aliasPath := getNSAlias(podName)
+	err := os.Symlink(netnsPath, aliasPath)
+
+	if errors.Is(err, os.ErrNotExist) {
+		// Create base dir if missing
+		err := os.MkdirAll(filepath.Dir(aliasPath), 0755)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(netnsPath, aliasPath)
+	}
+
+	return nil
+}
+
+func deleteNetNSAlias(podName string) error {
+	err := os.Remove(getNSAlias(podName))
+	if errors.Is(err, os.ErrNotExist) {
+		// No fail if the file is already gone
+		return nil
+	}
+	return err
+}

--- a/vpc/tool/cni/namespace_unsupported.go
+++ b/vpc/tool/cni/namespace_unsupported.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package cni
+
+import (
+	"github.com/Netflix/titus-executor/vpc/types"
+)
+
+func createNetNSAlias(podName string, netnsPath string) error {
+	return types.ErrUnsupported
+}
+
+func deleteNetNSAlias(podName string) error {
+	return types.ErrUnsupported
+}


### PR DESCRIPTION
We'll use this for making calls into the network namespace from the host.  The filename is to be a well-known format that can be determined from a pod-name.