### PR TITLE
Always log the full assumed arn in the titus imds logs

### DIFF
--- a/metadataserver/server.go
+++ b/metadataserver/server.go
@@ -445,6 +445,7 @@ func (ms *MetadataServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"referer":       r.Header.Get("Referer"),
 		"taskid":        ms.titusTaskInstanceID,
 		"source-addr":   r.RemoteAddr,
+		"assumed-arn":   ms.iamProxy.arn,
 	})
 	ms.internalMux.ServeHTTP(w, r2)
 }


### PR DESCRIPTION
Now that we live in a multi-account world, it is useful to log exactly what the imds is trying to do when proxying.

See TITUS-5087 for internal context.