### PR TITLE
Added the titus-storage service, with EBS support

### DIFF
--- a/cmd/titus-storage/ebs.go
+++ b/cmd/titus-storage/ebs.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/Netflix/titus-executor/logger"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mvisonneau/go-ebsnvme/pkg/ebsnvme"
+)
+
+func ebsRunner(ctx context.Context, command string, config MountConfig) error {
+	if config.ebsVolumeID == "" {
+		return errors.New("TITUS_EBS_VOLUME_ID unset, unable to perform any EBS-related operations")
+	}
+	ec2Client := getEc2Client()
+	var err error
+
+	switch command {
+	case "start":
+		err = ebsStart(ctx, ec2Client, config)
+	case "stop":
+		err = ebsStop(ctx, ec2Client, config)
+	default:
+		return fmt.Errorf("Command %q unsupported. Must be either start or stop", command)
+	}
+	if err != nil {
+		return fmt.Errorf("Unable to run command %q: %w", command, err)
+	}
+	return nil
+}
+
+func ebsStart(ctx context.Context, ec2Client *ec2.EC2, c MountConfig) error {
+	var err error
+	l := logger.GetLogger(ctx)
+
+	ec2DeviceName, ok := getDeviceName(c.ebsVolumeID)
+	if ok {
+		l.Printf("EBS volume %s is already attached locally, moving on", c.ebsVolumeID)
+	} else {
+		err = waitForVolumeToBeUnused(ctx, c.ebsVolumeID, ec2Client, 30)
+		if err != nil {
+			return fmt.Errorf("%s is not unused. Not safe to detach. %s", c.ebsVolumeID, err)
+		}
+		ec2DeviceName, err = attachEBS(ctx, c.ebsVolumeID, ec2Client, c.instanceID)
+		if err != nil {
+			return err
+		}
+	}
+
+	device, err := GetActualBlockDeviceName(ec2DeviceName)
+	if err != nil {
+		return err
+	}
+
+	err = mkfsIfNeeded(device, c.ebsFStype)
+	if err != nil {
+		return err
+	}
+
+	err = mountIt(ctx, device, c.ebsFStype, c.ebsMountPoint, c.ebsMountPerm, c.pid1Dir)
+	if err != nil {
+		return err
+	}
+	l.Printf("finished setting up EBS %s at %s inside the container", c.ebsVolumeID, c.ebsMountPoint)
+	return nil
+}
+
+func ebsStop(ctx context.Context, ec2Client *ec2.EC2, c MountConfig) error {
+	l := logger.GetLogger(ctx)
+	ec2Device, ok := getDeviceName(c.ebsVolumeID)
+	if !ok {
+		l.Printf("EBS volume %s doesn't look attached. Nothing to do", c.ebsVolumeID)
+		return nil
+	}
+
+	actualDeviceName, err := GetActualBlockDeviceName(ec2Device)
+	if err != nil {
+		return err
+	}
+
+	// Sometimes ebsStop gets called *before* a container dies, so we need to wait.
+	// Sometimes ebsStop gets called *after* a container dies, that is fine, will move on quickly
+	// *Sometimes* ebsStop gets called *defore* a container dies, but *after* a *different* container
+	// comes up, see it is attached, and mounts. In this case we need to still panic here, but it is "ok"
+	// In that situation we should not continue to detach a volume out from underneath it
+	l.Printf("Waiting up to %d seconds for %s to be not in use...", 30, actualDeviceName)
+	err = waitForDeviceToBeNotInUse(actualDeviceName, 30)
+	if err != nil {
+		return fmt.Errorf("Not detaching volume: %s", err)
+	}
+
+	// By the time we get here, we are confident the volume is attached, not in use, and safe to detatch
+	err = detatchEBS(ctx, c.ebsVolumeID, ec2Client, c.instanceID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getEc2Client() *ec2.EC2 {
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+	creds := credentials.NewCredentials(
+		&ec2rolecreds.EC2RoleProvider{
+			Client:       ec2metadata.New(sess),
+			ExpiryWindow: 5 * time.Minute,
+		},
+	)
+	sess.Config.Credentials = creds
+	sess.Config.Region = aws.String(os.Getenv("EC2_REGION"))
+	return ec2.New(sess)
+}
+
+func waitForVolumeToBeUnused(ctx context.Context, ebsVolumeID string, ec2Client *ec2.EC2, timeout int) error {
+	l := logger.GetLogger(ctx)
+	for attempt := 0; attempt < timeout; attempt++ {
+		req := ec2.DescribeVolumeStatusInput{
+			VolumeIds: []*string{aws.String(ebsVolumeID)},
+		}
+		response, err := ec2Client.DescribeVolumeStatus(&req)
+		if err != nil {
+			return err
+		}
+		if len(response.VolumeStatuses) > 0 {
+			s := response.VolumeStatuses[0].VolumeStatus.Status
+			if aws.StringValue(s) == "ok" {
+				return nil
+			}
+			l.Printf("Volume Status %+v", *s)
+		}
+		// This is a simple way to sleep longer and longer each time,
+		// to not hammer the aws API
+		time.Sleep(time.Duration(attempt) * time.Second)
+	}
+	return fmt.Errorf("Waited too long for volume to be unused")
+}
+
+func randDriveNamePicker() (string, error) {
+	deviceName := "/dev/xvd"
+	runes := []rune("fghijklmnopqrstuvwxyz")
+	for i := 0; i < len(runes); i++ {
+		drive := deviceName + string(runes[i])
+		if !doesDriveExist(drive) {
+			return drive, nil
+		}
+	}
+	return "", errors.New("Ran out of drive names")
+}
+
+func doesDriveExist(driveName string) bool {
+	if _, err := os.Stat(driveName); os.IsNotExist(err) {
+		for _, file := range listNvmeBlockDevices() {
+			if d, _ := ebsnvme.ScanDevice(file); d.Name == driveName {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// waitForDeviceToDisappear is an inexpensive way to poll for an EBS
+// detachment without calling the EC2 API. It does this by waiting
+// for the block device it was attached with to dissapear from /dev
+func waitForDeviceToDisappear(ctx context.Context, driveName string, maxAttempts int) error {
+	start := time.Now()
+	l := logger.GetLogger(ctx)
+	var attempts int
+	for doesDriveExist(driveName) {
+		time.Sleep(2 * time.Second)
+		attempts++
+		if attempts >= maxAttempts {
+			elapsed := int(time.Since(start).Seconds())
+			return fmt.Errorf("waited the max %d seconds for %s to go, but it is still here", elapsed, driveName)
+		}
+	}
+	elapsed := int(time.Since(start).Seconds())
+	l.Printf("waited for %s to disappear, and it is now gone after %d seconds", driveName, elapsed)
+	return nil
+}
+
+// waitForDriveToExistWithTimeout is an inexpensive way to poll for an EBS
+// attachment without calling the EC2 API. It does this by scaning the
+// list of nvme volumes on disk and looking at their 'serial number'
+func waitForDriveToExistWithTimeout(driveName string, maxAttempts int) error {
+	var attempts int
+	for !doesDriveExist(driveName) {
+		time.Sleep(2 * time.Second)
+		attempts++
+		if attempts >= maxAttempts {
+			return fmt.Errorf("drive %s still does't exist after waiting %d seconds", driveName, attempts*2)
+		}
+	}
+	return nil
+}
+
+// GetActualBlockDeviceName returns the actual name of the block device seen
+// within the instance, like /dev/nvme1
+// This is often different from the ec2 device name, which is usually
+// something like /dev/sdx
+func GetActualBlockDeviceName(name string) (string, error) {
+	for _, device := range listNvmeBlockDevices() {
+		if d, _ := ebsnvme.ScanDevice(device); d.Name == name {
+			return device, nil
+		}
+	}
+	if _, err := os.Stat(name); os.IsNotExist(err) {
+		return "", err
+	}
+	return name, nil
+}
+
+func listNvmeBlockDevices() (devices []string) {
+	re := regexp.MustCompile(`(^\/dev\/nvme[0-9]+n1$)`)
+	f, _ := filepath.Glob("/dev/nvme*")
+	for _, d := range f {
+		if re.Match([]byte(d)) {
+			devices = append(devices, d)
+		}
+	}
+	return
+}
+
+// getDeviceName scans the Nvme on disk and looks at the
+// serial numbers of the devices and returns the device name
+// (/dev/nmve1). Behaves like a hash get, returning key, ok.
+// returning "", false if unfound.
+func getDeviceName(ebsVolumeID string) (string, bool) {
+	for _, device := range listNvmeBlockDevices() {
+		if d, _ := ebsnvme.ScanDevice(device); d.VolumeID == ebsVolumeID {
+			return d.Name, true
+		}
+	}
+	return "", false
+}
+
+func attachEBS(ctx context.Context, ebsVolumeID string, ec2Client *ec2.EC2, instanceID string) (string, error) {
+	l := logger.GetLogger(ctx)
+	ec2DeviceName, ok := getDeviceName(ebsVolumeID)
+	if ok {
+		l.Printf("EBS Volume %s already attached as %s, no need to attach again", ebsVolumeID, ec2DeviceName)
+		return ec2DeviceName, nil
+	}
+	ec2DeviceName, err := randDriveNamePicker()
+	if err != nil {
+		return "", fmt.Errorf("Couldn't find an unused drive name to give to %s: %s", ebsVolumeID, err)
+	}
+	attachVolIn := &ec2.AttachVolumeInput{
+		Device:     &ec2DeviceName,
+		InstanceId: &instanceID,
+		VolumeId:   &ebsVolumeID,
+	}
+	volAttachments, err := ec2Client.AttachVolume(attachVolIn)
+	if err != nil {
+		return "", err
+	}
+	l.Printf("volAttachments status after AttachVolume: %+v", volAttachments)
+	l.Printf("Now waiting for device to exist as ec2Device name %s", ec2DeviceName)
+	err = waitForDriveToExistWithTimeout(ec2DeviceName, 10)
+	if err != nil {
+		return "", err
+	}
+	l.Printf("%s is now attached and ready to be mounted", ebsVolumeID)
+	return ec2DeviceName, nil
+}
+
+func detatchEBS(ctx context.Context, ebsVolumeID string, ec2Client *ec2.EC2, instanceID string) error {
+	l := logger.GetLogger(ctx)
+	deviceName, ok := getDeviceName(ebsVolumeID)
+	if !ok {
+		l.Printf("volume %s doesn't seem to connected. Not bothering to detach using the AWS API", ebsVolumeID)
+	}
+	detachVolIn := &ec2.DetachVolumeInput{
+		Device:     &deviceName,
+		InstanceId: &instanceID,
+		VolumeId:   &ebsVolumeID,
+	}
+	l.Printf("Calling the EC2 API to detach %s from %s", ebsVolumeID, instanceID)
+	volAttachment, err := ec2Client.DetachVolume(detachVolIn)
+	if err != nil {
+		return err
+	}
+	if *volAttachment.InstanceId != instanceID {
+		l.Printf("%+v is reporting a different ec2 instance id than mine, %s, could be a bug?", volAttachment, instanceID)
+	}
+	if *volAttachment.State != "detaching" {
+		l.Printf("%+v is reporting something other than 'detaching' after being ask to detach?", volAttachment)
+	} else {
+		l.Printf("%s is detaching", ebsVolumeID)
+	}
+	realDeviceName, err := GetActualBlockDeviceName(deviceName)
+	if err != nil {
+		return err
+	}
+	err = waitForDeviceToDisappear(ctx, realDeviceName, 10)
+	if err != nil {
+		return fmt.Errorf("Timed out waiting for detach of %s to finish!: %s", ebsVolumeID, err)
+	}
+	l.Printf("Detach of %s done", ebsVolumeID)
+	return nil
+}

--- a/cmd/titus-storage/main.go
+++ b/cmd/titus-storage/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/Netflix/titus-executor/logger"
+	"github.com/Netflix/titus-executor/utils/log"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	ebsVolumeFlagName     = "titus-ebs-volume-id"
+	taskIDFlagName        = "titus-task-id"
+	ec2InstanceIDFlagName = "ec2-instance-id"
+	ebsMountPointFlagName = "ebs-mount-point"
+	ebsMountPermFlagName  = "ebs-mount-perm"
+	ebsFSTypeFlagName     = "ebs-fstype"
+	titusPid1DirFlagName  = "titus-pid1-dir"
+)
+
+type MountConfig struct {
+	taskID        string
+	instanceID    string
+	pid1Dir       string
+	ebsMountPoint string
+	ebsMountPerm  string
+	ebsFStype     string
+	ebsVolumeID   string
+}
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	log.MaybeSetupLoggerIfOnJournaldAvailable()
+	v := viper.New()
+
+	var cmd = &cobra.Command{
+		Short:        "The container sidecar for attaching storage",
+		Long:         "",
+		ValidArgs:    []string{"start", "stop"},
+		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mountConfig := newMountConfigFromViper(v)
+			ctx = logger.WithFields(ctx, logrus.Fields{
+				"ebs_volume_id": mountConfig.ebsVolumeID,
+				"taskid":        mountConfig.taskID,
+			})
+			l := logger.GetLogger(ctx)
+			command := args[0]
+			l.Infof("Running titus-storage with %s", command)
+			err := ebsRunner(ctx, command, mountConfig)
+			if err != nil {
+				l.Error(err)
+			}
+			return err
+		},
+		Use: "titus-storage <start|stop>",
+	}
+
+	if err := v.BindPFlags(cmd.PersistentFlags()); err != nil {
+		logger.G(ctx).WithError(err).Fatal("Unable to configure Viper")
+	}
+
+	bindVariables(v)
+	v.AutomaticEnv()
+
+	err := cmd.Execute()
+	if err != nil {
+		// The reason we don't log here is because it wouldn't be
+		// under the structured logger object, so better to just
+		// let the caller log and not print anything here.
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func bindVariables(v *viper.Viper) {
+	if err := v.BindEnv(ebsVolumeFlagName, "TITUS_EBS_VOLUME_ID"); err != nil {
+		panic(err)
+	}
+	if err := v.BindEnv(taskIDFlagName, "TITUS_TASK_ID"); err != nil {
+		panic(err)
+	}
+	if err := v.BindEnv(ec2InstanceIDFlagName, "EC2_INSTANCE_ID"); err != nil {
+		panic(err)
+	}
+	if err := v.BindEnv(ebsMountPointFlagName, "TITUS_EBS_MOUNT_POINT"); err != nil {
+		panic(err)
+	}
+	if err := v.BindEnv(ebsMountPermFlagName, "TITUS_EBS_MOUNT_PERM"); err != nil {
+		panic(err)
+	}
+	if err := v.BindEnv(ebsFSTypeFlagName, "TITUS_EBS_FSTYPE"); err != nil {
+		panic(err)
+	}
+	if err := v.BindEnv(titusPid1DirFlagName, "TITUS_PID_1_DIR"); err != nil {
+		panic(err)
+	}
+
+}
+
+func newMountConfigFromViper(v *viper.Viper) MountConfig {
+	return MountConfig{
+		ebsVolumeID:   v.GetString(ebsVolumeFlagName),
+		taskID:        v.GetString(taskIDFlagName),
+		instanceID:    v.GetString(ec2InstanceIDFlagName),
+		ebsMountPoint: v.GetString(ebsMountPointFlagName),
+		ebsMountPerm:  v.GetString(ebsMountPermFlagName),
+		ebsFStype:     v.GetString(ebsFSTypeFlagName),
+		pid1Dir:       v.GetString(titusPid1DirFlagName),
+	}
+}

--- a/cmd/titus-storage/mount.go
+++ b/cmd/titus-storage/mount.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/Netflix/titus-executor/logger"
+)
+
+const (
+	mountCommand = "/apps/titus-executor/bin/titus-mount-block-device"
+)
+
+func calculateFlags(mountPerm string) (string, error) {
+	if mountPerm == "RW" {
+		return "1", nil
+	} else if mountPerm == "RO" {
+		return "0", nil
+	}
+	return "", fmt.Errorf("error parsing the mount permissions: '%s', needs to be only RW/RO", mountPerm)
+}
+
+func mountIt(ctx context.Context, dev string, fstype string, mountPoint string, mountPerm string, pid1Dir string) error {
+	l := logger.GetLogger(ctx)
+	flags, err := calculateFlags(mountPerm)
+	if err != nil {
+		return err
+	}
+	if pid1Dir == "" {
+		return fmt.Errorf("env var TITUS_PID_1_DIR is not set, unable to mount")
+	}
+	l.Printf("Running %s to mount %s onto %s in the container", mountCommand, dev, mountPoint)
+	cmd := exec.Command(mountCommand)
+	cmd.Env = []string{
+		"TITUS_PID_1_DIR=" + pid1Dir,
+		"MOUNT_TARGET=" + mountPoint,
+		"MOUNT_OPTIONS=source=" + dev,
+		"MOUNT_FLAGS=" + flags,
+		"MOUNT_FSTYPE=" + fstype,
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	l.Printf("%s %s", strings.Join(cmd.Env, " "), mountCommand)
+	return cmd.Run()
+}
+
+func mkfsIfNeeded(dev string, fstype string) error {
+	// TODO: Not currently supported
+	return nil
+}
+
+func waitForDeviceToBeNotInUse(device string, timeout int) error {
+	for attempts := 0; attempts < timeout; attempts++ {
+		inUse, err := deviceIsInUse(device)
+		if err != nil {
+			return err
+		}
+		if !inUse {
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("Waited %d seconds for %s to not be in use, but it still is", timeout, device)
+}
+
+func deviceIsInUse(device string) (bool, error) {
+	fd, err := os.OpenFile(device, os.O_EXCL, 0644)
+	if err == nil {
+		fd.Close()
+		return false, nil
+	} else if strings.Contains(err.Error(), "device or resource busy") {
+		return true, nil
+	} else {
+		return true, fmt.Errorf("Got unexpected error when trying to determine if %s was open: %s", device, err)
+	}
+}

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -991,6 +991,16 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context) error { // nolint: go
 		}
 	}
 
+	if shouldStartTitusStorage(&r.cfg, r.c) {
+		v := r.c.EBSInfo()
+		r.c.SetEnvs(map[string]string{
+			"TITUS_EBS_VOLUME_ID":   v.VolumeID,
+			"TITUS_EBS_MOUNT_POINT": v.MountPoint,
+			"TITUS_EBS_MOUNT_PERM":  v.MountPerm,
+			"TITUS_EBS_FSTYPE":      v.FSType,
+		})
+	}
+
 	if r.cfg.UseNewNetworkDriver {
 		group.Go(func(ctx context.Context) error {
 			prepareNetworkStartTime := time.Now()

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -995,7 +995,7 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context) error { // nolint: go
 		v := r.c.EBSInfo()
 		r.c.SetEnvs(map[string]string{
 			"TITUS_EBS_VOLUME_ID":   v.VolumeID,
-			"TITUS_EBS_MOUNT_POINT": v.MountPoint,
+			"TITUS_EBS_MOUNT_POINT": v.MountPath,
 			"TITUS_EBS_MOUNT_PERM":  v.MountPerm,
 			"TITUS_EBS_FSTYPE":      v.FSType,
 		})

--- a/executor/runtime/docker/docker_config.go
+++ b/executor/runtime/docker/docker_config.go
@@ -190,3 +190,7 @@ func shouldStartSSHD(cfg *config.Config, c runtimeTypes.Container) bool {
 func shouldStartLogViewer(cfg *config.Config, c runtimeTypes.Container) bool {
 	return cfg.ContainerLogViewer
 }
+
+func shouldStartTitusStorage(cfg *config.Config, c runtimeTypes.Container) bool {
+	return c.EBSInfo().VolumeID != ""
+}

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -120,6 +120,12 @@ var systemServices = []serviceOpts{
 		required:     true,
 		enabledCheck: shouldStartTitusSeccompAgent,
 	},
+	{
+		humanName:    "titus-storage",
+		unitName:     "titus-storage",
+		required:     true,
+		enabledCheck: shouldStartTitusStorage,
+	},
 }
 
 func getPeerInfo(unixConn *net.UnixConn) (ucred, error) {

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -122,6 +122,7 @@ type TitusInfoContainer struct {
 	envOverrides map[string]string
 	labels       map[string]string
 	titusInfo    *titus.ContainerInfo
+	ebsInfo      EBSInfo
 
 	resources Resources
 
@@ -136,7 +137,6 @@ type TitusInfoContainer struct {
 	vpcAccountID       string
 
 	// Log uploader fields
-
 	logUploadThresholdTime *time.Duration
 	logUploadCheckInterval *time.Duration
 	logStdioCheckInterval  *time.Duration
@@ -537,6 +537,16 @@ func (c *TitusInfoContainer) Capabilities() *titus.ContainerInfo_Capabilities {
 
 func (c *TitusInfoContainer) EfsConfigInfo() []*titus.ContainerInfo_EfsConfigInfo {
 	return c.titusInfo.GetEfsConfigInfo()
+}
+
+func (c *TitusInfoContainer) EBSInfo() EBSInfo {
+	// KYLE TODO: use c.pod.annotations and extract the data here
+	return EBSInfo{
+		VolumeID:   "vol-0cc20fbab97755b62",
+		MountPoint: "/ebs_mnt",
+		MountPerm:  "RW",
+		FSType:     "xfs",
+	}
 }
 
 func (c *TitusInfoContainer) ElasticIPPool() *string {

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -103,6 +103,10 @@ func (c *PodContainer) ContainerInfo() (*titus.ContainerInfo, error) {
 	return c.titusInfo, nil
 }
 
+func (c *PodContainer) EBSInfo() EBSInfo {
+	return EBSInfo{}
+}
+
 func (c *PodContainer) EfsConfigInfo() []*titus.ContainerInfo_EfsConfigInfo {
 	return nil
 }

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -104,6 +104,13 @@ type GPUContainer interface {
 	Env() map[string]string
 }
 
+type EBSInfo struct {
+	VolumeID   string
+	MountPoint string
+	MountPerm  string
+	FSType     string
+}
+
 type SidecarContainerConfig struct {
 	ServiceName string
 	Image       string
@@ -122,6 +129,7 @@ type Container interface {
 	Capabilities() *titus.ContainerInfo_Capabilities
 	CombinedAppStackDetails() string
 	ContainerInfo() (*titus.ContainerInfo, error)
+	EBSInfo() EBSInfo
 	EfsConfigInfo() []*titus.ContainerInfo_EfsConfigInfo
 	Env() map[string]string
 	ElasticIPPool() *string

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -105,10 +105,10 @@ type GPUContainer interface {
 }
 
 type EBSInfo struct {
-	VolumeID   string
-	MountPoint string
-	MountPerm  string
-	FSType     string
+	VolumeID  string
+	MountPath string
+	MountPerm string
+	FSType    string
 }
 
 type SidecarContainerConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/leanovate/gopter v0.0.0-20170420174722-9e6101e5a875
 	github.com/lib/pq v1.3.0
 	github.com/mdlayher/ndp v0.0.0-20200602162440-17ab9e3e5567
-	github.com/mitchellh/gox v1.0.1 // indirect
+	github.com/mvisonneau/go-ebsnvme v0.0.0-20201026165225-e63797fabc2f
 	github.com/myitcv/gobin v0.0.9
 	github.com/netflix-skunkworks/opencensus-go-exporter-datadog v0.0.0-20190911150647-ef71dde58796
 	github.com/opencontainers/runc v1.0.0-rc10

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Netflix/metrics-client-go v0.0.0-20171019173821-bb173f41fc07
 	github.com/Netflix/spectator-go v0.0.0-20190913215732-d4e0463555ef
 	github.com/Netflix/titus-api-definitions v0.0.1-rc9.0.20200520235959-0ab6f1129886
-	github.com/Netflix/titus-kube-common v0.9.0
+	github.com/Netflix/titus-kube-common v0.10.1
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
 	github.com/apparentlymart/go-cidr v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/Netflix/titus-api-definitions v0.0.1-rc9.0.20200520235959-0ab6f112988
 github.com/Netflix/titus-controllers-api v0.0.6/go.mod h1:tPzu+DV20a0usx4QPplTvSeg0ERTIyxWa1iemWsWCbI=
 github.com/Netflix/titus-kube-common v0.9.0 h1:cICC1qS+PPoXT/Ih0e2fyDdANsbgwAIegHsPm8OmiR8=
 github.com/Netflix/titus-kube-common v0.9.0/go.mod h1:fU8ZwjsXgEaZNx1H4UjLD9S2h55EKwHQQeZwGyiwsdU=
+github.com/Netflix/titus-kube-common v0.10.1 h1:gX6vJyvGK6QDDxwqcIYGQw+vgn5uVLRsxOZ7Aww/ckk=
+github.com/Netflix/titus-kube-common v0.10.1/go.mod h1:OoWxqK3nzjhkRvtox9JJR7gXcXAehJ2tpEtBX2X2c2w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -733,6 +735,7 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.0.1-alpha.6/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.0 h1:IZRgg4sfrDH7nsAD1Y/Nwj+GzIfEwpJSLjCaNC3SbsI=
 github.com/rogpeppe/go-internal v1.6.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,7 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -621,6 +622,8 @@ github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618/go.mod h1:x8F1gn
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mvdan/xurls v1.1.0/go.mod h1:tQlNn3BED8bE/15hnSL2HLkDeLWpNPAwtw7wkEq44oU=
+github.com/mvisonneau/go-ebsnvme v0.0.0-20201026165225-e63797fabc2f h1:YgXdZ3/j21L7an+HohN3OQw8jOUJmXX1czkzlBuaEX0=
+github.com/mvisonneau/go-ebsnvme v0.0.0-20201026165225-e63797fabc2f/go.mod h1:Zy+sBi1jPcjufO6ViaG/bUNxQe37fdDhuK1oHUhPB0k=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/myitcv/gobin v0.0.9 h1:TM3r18JE4Dil1aaEo33k8deW0k30NrgaW84kd2oZlSs=
@@ -750,6 +753,7 @@ github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvW
 github.com/securego/gosec/v2 v2.4.0 h1:ivAoWcY5DMs9n04Abc1VkqZBO0FL0h4ShTcVsC53lCE=
 github.com/securego/gosec/v2 v2.4.0/go.mod h1:0/Q4cjmlFDfDUj1+Fib61sc+U5IQb2w+Iv9/C3wPVko=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c h1:W65qqJCIOVP4jpqPQ0YvHYKwcMEMVWIzWC5iNQQfBTU=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
@@ -857,6 +861,7 @@ github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lP
 github.com/ultraware/whitespace v0.0.4 h1:If7Va4cM03mpgrNH9k49/VOicWpGoG70XPBFFODYDsg=
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/uudashr/gocognit v1.0.1 h1:MoG2fZ0b/Eo7NXoIwCVFLG5JED3qgQz5/NEE+rOsjPs=
 github.com/uudashr/gocognit v1.0.1/go.mod h1:j44Ayx2KW4+oB6SWMv8KsmHzZrOInQav7D3cQMJ5JUM=

--- a/root/lib/systemd/system/titus-storage@.service
+++ b/root/lib/systemd/system/titus-storage@.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Storage mounting for task %s
+ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
+# PartOf ensures that titus-storage will shutdown as part of the main titus-executor unit
+PartOf=titus-executor@default__%i.service
+
+# If the service restarts more than 10 times in 30 seconds, let it die
+StartLimitIntervalSec=30
+StartLimitBurst=10
+
+[Service]
+# This command is oneshot, it runs once, mounts and returns
+# Similar with stop.
+Type=oneshot
+RemainAfterExit=yes
+
+# This PID1 
+Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
+EnvironmentFile=-/var/lib/titus-environments/%i.env
+EnvironmentFile=-/var/lib/titus-environments/%i-titus-storage.env
+
+# We copy the env file for ourselves to ensure
+# it exists when it comes to stop.
+# Otherwise there is a race, where that env file
+# may not exist, and it stores the data we need to
+# stop cleanly
+ExecStart=/bin/cp /var/lib/titus-environments/%i.env /var/lib/titus-environments/%i-titus-storage.env
+ExecStart=/apps/titus-executor/bin/titus-storage start
+
+# The normal stop here is to do things like detatach
+ExecStop=/apps/titus-executor/bin/titus-storage stop
+# We just need to remember to clean up our copy afterwards here
+ExecStop=/bin/rm -f /var/lib/titus-environments/%i-titus-storage.env
+
+LimitNOFILE=65535
+PrivateTmp=yes
+KillMode=mixed


### PR DESCRIPTION
This is the new titus-storage system service.
Unlike previous storage options (nfs), this can
run as a system service, which should make it easier to debug
and iterate on. Eventually I would like for it to handle
other storage needs, perhaps nfs too.

It is pretty conservative, and will refuse to do anything scary.

Probably my biggest fear is around leaving orphaned attached volumes
that need to be manually cleaned up. I don't know how often this will
happen, but I think we'll need a reaper.
