### PR TITLE
Allow Tini to intercept networking system calls

### DIFF
--- a/tini/CMakeLists.txt
+++ b/tini/CMakeLists.txt
@@ -64,8 +64,8 @@ target_link_libraries(seccomp-fd-notify cap)
 
 add_executable (tini-static src/tini.c src/seccomp_fd_notify.c)
 target_link_libraries(tini-static seccomp-fd-notify cap -static)
-TARGET_LINK_LIBRARIES (tini  ${CMAKE_THREAD_LIBS_INIT} )
-TARGET_LINK_LIBRARIES (tini-static  ${CMAKE_THREAD_LIBS_INIT} )
+target_link_libraries (tini  ${CMAKE_THREAD_LIBS_INIT} )
+target_link_libraries (tini-static  ${CMAKE_THREAD_LIBS_INIT} )
 set_target_properties (tini-static PROPERTIES LINK_FLAGS "-Wl,--no-export-dynamic -static")
 
 # Installation

--- a/tini/CMakeLists.txt
+++ b/tini/CMakeLists.txt
@@ -55,7 +55,7 @@ configure_file (
 
 
 include_directories ("${PROJECT_BINARY_DIR}")
-
+find_package (Threads REQUIRED)
 add_executable (tini src/tini.c src/seccomp_fd_notify.c)
 target_link_libraries(tini seccomp-fd-notify cap)
 
@@ -64,6 +64,9 @@ target_link_libraries(seccomp-fd-notify cap)
 
 add_executable (tini-static src/tini.c src/seccomp_fd_notify.c)
 target_link_libraries(tini-static seccomp-fd-notify cap -static)
+TARGET_LINK_LIBRARIES (tini  ${CMAKE_THREAD_LIBS_INIT} )
+TARGET_LINK_LIBRARIES (tini-static  ${CMAKE_THREAD_LIBS_INIT} )
+set_target_properties (tini-static PROPERTIES LINK_FLAGS "-Wl,--no-export-dynamic -static")
 
 # Installation
 install (TARGETS tini DESTINATION bin)

--- a/tini/src/seccomp_fd_notify.c
+++ b/tini/src/seccomp_fd_notify.c
@@ -183,10 +183,6 @@ struct sock_filter net_perf_filter[] = {
 		return -1;
 	}
 
-	/* Setting up permissions to issue seccomp system call */
-	if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
-		PRINT_WARNING("Failed to setup priveleges before calling seccomp")
-	}
 	/* Install the filter with the SECCOMP_FILTER_FLAG_NEW_LISTENER flag; as
 	   a result, seccomp() returns a notification file descriptor. */
 

