### PR TITLE
WIP: titus-storage system service with ebs support

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -980,6 +980,13 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context) error { // nolint: go
 		}
 	}
 
+	if shouldStartTitusStorage(&r.cfg, r.c) {
+		// KYLE figure out how to... get this from the taskContext?
+		r.c.SetEnvs(map[string]string{
+			"TITUS_EBS_VOLUME_ID": "vol-0cc20fbab97755b62",
+		})
+	}
+
 	if r.cfg.UseNewNetworkDriver {
 		group.Go(func(ctx context.Context) error {
 			prepareNetworkStartTime := time.Now()

--- a/executor/runtime/docker/docker_config.go
+++ b/executor/runtime/docker/docker_config.go
@@ -138,6 +138,12 @@ func shouldStartTitusSeccompAgent(cfg *config.Config, c runtimeTypes.Container) 
 	return c.SeccompAgentEnabledForPerfSyscalls()
 }
 
+func shouldStartTitusStorage(cfg *config.Config, c runtimeTypes.Container) bool {
+	// KYLE
+	
+	return *c.JobID() == "8b2a60ce-74fe-404a-9598-c097f1002e22"
+}
+
 func shouldStartServiceMesh(cfg *config.Config, c runtimeTypes.Container) bool {
 	return c.ServiceMeshEnabled()
 }

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -113,6 +113,12 @@ var systemServices = []serviceOpts{
 		required:     true,
 		enabledCheck: shouldStartTitusSeccompAgent,
 	},
+	{
+		humanName:    "storage",
+		unitName:     "titus-storage",
+		required:     true,
+		enabledCheck: shouldStartTitusStorage,
+	},
 }
 
 func getPeerInfo(unixConn *net.UnixConn) (ucred, error) {

--- a/mount.xfs/Makefile
+++ b/mount.xfs/Makefile
@@ -1,0 +1,2 @@
+titus-mount.xfs: mount.c scm_rights.c
+	gcc -std=gnu11 -Wall -static -g -o titus-mount.xfs mount.c scm_rights.c

--- a/mount.xfs/mount.c
+++ b/mount.xfs/mount.c
@@ -1,0 +1,257 @@
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+/* getaddrinfo */
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <string.h>
+/* setns */
+#include <sched.h>
+/* for mount syscalls */
+#include <asm-generic/unistd.h>
+#include <linux/mount.h>
+/* fcntl */
+#include <unistd.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <sys/wait.h>
+#include "scm_rights.h"
+/* mkdir */
+#include <sys/stat.h>
+
+#define E(x) do { if ((x) == -1) { perror(#x); exit(1); } } while(0)
+
+static void check_messages(int fd)
+{
+	char buf[4096];
+	int err, n;
+	err = errno;
+	for (;;) {
+		n = read(fd, buf, sizeof(buf));
+		if (n < 0)
+			break;
+		n -= 2;
+		switch (buf[0]) {
+		case 'e':
+			fprintf(stderr, "Error: %*.*s\n", n, n, buf + 2);
+			break;
+		case 'w':
+			fprintf(stderr, "Warning: %*.*s\n", n, n, buf + 2);
+			break;
+		case 'i':
+			fprintf(stderr, "Info: %*.*s\n", n, n, buf + 2);
+			break;
+		}
+	}
+	errno = err;
+}
+
+static __attribute__((noreturn))
+void mount_error(int fd, const char *s)
+{
+	check_messages(fd);
+	fprintf(stderr, "titus-mount mount error on '%s': %m\n", s);
+	exit(1);
+}
+
+static inline int pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(__NR_pidfd_open, pid, flags);
+}
+
+static inline int fsopen(const char *fs_name, unsigned int flags)
+{
+	return syscall(__NR_fsopen, fs_name, flags);
+}
+
+static inline int fsmount(int fsfd, unsigned int flags, unsigned int ms_flags)
+{
+	return syscall(__NR_fsmount, fsfd, flags, ms_flags);
+}
+
+static inline int fsconfig(int fsfd, unsigned int cmd,
+			   const char *key, const void *val, int aux)
+{
+	return syscall(__NR_fsconfig, fsfd, cmd, key, val, aux);
+}
+
+static inline int move_mount(int from_dfd, const char *from_pathname,
+			     int to_dfd, const char *to_pathname,
+			     unsigned int flags)
+{
+	return syscall(__NR_move_mount,
+		       from_dfd, from_pathname,
+		       to_dfd, to_pathname, flags);
+}
+
+#define E_fsconfig(fd, cmd, key, val, aux)                              \
+        do {                                                            \
+                if (fsconfig(fd, cmd, key, val, aux) == -1)             \
+                        mount_error(fd, key ?: "create");               \
+        } while (0)
+
+
+static void process_option(char* option, int fsfd) {
+	/* Splits up a k=v string and runs fsconfig on it.
+           We supply all the inputs here, so it is safe, but parsing things
+           like this is a little dangerous */
+	char *key, *value, *saveptr;
+	key = strtok_r (option, "=", &saveptr);
+	option = NULL;
+	value = strtok_r (option, "=", &saveptr);
+	fprintf(stderr, "titus-mount: Setting filesystem mount option %s=%s\n", key, value);
+	E_fsconfig(fsfd, FSCONFIG_SET_STRING, key, value, 0);
+}
+
+static void do_fsconfigs(int fsfd, char *options) {
+	char *str1, *token, *saveptr;
+	/* Mount options come in in the classic comma-separated key=value pairs
+	   we need to split them up and pass them in for fsconfig to handle one at a time */
+	for (str1 = options; ;str1 = NULL) {
+		token = strtok_r(str1, ",", &saveptr);
+		if (token == NULL)
+			break;
+		process_option(token, fsfd);
+	}
+	/* This last FSCONFIG_CMD_CREATE fsconfig call actually creates the superblock */
+	E_fsconfig(fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0);
+}
+
+
+static int setup_fsfd_in_namespaces(int sk, int pidfd) {
+	int fsfd, ret;
+	ret = setns(pidfd, CLONE_NEWUSER);
+	if (ret == -1) {
+		perror("setns user");
+		return 1;
+	}
+	ret = setns(pidfd, CLONE_NEWNET);
+	if (ret == -1) {
+		perror("setns net");
+		return 1;
+	}
+	ret = setns(pidfd, CLONE_NEWNS);
+	if (ret == -1) {
+		perror("setns mnt");
+		return 1;
+	}
+	fsfd = fsopen("xfs", 0);
+	if (fsfd == -1) {
+		perror("fsopen");
+		return 1;
+	}
+	assert(send_fd(sk, fsfd) == 0);
+	return 0;
+}
+
+static int fork_and_get_fsfd(long int pidfd) {
+	int  sk_pair[2], ret, fsfd, status;
+	pid_t worker;
+
+	if (socketpair(PF_LOCAL, SOCK_SEQPACKET, 0, sk_pair) < 0) {
+		perror("socketpair");
+		exit(1);
+	}
+	worker = fork();
+	if (worker < 0) {
+		perror("fork");
+		exit(1);
+	}
+	if (worker == 0) {
+		close(sk_pair[0]);
+		ret = setup_fsfd_in_namespaces(sk_pair[1], pidfd);
+		close(sk_pair[1]);
+		exit(ret);
+	}
+	close(sk_pair[1]);
+	fsfd = recv_fd(sk_pair[0]);
+	assert(fsfd >= 0);
+	if (waitpid(worker, &status, 0) != worker) {
+		perror("waitpid");
+		exit(1);
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status)) {
+		fprintf(stderr, "worker exited nonzero\n");
+		exit(1);
+	}
+	close(sk_pair[0]);
+	return fsfd;
+}
+
+static void switch_namespaces(int pidfd) {
+	int ret;
+	ret = setns(pidfd, CLONE_NEWNET | CLONE_NEWNS);
+	if (ret == -1) {
+		perror("setns net / mount");
+		exit(1);
+	}
+}
+
+static void mount_and_move(int fsfd, const char* target, int pidfd, unsigned long flags) {
+	int mfd = fsmount(fsfd, 0, flags);
+	if (mfd < 0) {
+		mount_error(fsfd, "fsmount");
+		E(close(fsfd));
+	}
+	E(move_mount(mfd, "", AT_FDCWD, target, MOVE_MOUNT_F_EMPTY_PATH));
+	E(close(mfd));
+}
+
+int main(int argc, char *argv[]) {
+	int pidfd, fsfd;
+	long int container_pid;
+	unsigned long flags_ul;
+	/*
+	 * We do this because parsing args is a bigger pain than passing
+	 * via environment variable, although passing via environment
+	 * variable has a "cost" in that they are limited in size
+	 */
+	const char *target = getenv("MOUNT_TARGET");
+	const char *flags = getenv("MOUNT_FLAGS");
+	const char *options = getenv("MOUNT_OPTIONS");
+
+	if (argc != 2) {
+		printf("Usage: %s container_pid", argv[0]);
+		return 1;
+	}
+	errno = 0;
+	container_pid = strtol(argv[1], NULL, 10);
+	assert(errno == 0);
+
+	int buf_size = sysconf(_SC_PAGESIZE);
+	char final_options [buf_size];
+	strcpy(final_options, options);
+
+	if (!(target && flags && options)) {
+		fprintf(stderr, "Usage: must provide MOUNT_TARGET, MOUNT_FLAGS, and MOUNT_OPTIONS env vars");
+		return 1;
+	}
+
+	errno = 0;
+	flags_ul = strtoul(flags, NULL, 10);
+	if (errno) {
+		perror("flags");
+		return 1;
+	}
+	pidfd = pidfd_open(container_pid, 0);
+	if (pidfd == -1) {
+		perror("pidfd_open");
+		return 1;
+	}
+
+	/* First we need to get a fsfd, but it must be created inside the user namespace */
+	fsfd = fork_and_get_fsfd(pidfd);
+
+	/* Now we can switch net/mount namespaces so we can lookup the ip and eventually mount */
+	fprintf(stderr, "titus-mount: user-inputed options: %s\n", options);
+
+	/* Now we can do the fs_config calls and actual mount */
+	do_fsconfigs(fsfd, options);
+	switch_namespaces(pidfd);
+	mkdir(target, 0777);
+	mount_and_move(fsfd, target, pidfd, flags_ul);
+
+	fprintf(stderr, "titus-mount: All done, mounted on %s\n", target);
+	return 0;
+}

