### PR TITLE
Fix entrypoint of spectatord service.

### DIFF
--- a/root/lib/systemd/system/titus-spectatord@.service
+++ b/root/lib/systemd/system/titus-spectatord@.service
@@ -9,7 +9,7 @@ StartLimitBurst=10
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
 # Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work
-ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/spectatord/spectatord
+ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/spectatord/start-spectatord
 
 Restart=on-failure
 RestartSec=1


### PR DESCRIPTION
Specify the correct entry point into the spectatord-rootless container.
