### PR TITLE
Spectatord service

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	ContainerSSHDUsers  cli.StringSlice
 	SSHAccountID        string
 
+	// Do we enable spectator rootless image?
+	ContainerSpectatord      bool
+	ContainerSpectatordImage string
+
 	// CopiedFromHost indicates which environment variables to lift from the current config
 	copiedFromHostEnv cli.StringSlice
 	hardCodedEnv      cli.StringSlice
@@ -200,6 +204,16 @@ func NewConfig() (*Config, []cli.Flag) {
 			Name:        "ssh-account-id",
 			Destination: &cfg.SSHAccountID,
 			EnvVar:      "SSH_ACCOUNT_ID",
+		},
+		cli.BoolFlag{
+			Name:        "container-spectatord",
+			EnvVar:      "CONTAINER_SPECTATORD",
+			Destination: &cfg.ContainerSpectatord,
+		},
+		cli.StringFlag{
+			Name:        "container-spectatord-image",
+			EnvVar:      "SPECTATORD_SERVICE_IMAGE",
+			Destination: &cfg.ContainerSpectatordImage,
 		},
 		cli.StringSliceFlag{
 			Name:  "copied-from-host-env",

--- a/config/config.go
+++ b/config/config.go
@@ -55,8 +55,8 @@ type Config struct {
 	SSHAccountID        string
 
 	// Do we enable spectator rootless image?
-	ContainerSpectatord      bool
-	ContainerSpectatordImage string
+	ContainerSpectatord    bool
+	SpectatordServiceImage string
 
 	// CopiedFromHost indicates which environment variables to lift from the current config
 	copiedFromHostEnv cli.StringSlice
@@ -213,7 +213,7 @@ func NewConfig() (*Config, []cli.Flag) {
 		cli.StringFlag{
 			Name:        "container-spectatord-image",
 			EnvVar:      "SPECTATORD_SERVICE_IMAGE",
-			Destination: &cfg.ContainerSpectatordImage,
+			Destination: &cfg.SpectatordServiceImage,
 		},
 		cli.StringSliceFlag{
 			Name:  "copied-from-host-env",

--- a/executor/runtime/docker/docker_config.go
+++ b/executor/runtime/docker/docker_config.go
@@ -156,7 +156,7 @@ func shouldStartSpectatord(cfg *config.Config, c runtimeTypes.Container) bool {
 		return false
 	}
 
-	if cfg.ContainerSpectatordImage == "" {
+	if cfg.SpectatordServiceImage == "" {
 		return false
 	}
 	return true

--- a/executor/runtime/docker/docker_config.go
+++ b/executor/runtime/docker/docker_config.go
@@ -149,3 +149,23 @@ func shouldStartAbmetrix(cfg *config.Config, c runtimeTypes.Container) bool {
 	return true
 
 }
+
+func shouldStartSpectatord(cfg *config.Config, c runtimeTypes.Container) bool {
+	enabled := cfg.ContainerSpectatord
+	if !enabled {
+		return false
+	}
+
+	if cfg.ContainerSpectatordImage == "" {
+		return false
+	}
+	return true
+}
+
+func shouldStartSSHD(cfg *config.Config, c runtimeTypes.Container) bool {
+	return cfg.ContainerSSHD
+}
+
+func shouldStartLogViewer(cfg *config.Config, c runtimeTypes.Container) bool {
+	return cfg.ContainerLogViewer
+}

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -61,16 +61,18 @@ const (
 
 var systemServices = []serviceOpts{
 	{
+		humanName:    "spectatord",
+		unitName:     "titus-spectatord",
+		enabledCheck: shouldStartSpectatord,
+	},
+	{
 		humanName: "atlas",
 		unitName:  "atlas-titus-agent",
 	},
 	{
-		humanName: "ssh",
-		unitName:  "titus-sshd",
-		required:  true,
-		enabledCheck: func(cfg *config.Config, c runtimeTypes.Container) bool {
-			return cfg.ContainerSSHD
-		},
+		humanName:    "ssh",
+		unitName:     "titus-sshd",
+		enabledCheck: shouldStartSSHD,
 	},
 	{
 		humanName: "metadata proxy",
@@ -85,12 +87,10 @@ var systemServices = []serviceOpts{
 		enabledCheck: shouldStartMetatronSync,
 	},
 	{
-		humanName: "logviewer",
-		unitName:  "titus-logviewer",
-		required:  true,
-		enabledCheck: func(cfg *config.Config, c runtimeTypes.Container) bool {
-			return cfg.ContainerLogViewer
-		},
+		humanName:    "logviewer",
+		unitName:     "titus-logviewer",
+		required:     true,
+		enabledCheck: shouldStartLogViewer,
 	},
 	{
 		humanName:    "service mesh",

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -961,6 +961,7 @@ func (c *TitusInfoContainer) SidecarConfigs() (map[string]*SidecarContainerConfi
 		SidecarServiceMetatron:    c.config.MetatronServiceImage,
 		SidecarServiceServiceMesh: svcMeshImage,
 		SidecarServiceSshd:        c.config.SSHDServiceImage,
+		SidecarServiceSpectatord:  c.config.SpectatordServiceImage,
 	}
 
 	for _, sc := range sideCars {

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -6,6 +6,7 @@ const (
 	SidecarServiceMetatron    = "metatron"
 	SidecarServiceServiceMesh = "servicemesh"
 	SidecarServiceSshd        = "sshd"
+	SidecarServiceSpectatord  = "spectatord"
 )
 
 var sideCars = []SidecarContainerConfig{
@@ -37,6 +38,12 @@ var sideCars = []SidecarContainerConfig{
 		ServiceName: SidecarServiceServiceMesh,
 		Volumes: map[string]struct{}{
 			"/titus/proxyd": {},
+		},
+	},
+	{
+		ServiceName: SidecarServiceSpectatord,
+		Volumes: map[string]struct{}{
+			"/titus/spectatord": {},
 		},
 	},
 }

--- a/root/lib/systemd/system/titus-spectatord@.service
+++ b/root/lib/systemd/system/titus-spectatord@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Spectatord for container %i
+ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
+
+# If the service restarts more than 10 times in 30 seconds, let it die
+StartLimitIntervalSec=30
+StartLimitBurst=10
+
+[Service]
+EnvironmentFile=/var/lib/titus-environments/%i.env
+# Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work
+ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/spectatord/spectatord
+
+Restart=on-failure
+RestartSec=1
+KillMode=mixed


### PR DESCRIPTION
Start injecting spectatord-rootless as a system service, which is a metric proxy required by next generation atlas clients.