--- a/mount.xfs/scm_rights.c
+++ b/mount.xfs/scm_rights.c
@@ -1,0 +1,54 @@
+#define _GNU_SOURCE
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include "scm_rights.h"
+
+int send_fd(int sock, int fd)
+{
+	struct msghdr msg = {};
+	struct cmsghdr *cmsg;
+	char buf[CMSG_SPACE(sizeof(int))] = {0}, c = 'c';
+	struct iovec io = {
+		.iov_base = &c,
+		.iov_len = 1,
+	};
+	msg.msg_iov = &io;
+	msg.msg_iovlen = 1;
+	msg.msg_control = buf;
+	msg.msg_controllen = sizeof(buf);
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	*((int *)CMSG_DATA(cmsg)) = fd;
+	msg.msg_controllen = cmsg->cmsg_len;
+	if (sendmsg(sock, &msg, 0) < 0) {
+		perror("sendmsg");
+		return -1;
+	}
+	return 0;
+}
+
+int recv_fd(int sock)
+{
+	struct msghdr msg = {};
+	struct cmsghdr *cmsg;
+	char buf[CMSG_SPACE(sizeof(int))] = {0}, c = 'c';
+	struct iovec io = {
+		.iov_base = &c,
+		.iov_len = 1,
+	};
+	msg.msg_iov = &io;
+	msg.msg_iovlen = 1;
+	msg.msg_control = buf;
+	msg.msg_controllen = sizeof(buf);
+	if (recvmsg(sock, &msg, 0) < 0) {
+		perror("recvmsg");
+		return -1;
+	}
+	cmsg = CMSG_FIRSTHDR(&msg);
+	return *((int *)CMSG_DATA(cmsg));
+}

