### PR TITLE
Fix the imds local_ipv4 env variable

### DIFF
--- a/cmd/titus-imds-cni/env.go
+++ b/cmd/titus-imds-cni/env.go
@@ -89,10 +89,10 @@ func extractEnv(prev *current.Result, pod *v1.Pod) (map[string]string, error) {
 	for _, ip := range prev.IPs {
 		switch ip.Version {
 		case "4":
-			env[mt.EC2IPv4EnvVarName] = ip.Address.String()
+			env[mt.EC2IPv4EnvVarName] = ip.Address.IP.String()
 			ok = true
 		case "6":
-			env["EC2_IPV6S"] = ip.Address.String()
+			env[mt.EC2IPv6sEnvVarName] = ip.Address.IP.String()
 			ok = true
 		}
 	}


### PR DESCRIPTION
The full ip object includes the CIDR, so things like:

    192.0.2.1/18

Were being written down, latter to be consumed by net.ParseIP,
which doesn't understand that, so it returns nil.

This fix is to always write down on the IP portion (not the mask), so
that it can be parsed correctly later.
