### PR TITLE
Added new seccomp agent capability for intercepting net syscalls

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -978,6 +978,11 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context) error { // nolint: go
 				"TITUS_SECCOMP_AGENT_HANDLE_PERF_SYSCALLS": "true",
 			})
 		}
+		if r.c.SeccompAgentEnabledForPerfSyscalls() {
+			r.c.SetEnvs(map[string]string{
+				"TITUS_SECCOMP_AGENT_HANDLE_NET_SYSCALLS": "true",
+			})
+		}
 	}
 
 	if r.cfg.UseNewNetworkDriver {

--- a/executor/runtime/docker/docker_config.go
+++ b/executor/runtime/docker/docker_config.go
@@ -134,8 +134,7 @@ func shouldStartMetatronSync(cfg *config.Config, c runtimeTypes.Container) bool 
 }
 
 func shouldStartTitusSeccompAgent(cfg *config.Config, c runtimeTypes.Container) bool {
-	// Starting off with just perf, but there will be more in the future
-	return c.SeccompAgentEnabledForPerfSyscalls()
+	return c.SeccompAgentEnabledForPerfSyscalls() || c.SeccompAgentEnabledForNetSyscalls()
 }
 
 func shouldStartServiceMesh(cfg *config.Config, c runtimeTypes.Container) bool {

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -54,6 +54,7 @@ const (
 	LogKeepLocalFileAfterUploadParam        = "titusParameter.agent.log.keepLocalFileAfterUpload"
 	FuseEnabledParam                        = "titusParameter.agent.fuseEnabled"
 	KvmEnabledParam                         = "titusParameter.agent.kvmEnabled"
+	SeccompAgentEnabledForNetSyscallsParam  = "titusParameter.agent.seccompAgentEnabledForNetSyscalls"
 	SeccompAgentEnabledForPerfSyscallsParam = "titusParameter.agent.seccompAgentEnabledForPerfSyscalls"
 	assignIPv6AddressParam                  = "titusParameter.agent.assignIPv6Address"
 	batchPriorityParam                      = "titusParameter.agent.batchPriority"
@@ -161,6 +162,7 @@ type TitusInfoContainer struct {
 	// KvmEnabled determines whether the container has KVM exposed to it
 	kvmEnabled                         bool
 	requireIMDSToken                   string
+	seccompAgentEnabledForNetSyscalls  bool
 	seccompAgentEnabledForPerfSyscalls bool
 	serviceMeshEnabled                 *bool
 	serviceMeshImage                   string
@@ -301,6 +303,10 @@ func NewContainerWithPod(taskID string, titusInfo *titus.ContainerInfo, resource
 		{
 			paramName:     KvmEnabledParam,
 			containerAttr: &c.kvmEnabled,
+		},
+		{
+			paramName:     SeccompAgentEnabledForNetSyscallsParam,
+			containerAttr: &c.seccompAgentEnabledForNetSyscalls,
 		},
 		{
 			paramName:     SeccompAgentEnabledForPerfSyscallsParam,
@@ -879,6 +885,10 @@ func (c *TitusInfoContainer) Runtime() string {
 
 func (c *TitusInfoContainer) SeccompAgentEnabledForPerfSyscalls() bool {
 	return c.seccompAgentEnabledForPerfSyscalls
+}
+
+func (c *TitusInfoContainer) SeccompAgentEnabledForNetSyscalls() bool {
+	return c.seccompAgentEnabledForNetSyscalls
 }
 
 func (c *TitusInfoContainer) SecurityGroupIDs() *[]string {

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -247,6 +247,10 @@ func (c *PodContainer) Runtime() string {
 	return ""
 }
 
+func (c *PodContainer) SeccompAgentEnabledForNetSyscalls() bool {
+	return false
+}
+
 func (c *PodContainer) SeccompAgentEnabledForPerfSyscalls() bool {
 	return false
 }

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -158,6 +158,7 @@ type Container interface {
 	Resources() *Resources
 	RequireIMDSToken() *string
 	Runtime() string
+	SeccompAgentEnabledForNetSyscalls() bool
 	SeccompAgentEnabledForPerfSyscalls() bool
 	SecurityGroupIDs() *[]string
 	ServiceMeshEnabled() bool

--- a/root/lib/systemd/system/titus-seccomp-agent@.service
+++ b/root/lib/systemd/system/titus-seccomp-agent@.service
@@ -5,6 +5,7 @@ StartLimitIntervalSec=30
 StartLimitBurst=10
 
 [Service]
+Type=notify
 EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/usr/bin/tsa
 


### PR DESCRIPTION
This adds the next bool for configuring TSA to intercept network calls.

A different update will come later for `tini` to interpret this variable and apply the right seccomp filter.

Eventually some higher-level control will set "ipv6-only" or something, which will in turn set this parameter so that TSA can handle ipv4 calls for tasks, but that can come later when we interact with the vpc service.