### PR TITLE
Fix accountId in kubelet IMDS instance-identity document

### DIFF
--- a/metadataserver/types/types.go
+++ b/metadataserver/types/types.go
@@ -16,6 +16,7 @@ const (
 	EC2PublicIPv4EnvVarName   = "EC2_PUBLIC_IPV4"
 	EC2PublicIPv4sEnvVarName  = "EC2_PUBLIC_IPV4S"
 	EC2IPv6sEnvVarName        = "EC2_IPV6S"
+	NetflixAccountIDVarName   = "NETFLIX_ACCOUNT_ID"
 )
 
 // MetadataServerConfiguration is a configuration for metadata service + IAM Proxy


### PR DESCRIPTION
The NETFLIX_ACCOUNT_ID is set by TJC, we can't use whatever it is
set to on the agent (could be any crazy account ID).

The IMDS uses this when it returns data for

    curl http://169.254.169.254/latest/dynamic/instance-identity/document

Previously this was unset, causing `accountId` to be the empty string.
With this change it will show the account ID set to whatever is set
in the main container's environment.