--- a/tini/src/seccomp_fd_notify.c
+++ b/tini/src/seccomp_fd_notify.c
@@ -293,9 +293,11 @@ void * catch_send_fd(void *fd_arg)
 		
 		if (evlist[0].events & EPOLLHUP) {
 			/* Client has exited */
-			printf("Client termination notification");
 			char buf[16];
-			read(evlist[0].data.fd, buf, 16);
+			int r =  read(evlist[0].data.fd, buf, 16);
+			if (r < 0) {
+				PRINT_INFO("Client exited, draining notification, removing notify fd");
+			}
 			if (epoll_ctl(epfd, EPOLL_CTL_DEL, notify_fd, &ev) !=
 			    0) {
 				perror("Could not epoll_del the notifyfd\n");

--- a/tini/src/seccomp_fd_notify.c
+++ b/tini/src/seccomp_fd_notify.c
@@ -24,8 +24,9 @@
 #include <sys/ioctl.h>  
 #include <linux/seccomp.h>
 #include <linux/filter.h>
-
+#include <stddef.h>
 #include "seccomp_fd_notify.h"
+
 #define MAX_EVENTS 16
 #define EPOLL_IGNORED_VAL 3
 

--- a/tini/src/seccomp_fd_notify.c
+++ b/tini/src/seccomp_fd_notify.c
@@ -10,6 +10,7 @@
 #include <linux/filter.h>
 #include <linux/perf_event.h>
 #include <linux/seccomp.h>
+#include <sys/syscall.h>
 #include <stddef.h>
 #include <sys/capability.h>
 #include <sys/ioctl.h>
@@ -17,9 +18,16 @@
 
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <sys/xattr.h>
+
+#include <pthread.h>
+#include <sys/epoll.h>
+#include <sys/ioctl.h>  
+#include <linux/seccomp.h>
+#include <linux/filter.h>
 
 #include "seccomp_fd_notify.h"
+#define MAX_EVENTS 16
+#define EPOLL_IGNORED_VAL 3
 
 #define PRINT_WARNING(...)                                                     \
 	{                                                                      \
@@ -86,14 +94,12 @@ static int seccomp(unsigned int operation, unsigned int flags, void *args)
    filter allows all other system calls.
 
    The function return value is a file descriptor from which the user-space
-   notifications can be fetched. */
-static int install_notify_filter(void)
-{
-	/* If you are debugging this, sometimes it is helpful to inspect what a filter
-	actually is, live on a process. Try using this on a container:
-	sudo seccomp-tools dump  -l2 -p $pid # where pid is tini
-	and seccomp-tools is https://github.com/david942j/seccomp-tools */
-	struct sock_filter filter[] = {
+   notifications can be fetched. 
+*/
+static int install_notify_filter(void) {
+	struct sock_fprog prog = {0};
+	
+	struct sock_filter perf_filter[] = {
 		/* X86_64_CHECK_ARCH_AND_LOAD_SYSCALL_NR */
 		BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
 			 (offsetof(struct seccomp_data, arch))),
@@ -123,9 +129,27 @@ static int install_notify_filter(void)
 		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
 	};
 
-	struct sock_fprog prog = {
-		.len = (unsigned short)(sizeof(filter) / sizeof(filter[0])),
-		.filter = filter,
+struct sock_filter net_perf_filter[] = {
+		/* X86_64_CHECK_ARCH_AND_LOAD_SYSCALL_NR */
+		BPF_STMT(BPF_LD | BPF_W | BPF_ABS, (offsetof(struct seccomp_data, arch))),
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, AUDIT_ARCH_X86_64, 0, 2),
+		BPF_STMT(BPF_LD | BPF_W | BPF_ABS, (offsetof(struct seccomp_data, nr))),
+		BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, X32_SYSCALL_BIT, 0, 1),
+		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+
+		/* Trap sendto */
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_sendto, 0, 1),
+		BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_USER_NOTIF),
+		/* Trap sendmsg */
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_sendmsg, 0, 1),
+		BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_USER_NOTIF),
+		/* Trap connect */
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_connect, 0, 1),
+		BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_USER_NOTIF),
+
+
+		/* Every other system call is allowed */
+		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
 	};
 
 	/* If we don't have CAP_SYSADMIN, we MUST set NO_NEW_PRIVS.
@@ -141,6 +165,19 @@ static int install_notify_filter(void)
 		}
 	}
 
+	char *is_handle_net = getenv("TITUS_SECCOMP_AGENT_HANDLE_NET_SYSCALLS");
+	if (is_handle_net != NULL) {
+		prog.filter = net_perf_filter;
+		prog.len = 
+			(unsigned short)(sizeof(net_perf_filter) / sizeof(net_perf_filter[0]));
+		PRINT_INFO("Networking system calls will be intercepted");
+	} else {
+		prog.filter = perf_filter;
+		prog.len = 
+			(unsigned short)(sizeof(perf_filter) / sizeof(perf_filter[0]));
+		PRINT_INFO("BPF/Perf system calls will be intercepted");
+	}
+
 	/* Install the filter with the SECCOMP_FILTER_FLAG_NEW_LISTENER flag; as
 	   a result, seccomp() returns a notification file descriptor. */
 
@@ -154,12 +191,139 @@ static int install_notify_filter(void)
 			      strerror(errno));
 		return -1;
 	}
+	
 	return notify_fd;
 }
 