--- a/mount.xfs/scm_rights.h
+++ b/mount.xfs/scm_rights.h
@@ -1,0 +1,2 @@
+int send_fd(int sock, int fd);
+int recv_fd(int sock);

--- a/root/apps/titus-executor/bin/titus-storage
+++ b/root/apps/titus-executor/bin/titus-storage
@@ -1,0 +1,99 @@
+#!/bin/bash
+echo "Got called to manage external storage for $TITUS_TASK_ID"
+TASK_PID1=$(grep Pid: $TITUS_PID_1_DIR/status | awk '{print $2}' | head -n1)
+
+if [[ -z $TITUS_EBS_VOLUME_ID ]]; then
+  echo "No TITUS_EBS_VOLUME_ID in the env. Is this task supposed to mount something?"
+  exit 0
+fi
+
+echo "Grabbing a lock on /tmp/$TITUS_EBS_VOLUME_ID.lock"
+
+# TODO? Does this make a difference?
+export EBS_ROOT_DEVICE=/dev/sdz
+
+function mount_it {
+  # TODO: not use temp path
+  MOUNT_TARGET=/efs MOUNT_OPTIONS="source=$1" MOUNT_FLAGS="0" /home/nfsuper/mount.xfs/titus-mount.xfs $TASK_PID1
+}
+
+function attach_ebs {
+  retry_count=30
+  attachment_state=$(aws ec2 describe-volumes --region us-east-1 --volume-id ${TITUS_EBS_VOLUME_ID} | jq '.Volumes[0].Attachments[0].State')
+  
+  echo "Attaching volume ${TITUS_EBS_VOLUME_ID}" >&2
+  aws ec2 attach-volume \
+      --region $EC2_REGION \
+      --device $EBS_ROOT_DEVICE \
+      --instance-id $EC2_INSTANCE_ID \
+      --volume-id $TITUS_EBS_VOLUME_ID
+  if [[ $? -ne 0 ]] && [[ "${attachment_state}" != "\"attached\"" ]]; then
+    echo "Would exit 1"
+  fi
+
+  while [[ "${attachment_state}" != "\"attached\"" ]] && [[ ${retry_count} -gt 0 ]]; do
+    echo "Waiting for attach of volume: ${TITUS_EBS_VOLUME_ID}, attachment_state: ${attachment_state} retry count: ${retry_count}" >&2
+    attachment_state=$(aws ec2 describe-volumes --region us-east-1 --volume-id ${TITUS_EBS_VOLUME_ID} | jq '.Volumes[0].Attachments[0].State')
+    retry_count=$((retry_count-1))
+    sleep 1
+  done
+  
+  root_vol_id_trunc=${TITUS_EBS_VOLUME_ID//-}
+  
+  # Successfully attached volume
+  if [[ ${retry_count} -gt 0 ]] ; then
+    # Find out where it was attached
+    for dev_path in $(find /dev/nvme*n*)
+    do
+      #sn      : vol0f6d39b95dd9cbc8b
+      row=$(nvme id-ctrl -v ${dev_path} | sed -n 4p)
+      row_array=($row)
+  
+      # vol0f6d39b95dd9cbc8b
+      vol_id_trunc=${row_array[2]}
+  
+      if [[ "$vol_id_trunc" = "$root_vol_id_trunc" ]] ; then
+        echo EBS_DEVICE_PATH=${dev_path} >> /var/lib/titus-environments/${TITUS_TASK_ID}.env
+	echo ${dev_path}
+	mount_it ${dev_path}
+        return
+      fi
+    done
+  fi
+
+  echo "Failed to attach $TITUS_EBS_VOLUME_ID. Exiting 1"
+  exit 1
+}
+
+function detach_ebs {
+  retry_count=30
+  attachment_state=$(aws ec2 describe-volumes --region us-east-1 --volume-id ${TITUS_EBS_VOLUME_ID} | jq '.Volumes[0].Attachments[0].State')
+  
+  if [[ "$attachment_state" != "null" ]] ; then
+    echo "Detaching volume ${TITUS_EBS_VOLUME_ID}"
+    aws ec2 detach-volume \
+        --region $EC2_REGION \
+        --volume-id $TITUS_EBS_VOLUME_ID
+  fi
+  
+  while [[ "${attachment_state}" != "null" ]] && [[ ${retry_count} -gt 0 ]]; do
+    echo "Waiting for detach of volume: ${TITUS_EBS_VOLUME_ID}, attachment_state: ${attachment_state} retry count: ${retry_count}"
+    attachment_state=$(aws ec2 describe-volumes --region us-east-1 --volume-id ${TITUS_EBS_VOLUME_ID} | jq '.Volumes[0].Attachments[0].State')
+    retry_count=$((retry_count-1))
+    sleep 1
+  done
+}
+
+(
+  echo "Grabbing a lock on /tmp/$TITUS_EBS_VOLUME_ID.lock for Task $TITUS_TASK_ID..."
+  flock -w 240 -s 200
+echo "Would mount $TITUS_EBS_VOLUME_ID"
+systemd-notify --status="Attaching $TITUS_EBS_VOLUME_ID..."
+attach_ebs
+systemd-notify --ready --status="Attached and mounted $TITUS_EBS_VOLUME_ID. Waiting for task to finish."
+echo "Waiting for $TASK_PID1 to finish before detatching"
+tail --pid=$TASK_PID1 -f /dev/null
+echo "Ok done. Now would detach"
+detach_ebs
+) 200>/tmp/$TITUS_EBS_VOLUME_ID.lock
+exit 0

--- a/root/lib/systemd/system/titus-storage@.service
+++ b/root/lib/systemd/system/titus-storage@.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Storage mounting for task %s
+ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
+
+# If the service restarts more than 10 times in 30 seconds, let it die
+StartLimitIntervalSec=30
+StartLimitBurst=10
+
+[Service]
+Type=notify
+NotifyAccess=all
+Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
+EnvironmentFile=/var/lib/titus-environments/%i.env
+ExecStart=/apps/titus-executor/bin/titus-storage
+LimitNOFILE=65535
+## TODO: Wire up more "lockdown" so this unit can't wreck havoc if it gets compromised
+PrivateTmp=yes
+
+KillMode=mixed
+
+# TODO: Setup Memory / CPU / PID limits since this isn't running under the same cgroup
+# as the PID, and a bad user could wipe out the host.


### PR DESCRIPTION
This adds a new system sidecar: `titus-storage`.
The goal of this sidecar is to mount all external storage,
ebs to start, and nfs later (or if you want I can do nfs first?).

I think there could be few nice things about doing it this way:

* Long term could be externalized into a "true" external sidecar
* Way easier to troubleshoot / debug (it is a systemd unit, not an
  internal titus-executor thing)

Some downsides:

* Being external to the titus-executor codebase, most of our message
  passing comes via environment variables (Hard to do N ebs mounts?)
* I don't know what to think of having multiple mount binaries, but
  same deal, could be externalized to other teams some day
* This system service *must* wait, otherwise there isn't a good
  way for it to "stop" and detach.
* All attach/detach is happening client side, not centrally orchestrated
  like the aws-ebs-csi driver.

This POC is in bash because a lot of bash code existing already.
For production I would rewrite it in golang, with real error codes
and not having to "tail" to wait for a pid.

Also in this POC I'm hard-coding the volume ID. I'll need to get that
from the task context somehow. Also somehow I need to extract
mount, rw, etc preferences. 
