### PR TITLE
Make titus-mount-block-device use fd instead of pid

### DIFF
--- a/mount/Makefile
+++ b/mount/Makefile
@@ -1,3 +1,5 @@
+all: titus-mount titus-mount-block-device
+
 titus-mount: mount.c scm_rights.c
 	# musl needs this extra path here
 	# so it can pick up our linux headers for syscalls
@@ -5,6 +7,10 @@ titus-mount: mount.c scm_rights.c
 
 titus-mount-block-device: titus-mount-block-device.c scm_rights.c
 	gcc -g -static -o titus-mount-block-device titus-mount-block-device.c scm_rights.c
+
+
+install: titus-mount titus-mount-block-device
+	sudo rsync -a titus-mount titus-mount-block-device /apps/titus-executor/bin/
 
 clean:
 	rm -f titus-mount titus-mount-block-device


### PR DESCRIPTION
In general fds are more robust than PIDs, but with
titus, it isn't super easy to know what this PID
of your container actually is.

But we do know a well-known path. From that path,
with some C trickery, we can get all the namespaces
we would have needed otherwise and gotten from a pidfd.

----

This is a tradeoff between where I put the complexity.
The pid1 approach was nice, but it required complexity
in `titus-storage` to even get the pid1. With this change,
`titus-storage` can be simpler (can just pass the env variable
on through) and we make `titus-mount-block-device` pick
apart the namespaces given a directory.