-void maybe_setup_seccomp_notifer()
+void set_seccomp_response_to_continue(struct seccomp_notif *req,
+				      struct seccomp_notif_resp *resp)
 {
+	resp->id = req->id;
+	resp->val = 0;
+	resp->flags = SECCOMP_USER_NOTIF_FLAG_CONTINUE;
+	resp->error = 0;
+}
+
+void respond_to_seccomp_client(int notify_fd, struct seccomp_notif_resp *resp)
+{
+	if (ioctl(notify_fd, SECCOMP_IOCTL_NOTIF_SEND, resp) == -1) {
+		if (errno == ENOENT) {
+			printf(
+				"response failed with ENOENT; perhaps target "
+				"process's syscall was interrupted by signal?");
+		} else {
+			perror("ioctl-SECCOMP_IOCTL_NOTIF_SEND");
+		}
+	}
+}
+
+void * catch_send_fd(void *fd_arg)
+{
+	struct seccomp_notif *req;
+	struct seccomp_notif_resp *resp;
+	struct seccomp_notif_sizes sizes;
+	struct epoll_event ev;
+	struct epoll_event evlist[MAX_EVENTS];
+	int epfd = -1, ready = 0;
+	int set_break = 0;
+	int notify_fd = *(int *)fd_arg;
+
+	if (seccomp(SECCOMP_GET_NOTIF_SIZES, 0, &sizes) == -1) {
+        PRINT_WARNING("seccomp-SECCOMP_GET_NOTIF_SIZES not available?");
+		return NULL;
+	}
+	
+	req = malloc(sizes.seccomp_notif);
+	if (req == NULL) {
+		PRINT_WARNING("malloc req error!");
+		return NULL;
+	}
+
+	resp = malloc(sizes.seccomp_notif_resp);
+	if (resp == NULL) {
+		PRINT_WARNING("malloc resp error!");
+		return NULL;
+	}
+
+	epfd = epoll_create(EPOLL_IGNORED_VAL);
+	if (epfd == -1) {
+		PRINT_WARNING("epoll_create error");
+		return NULL;
+	}
+	ev.events = EPOLLIN;
+	ev.data.fd = notify_fd;
+	if (epoll_ctl(epfd, EPOLL_CTL_ADD, notify_fd, &ev) == -1) {
+		perror("epoll_ctl");
+		PRINT_WARNING("Unexpected error in adding notify_fd to epoll watch");
+		return NULL;
+	}
+	PRINT_INFO("Listening to networking syscall notifications on %d..", notify_fd);
+
+	for (;;) {
+		/* Wait for next notification, returning info in '*req' */
+		memset(req, 0, sizeof(*req));
+		memset(resp, 0, sizeof(*resp));
+		pthread_mutex_lock(&wait_to_send);
+		send_notify_fd = 1;
+		pthread_cond_signal(&ready_to_send);
+		pthread_mutex_unlock(&wait_to_send);
+		ready = epoll_wait(epfd, evlist, MAX_EVENTS, -1);
+		if (ready == -1) {
+			if (errno == EINTR)
+				continue; /* Restart if interrupted by signal */
+			else {
+				perror("epoll_wait");
+				PRINT_WARNING("epoll_wait error");
+				return NULL;
+			}
+		}
+		PRINT_INFO("  fd=%d; events: %s%s%s", evlist[0].data.fd,
+			    (evlist[0].events & EPOLLIN) ? "EPOLLIN " : "",
+			    (evlist[0].events & EPOLLHUP) ? "EPOLLHUP " : "",
+			    (evlist[0].events & EPOLLERR) ? "EPOLLERR " : "");
+
+		if (evlist[0].events & EPOLLIN) {
+			if (ioctl(evlist[0].data.fd, SECCOMP_IOCTL_NOTIF_RECV,
+				  req) == -1) {
+				PRINT_WARNING(
+					"ioctl SECCOMP_IOCTL_NOTIF_RECV error");
+				return NULL;
+			}
+		}
+		
+		if (evlist[0].events & EPOLLHUP) {
+			/* Client has exited */
+			printf("Client termination notification");
+			char buf[16];
+			read(evlist[0].data.fd, buf, 16);
+			if (epoll_ctl(epfd, EPOLL_CTL_DEL, notify_fd, &ev) !=
+			    0) {
+				perror("Could not epoll_del the notifyfd\n");
+			} else {
+				PRINT_INFO("Removed the notify_fd of client");
+			}
+			return NULL;
+		}
+		if (req->data.nr == __NR_sendmsg) {
+			PRINT_INFO("Intercepted sendmsg - passthrough!\n");
+			set_break = 1;
+		} else {
+			PRINT_INFO("Intercepted syscall %d - passthrough!\n", req->data.nr);
+		}
+		set_seccomp_response_to_continue(req, resp);
+		respond_to_seccomp_client(notify_fd, resp);
+		if (set_break) {
+			break;
+		}
+	}
+	PRINT_INFO("Stopped polling notifyfd = %d!", notify_fd);
+	return NULL;
+}
+
+void maybe_setup_seccomp_notifer() {
 	char *socket_path;
+	pthread_t thread_id;
+
 	socket_path = getenv(TITUS_SECCOMP_NOTIFY_SOCK_PATH);
 	if (socket_path) {
 		int sock_fd = -1;
@@ -207,6 +371,16 @@ void maybe_setup_seccomp_notifer()
 
 		int notify_fd = -1;
 		notify_fd = install_notify_filter();
+
+		pthread_create(&thread_id, NULL, &catch_send_fd, (void *)&notify_fd);		
+		pthread_mutex_lock(&wait_to_send);
+		while(send_notify_fd == 0) {
+			pthread_cond_wait(&ready_to_send, &wait_to_send);
+		}
+		PRINT_INFO("Can send the notify fd now!");
+		pthread_mutex_unlock(&wait_to_send);
+		
+
 		if (send_fd(sock_fd, notify_fd) == -1) {
 			PRINT_WARNING(
 				"Couldn't send fd to the socket at %s: %s",
@@ -217,6 +391,7 @@ void maybe_setup_seccomp_notifer()
 				"Sent the notify fd to the seccomp agent socket at %s",
 				socket_path)
 		}
+		pthread_join(thread_id, NULL);
 	}
 	return;
 }

