### PR TITLE
Make the ssh system sidecar optional

### DIFF
--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -64,15 +64,18 @@ var systemServices = []serviceOpts{
 		humanName:    "spectatord",
 		unitName:     "titus-spectatord",
 		enabledCheck: shouldStartSpectatord,
+		required:     false,
 	},
 	{
 		humanName: "atlas",
 		unitName:  "atlas-titus-agent",
+		required:  false,
 	},
 	{
 		humanName:    "ssh",
 		unitName:     "titus-sshd",
 		enabledCheck: shouldStartSSHD,
+		required:     false,
 	},
 	{
 		humanName: "metadata proxy",
@@ -254,9 +257,12 @@ func startSystemdUnit(ctx context.Context, conn *dbus.Conn, taskID string, cID s
 	select {
 	case <-ctx.Done():
 		doneErr := ctx.Err()
-
 		if doneErr == context.DeadlineExceeded {
-			return errors.Wrapf(doneErr, "timeout starting %s service", opts.humanName)
+			if opts.required {
+				return errors.Wrapf(doneErr, "timeout starting %s service", opts.humanName)
+			}
+			l.Errorf("timeout starting %s service (not required to launch this task)", opts.humanName)
+			return nil
 		}
 		return doneErr
 	case val := <-ch:


### PR DESCRIPTION
The ssh sidecar should be considered optional,
the show must go on if it can't be started for
whatever reason. (weird images, timeouts, who knows)

Additionally, this change makes it so if there is a timeout
starting a sidecar service, and it is not required, then
we continue anyway.