### PR TITLE
Use CNI Based netns dialer for proxy mode on kubelet

### DIFF
--- a/logviewer/api/proxy.go
+++ b/logviewer/api/proxy.go
@@ -24,10 +24,6 @@ func getNetNsPath(containerID string) string {
 	return fmt.Sprintf("%s/%s/ns/net", utils.TitusInits, containerID)
 }
 
-func getKubeletNetNsPath(podID string) string {
-	return fmt.Sprintf("/var/run/pod/netns-%s", podID)
-}
-
 func doProxy(w http.ResponseWriter, r *http.Request, containerID string, proxy *httputil.ReverseProxy) {
 	proxyURL, _ := url.Parse(inContainerURL)
 

--- a/logviewer/api/proxy.go
+++ b/logviewer/api/proxy.go
@@ -7,16 +7,25 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/Netflix/titus-executor/utils/netns"
-
+	"github.com/Netflix/titus-executor/logviewer/conf"
 	"github.com/Netflix/titus-executor/utils"
+	"github.com/Netflix/titus-executor/utils/netns"
+	"github.com/Netflix/titus-executor/vpc/tool/cni"
 )
 
 // The URL to connect to once we've done a Setns() into the container
 const inContainerURL = "http://127.0.0.1:8004"
 
 func getNetNsPath(containerID string) string {
+	if conf.KubeletMode {
+		return cni.NSAliasPath(containerID)
+	}
+
 	return fmt.Sprintf("%s/%s/ns/net", utils.TitusInits, containerID)
+}
+
+func getKubeletNetNsPath(podID string) string {
+	return fmt.Sprintf("/var/run/pod/netns-%s", podID)
 }
 
 func doProxy(w http.ResponseWriter, r *http.Request, containerID string, proxy *httputil.ReverseProxy) {

--- a/logviewer/conf/conf.go
+++ b/logviewer/conf/conf.go
@@ -15,14 +15,6 @@ var (
 	KubeletMode        = false
 )
 
-const confTemplate = `Starting with config:
-ContainersHome     = %s
-ContainerID        = %s
-RunningInContainer = %t
-ProxyMode          = %t
-KubeletMode        = %t
-`
-
 func init() {
 	loc := os.Getenv("CONTAINER_HOME")
 	if loc != "" {

--- a/logviewer/conf/conf.go
+++ b/logviewer/conf/conf.go
@@ -12,6 +12,7 @@ var (
 	ContainerID        = ""
 	RunningInContainer = false
 	ProxyMode          = true
+	KubeletMode        = false
 )
 
 func init() {
@@ -27,6 +28,12 @@ func init() {
 		ContainerID = cID
 		RunningInContainer = true
 		ContainersHome = "/"
+	}
+
+	kubeMode := os.Getenv("KUBELET_MODE")
+	if kubeMode != "" {
+		log.Println("KUBELET_MODE set")
+		KubeletMode = true
 	}
 
 	proxyMode := os.Getenv("DISABLE_PROXY_MODE")

--- a/logviewer/conf/conf.go
+++ b/logviewer/conf/conf.go
@@ -15,16 +15,22 @@ var (
 	KubeletMode        = false
 )
 
+const confTemplate = `Starting with config:
+ContainersHome     = %s
+ContainerID        = %s
+RunningInContainer = %t
+ProxyMode          = %t
+KubeletMode        = %t
+`
+
 func init() {
 	loc := os.Getenv("CONTAINER_HOME")
 	if loc != "" {
-		log.Println("CONTAINER_HOME set: ContainersHome=" + loc)
 		ContainersHome = loc
 	}
 
 	cID := os.Getenv("TITUS_TASK_ID")
 	if cID != "" {
-		log.Println("TITUS_TASK_ID set: RunningInContainer=true, ContainerID=" + cID)
 		ContainerID = cID
 		RunningInContainer = true
 		ContainersHome = "/"
@@ -32,13 +38,19 @@ func init() {
 
 	kubeMode := os.Getenv("KUBELET_MODE")
 	if kubeMode != "" {
-		log.Println("KUBELET_MODE set")
 		KubeletMode = true
 	}
 
 	proxyMode := os.Getenv("DISABLE_PROXY_MODE")
 	if proxyMode != "" {
-		log.Println("DISABLE_PROXY_MODE set")
 		ProxyMode = false
 	}
+
+	log.WithFields(log.Fields{
+		"ContainersHome":     ContainersHome,
+		"ContainerID":        ContainerID,
+		"RunningInContainer": RunningInContainer,
+		"ProxyMode":          ProxyMode,
+		"KubeletMode":        KubeletMode,
+	}).Info("Config loaded")
 }

--- a/root/apps/titus-executor/bin/run-titus-logviewer.sh
+++ b/root/apps/titus-executor/bin/run-titus-logviewer.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ -f "/run/is_kubelet" ]]; then
+  export KUBELET_MODE=true
+fi
+
+exec /apps/titus-exectuor/bin/titus-logviewer

--- a/root/lib/systemd/system/titus-logviewer.service
+++ b/root/lib/systemd/system/titus-logviewer.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Titus Log Viewer Server
 Conflicts=halt.target shutdown.target sigpwr.target
+After=titus-backend-selector.service
 
 [Service]
 EnvironmentFile=-/etc/titus-shared.env
 Environment=CONTAINER_HOME=/var/lib/titus-container-logs
-ExecStart=/apps/titus-executor/bin/titus-logviewer
+ExecStart=/apps/titus-executor/bin/run-titus-logviewer.sh
 Restart=always
 StartLimitInterval=0
 RestartSec=5

--- a/vpc/tool/cni/cni.go
+++ b/vpc/tool/cni/cni.go
@@ -280,7 +280,7 @@ func (c *Command) Add(args *skel.CmdArgs) error {
 
 	err = createNetNSAlias(pod.Name, args.Netns)
 	if err != nil {
-		logger.G(ctx).WithError(err).Error("Could not create symlink for network nameespace")
+		logger.G(ctx).WithError(err).Error("Could not create symlink for network namespace")
 		// Do not return
 	}
 

--- a/vpc/tool/cni/cni.go
+++ b/vpc/tool/cni/cni.go
@@ -278,6 +278,12 @@ func (c *Command) Add(args *skel.CmdArgs) error {
 		return err
 	}
 
+	err = createNetNSAlias(pod.Name, args.Netns)
+	if err != nil {
+		logger.G(ctx).WithError(err).Error("Could not create symlink for network nameespace")
+		// Do not return
+	}
+
 	result := current.Result{
 		CNIVersion: "0.3.1",
 		Interfaces: []*current.Interface{
@@ -368,6 +374,11 @@ func (c *Command) Del(args *skel.CmdArgs) (e error) {
 		err = errors.Wrap(err, "Could not tear down container state")
 		tracehelpers.SetStatus(err, span)
 		return err
+	}
+
+	err = deleteNetNSAlias(string(cfg.k8sArgs.K8S_POD_NAME))
+	if err != nil {
+		logger.G(ctx).WithError(err).Error("Could not delete symlink to network namespace")
 	}
 
 	logger.G(ctx).Info("Successfully tore down networking")

--- a/vpc/tool/cni/namespace_linux.go
+++ b/vpc/tool/cni/namespace_linux.go
@@ -1,0 +1,40 @@
+// +build linux
+
+package cni
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+const namespacePath string = "/var/run/pods/"
+
+func getNSAlias(podName string) string {
+	return filepath.Join(namespacePath, "netns-"+podName)
+}
+
+func createNetNSAlias(podName string, netnsPath string) error {
+	aliasPath := getNSAlias(podName)
+	err := os.Symlink(netnsPath, aliasPath)
+
+	if errors.Is(err, os.ErrNotExist) {
+		// Create base dir if missing
+		err := os.MkdirAll(filepath.Dir(aliasPath), 0755)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(netnsPath, aliasPath)
+	}
+
+	return nil
+}
+
+func deleteNetNSAlias(podName string) error {
+	err := os.Remove(getNSAlias(podName))
+	if errors.Is(err, os.ErrNotExist) {
+		// No fail if the file is already gone
+		return nil
+	}
+	return err
+}

--- a/vpc/tool/cni/namespace_linux.go
+++ b/vpc/tool/cni/namespace_linux.go
@@ -10,12 +10,12 @@ import (
 
 const namespacePath string = "/var/run/pods/"
 
-func getNSAlias(podName string) string {
+func NSAliasPath(podName string) string {
 	return filepath.Join(namespacePath, "netns-"+podName)
 }
 
 func createNetNSAlias(podName string, netnsPath string) error {
-	aliasPath := getNSAlias(podName)
+	aliasPath := NSAliasPath(podName)
 	err := os.Symlink(netnsPath, aliasPath)
 
 	if errors.Is(err, os.ErrNotExist) {
@@ -31,7 +31,7 @@ func createNetNSAlias(podName string, netnsPath string) error {
 }
 
 func deleteNetNSAlias(podName string) error {
-	err := os.Remove(getNSAlias(podName))
+	err := os.Remove(NSAliasPath(podName))
 	if errors.Is(err, os.ErrNotExist) {
 		// No fail if the file is already gone
 		return nil

--- a/vpc/tool/cni/namespace_linux.go
+++ b/vpc/tool/cni/namespace_linux.go
@@ -27,7 +27,7 @@ func createNetNSAlias(podName string, netnsPath string) error {
 		return os.Symlink(netnsPath, aliasPath)
 	}
 
-	return nil
+	return err
 }
 
 func deleteNetNSAlias(podName string) error {

--- a/vpc/tool/cni/namespace_unsupported.go
+++ b/vpc/tool/cni/namespace_unsupported.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package cni
+
+import (
+	"github.com/Netflix/titus-executor/vpc/types"
+)
+
+func createNetNSAlias(podName string, netnsPath string) error {
+	return types.ErrUnsupported
+}
+
+func deleteNetNSAlias(podName string) error {
+	return types.ErrUnsupported
+}

--- a/vpc/tool/cni/namespace_unsupported.go
+++ b/vpc/tool/cni/namespace_unsupported.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Netflix/titus-executor/vpc/types"
 )
 
-func NSAliasPath(podName string) {
+func NSAliasPath(podName string) string {
 	return ""
 }
 

--- a/vpc/tool/cni/namespace_unsupported.go
+++ b/vpc/tool/cni/namespace_unsupported.go
@@ -6,6 +6,10 @@ import (
 	"github.com/Netflix/titus-executor/vpc/types"
 )
 
+func NSAliasPath(podName string) {
+	return ""
+}
+
 func createNetNSAlias(podName string, netnsPath string) error {
 	return types.ErrUnsupported
 }


### PR DESCRIPTION
Detects if we're on a kubelet host and configures titus-logviewer to run in proxy mode.
Uses the CNI created netns aliases to dial into the pod for log viewing.

Depends on #512
Replaces #478