--- a/tini/src/seccomp_fd_notify.c
+++ b/tini/src/seccomp_fd_notify.c
@@ -39,6 +39,10 @@
 		fprintf(stderr, "\n");                                         \
 	}
 
+pthread_mutex_t wait_to_send = PTHREAD_MUTEX_INITIALIZER;
+int send_notify_fd = 0;
+pthread_cond_t ready_to_send = PTHREAD_COND_INITIALIZER;
+
 bool have_cap_sysadmin()
 {
 	cap_t current_capabilties = cap_get_proc();

--- a/tini/src/seccomp_fd_notify.h
+++ b/tini/src/seccomp_fd_notify.h
@@ -1,3 +1,6 @@
-#define TITUS_SECCOMP_NOTIFY_SOCK_PATH "TITUS_SECCOMP_NOTIFY_SOCK_PATH"
+#include <stddef.h>
+
+
+#define TITUS_SECCOMP_NOTIFY_SOCK_PATH  "TITUS_SECCOMP_NOTIFY_SOCK_PATH"
 
 void maybe_setup_seccomp_notifer();

--- a/tini/src/seccomp_fd_notify.h
+++ b/tini/src/seccomp_fd_notify.h
@@ -1,6 +1,7 @@
-#include <stddef.h>
-
+#ifndef __SECCOMP_FD_NOTIFY_H__
+#define __SECCOMP_FD_NOTIFY_H__
 
 #define TITUS_SECCOMP_NOTIFY_SOCK_PATH  "TITUS_SECCOMP_NOTIFY_SOCK_PATH"
-
 void maybe_setup_seccomp_notifer();
+
+#endif


### PR DESCRIPTION
Add networking system calls to seccomp filter conditional upon an environment variable.

Intercept/Listen to the first sendmsg syscall via seccomp so that we avoid a catch-22 with the Titus Seccomp Agent while sending across the notifyfd.

Tini logs should read like this
```
Networking system calls will be intercepted
Listening to networking syscall notifications on 6..
Can send the notify fd now!
  fd=6; events: EPOLLIN
Intercepted sendmsg - passthrough!
Stopped polling notifyfd on Tini, over to TSA!
Sent the notify fd to the seccomp agent socket at /titus-executor-sockets/titus-seccomp-agent.sock