### PR TITLE
Set network namespace

### DIFF
--- a/cmd/titus-vpc-tool/main.go
+++ b/cmd/titus-vpc-tool/main.go
@@ -189,7 +189,7 @@ func main() {
 	rootCmd.AddCommand(setupInstanceCommand(ctx, v, ipr.getProvider))
 	rootCmd.AddCommand(backfilleniCommand(ctx, v))
 	rootCmd.AddCommand(globalGCCommand(ctx, v))
-	rootCmd.AddCommand(setupContainercommand(ctx, v, ipr.getProvider))
+	rootCmd.AddCommand(setupContainercommand(ctx, v, ipr.getProvider)...)
 	rootCmd.AddCommand(teardownContainercommand(ctx, v, ipr.getProvider))
 	rootCmd.AddCommand(gcCommand(ctx, v, ipr.getProvider))
 	rootCmd.AddCommand(operatorCmd(ctx, v, ipr.getProvider))

--- a/cmd/titus-vpc-tool/main.go
+++ b/cmd/titus-vpc-tool/main.go
@@ -189,7 +189,7 @@ func main() {
 	rootCmd.AddCommand(setupInstanceCommand(ctx, v, ipr.getProvider))
 	rootCmd.AddCommand(backfilleniCommand(ctx, v))
 	rootCmd.AddCommand(globalGCCommand(ctx, v))
-	rootCmd.AddCommand(setupContainercommand(ctx, v, ipr.getProvider)...)
+	rootCmd.AddCommand(setupContainercommand(ctx, v, ipr.getProvider))
 	rootCmd.AddCommand(teardownContainercommand(ctx, v, ipr.getProvider))
 	rootCmd.AddCommand(gcCommand(ctx, v, ipr.getProvider))
 	rootCmd.AddCommand(operatorCmd(ctx, v, ipr.getProvider))

--- a/cmd/titus-vpc-tool/setup_container.go
+++ b/cmd/titus-vpc-tool/setup_container.go
@@ -13,20 +13,20 @@ import (
 )
 
 func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentityProviderGetter) *cobra.Command {
-	withTransition := false
-
-	netNS := []interface{}{v.GetInt("netns")}
-	if v.GetString("trans-netns") != "" {
-		withTransition = true
-		netNS = append(netNS, v.GetString("trans-netns"))
-	}
 	cmd := &cobra.Command{
 		Use:   "setup-container",
 		Short: "Setup networking for a particular container",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			withTransition := false
 			bandwidth := v.GetInt64("bandwidth")
 			burst := v.GetBool("burst")
 			jumbo := v.GetBool("jumbo")
+
+			netNS := []interface{}{v.GetInt("netns")}
+			if v.GetString("transition-netns") != "" {
+				withTransition = true
+				netNS = append(netNS, v.GetString("transition-netns"))
+			}
 			switch strings.ToLower(v.GetString(generationFlagName)) {
 			case "v1":
 				return container.SetupContainer(ctx, iipGetter(), netNS, withTransition, uint64(bandwidth), burst, jumbo)
@@ -39,7 +39,7 @@ func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter ins
 	}
 
 	cmd.Flags().Int("netns", 3, "The File Descriptor # of the network namespace to setup")
-	cmd.Flags().String("transition-netns", "trans-netns", "The name # of the network namespace to setup for transition")
+	cmd.Flags().String("transition-netns", "", "The name # of the network namespace to setup for transition")
 	cmd.Flags().Int64("bandwidth", 128*1024*1024, "Bandwidth to allocate to the device, in bps")
 	cmd.Flags().Bool("burst", false, "Allow this container to burst its network allocation")
 	cmd.Flags().Bool("jumbo", false, "Allow this container to use jumbo frames")

--- a/cmd/titus-vpc-tool/setup_container.go
+++ b/cmd/titus-vpc-tool/setup_container.go
@@ -12,30 +12,32 @@ import (
 	pkgviper "github.com/spf13/viper"
 )
 
-func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentityProviderGetter) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "setup-container",
-		Short: "Setup networking for a particular container",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			netns := v.GetInt("netns")
-			bandwidth := v.GetInt64("bandwidth")
-			burst := v.GetBool("burst")
-			jumbo := v.GetBool("jumbo")
-			switch strings.ToLower(v.GetString(generationFlagName)) {
-			case "v1":
-				return container.SetupContainer(ctx, iipGetter(), netns, uint64(bandwidth), burst, jumbo)
-			case "v2", "v3":
-				return container2.SetupContainer(ctx, iipGetter(), netns, uint64(bandwidth), burst)
-			default:
-				return fmt.Errorf("Version %q not recognized", v.GetString(generationFlagName))
-			}
-		},
-	}
+func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentityProviderGetter) []*cobra.Command {
+	cmds := []*cobra.Command{}
+	for _, netns := range []interface{}{v.GetInt("netns"), v.GetString("trans-netns")} {
+		cmd := &cobra.Command{
+			Use:   "setup-container",
+			Short: "Setup networking for a particular container",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				bandwidth := v.GetInt64("bandwidth")
+				burst := v.GetBool("burst")
+				jumbo := v.GetBool("jumbo")
+				switch strings.ToLower(v.GetString(generationFlagName)) {
+				case "v1":
+					return container.SetupContainer(ctx, iipGetter(), netns, uint64(bandwidth), burst, jumbo)
+				case "v2", "v3":
+					return container2.SetupContainer(ctx, iipGetter(), netns, uint64(bandwidth), burst)
+				default:
+					return fmt.Errorf("Version %q not recognized", v.GetString(generationFlagName))
+				}
+			},
+		}
 
-	cmd.Flags().Int("netns", 3, "The File Descriptor # of the network namespace to setup")
-	cmd.Flags().Int64("bandwidth", 128*1024*1024, "Bandwidth to allocate to the device, in bps")
-	cmd.Flags().Bool("burst", false, "Allow this container to burst its network allocation")
-	cmd.Flags().Bool("jumbo", false, "Allow this container to use jumbo frames")
-	cmd.Flags().String(generationFlagName, generationDefaultValue, "Generation of VPC Tool to use, specify v1, or v2")
-	return cmd
+		cmd.Flags().Int("netns", 3, "The File Descriptor # of the network namespace to setup")
+		cmd.Flags().Int64("bandwidth", 128*1024*1024, "Bandwidth to allocate to the device, in bps")
+		cmd.Flags().Bool("burst", false, "Allow this container to burst its network allocation")
+		cmd.Flags().Bool("jumbo", false, "Allow this container to use jumbo frames")
+		cmd.Flags().String(generationFlagName, generationDefaultValue, "Generation of VPC Tool to use, specify v1, or v2")
+	}
+	return cmds
 }

--- a/cmd/titus-vpc-tool/setup_container.go
+++ b/cmd/titus-vpc-tool/setup_container.go
@@ -12,40 +12,37 @@ import (
 	pkgviper "github.com/spf13/viper"
 )
 
-func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentityProviderGetter) []*cobra.Command {
+func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentityProviderGetter) *cobra.Command {
 	withTransition := false
-	cmds := []*cobra.Command{}
 
 	netNS := []interface{}{v.GetInt("netns")}
 	if v.GetString("trans-netns") != "" {
 		withTransition = true
 		netNS = append(netNS, v.GetString("trans-netns"))
 	}
-	for _, netns := range netNS {
-		netns := netns
-		cmd := &cobra.Command{
-			Use:   "setup-container",
-			Short: "Setup networking for a particular container",
-			RunE: func(cmd *cobra.Command, args []string) error {
-				bandwidth := v.GetInt64("bandwidth")
-				burst := v.GetBool("burst")
-				jumbo := v.GetBool("jumbo")
-				switch strings.ToLower(v.GetString(generationFlagName)) {
-				case "v1":
-					return container.SetupContainer(ctx, iipGetter(), netns, withTransition, uint64(bandwidth), burst, jumbo)
-				case "v2", "v3":
-					return container2.SetupContainer(ctx, iipGetter(), netns, withTransition, uint64(bandwidth), burst)
-				default:
-					return fmt.Errorf("Version %q not recognized", v.GetString(generationFlagName))
-				}
-			},
-		}
-
-		cmd.Flags().Int("netns", 3, "The File Descriptor # of the network namespace to setup")
-		cmd.Flags().Int64("bandwidth", 128*1024*1024, "Bandwidth to allocate to the device, in bps")
-		cmd.Flags().Bool("burst", false, "Allow this container to burst its network allocation")
-		cmd.Flags().Bool("jumbo", false, "Allow this container to use jumbo frames")
-		cmd.Flags().String(generationFlagName, generationDefaultValue, "Generation of VPC Tool to use, specify v1, or v2")
+	cmd := &cobra.Command{
+		Use:   "setup-container",
+		Short: "Setup networking for a particular container",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bandwidth := v.GetInt64("bandwidth")
+			burst := v.GetBool("burst")
+			jumbo := v.GetBool("jumbo")
+			switch strings.ToLower(v.GetString(generationFlagName)) {
+			case "v1":
+				return container.SetupContainer(ctx, iipGetter(), netNS, withTransition, uint64(bandwidth), burst, jumbo)
+			case "v2", "v3":
+				return container2.SetupContainer(ctx, iipGetter(), netNS, withTransition, uint64(bandwidth), burst)
+			default:
+				return fmt.Errorf("Version %q not recognized", v.GetString(generationFlagName))
+			}
+		},
 	}
-	return cmds
+
+	cmd.Flags().Int("netns", 3, "The File Descriptor # of the network namespace to setup")
+	cmd.Flags().String("transition-netns", "trans-netns", "The name # of the network namespace to setup for transition")
+	cmd.Flags().Int64("bandwidth", 128*1024*1024, "Bandwidth to allocate to the device, in bps")
+	cmd.Flags().Bool("burst", false, "Allow this container to burst its network allocation")
+	cmd.Flags().Bool("jumbo", false, "Allow this container to use jumbo frames")
+	cmd.Flags().String(generationFlagName, generationDefaultValue, "Generation of VPC Tool to use, specify v1, or v2")
+	return cmd
 }

--- a/cmd/titus-vpc-tool/teardown.go
+++ b/cmd/titus-vpc-tool/teardown.go
@@ -9,15 +9,20 @@ import (
 )
 
 func teardownContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentityProviderGetter) *cobra.Command {
+	netNS := []interface{}{v.GetInt("netns")}
+	if v.GetString("trans-netns") != "" {
+		netNS = append(netNS, v.GetString("trans-netns"))
+	}
+
 	cmd := &cobra.Command{
 		Use:   "teardown-container",
 		Short: "Tear down networking for a particular container",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			netns := v.GetInt("netns")
-			return container2.TeardownContainer(ctx, netns)
+			return container2.TeardownContainer(ctx, netNS)
 		},
 	}
 
 	cmd.Flags().Int("netns", 3, "The File Descriptor # of the network namespace to setup")
+	cmd.Flags().String("transition-netns", "trans-netns", "The name # of the network namespace to setup for transition")
 	return cmd
 }

--- a/cmd/titus-vpc-tool/teardown.go
+++ b/cmd/titus-vpc-tool/teardown.go
@@ -9,20 +9,19 @@ import (
 )
 
 func teardownContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentityProviderGetter) *cobra.Command {
-	netNS := []interface{}{v.GetInt("netns")}
-	if v.GetString("trans-netns") != "" {
-		netNS = append(netNS, v.GetString("trans-netns"))
-	}
-
 	cmd := &cobra.Command{
 		Use:   "teardown-container",
 		Short: "Tear down networking for a particular container",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			netNS := []interface{}{v.GetInt("netns")}
+			if v.GetString("transition-netns") != "" {
+				netNS = append(netNS, v.GetString("transition-netns"))
+			}
 			return container2.TeardownContainer(ctx, netNS)
 		},
 	}
 
 	cmd.Flags().Int("netns", 3, "The File Descriptor # of the network namespace to setup")
-	cmd.Flags().String("transition-netns", "trans-netns", "The name # of the network namespace to setup for transition")
+	cmd.Flags().String("transition-netns", "", "The name # of the network namespace to setup for transition")
 	return cmd
 }

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -978,9 +978,10 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context) error { // nolint: go
 				"TITUS_SECCOMP_AGENT_HANDLE_PERF_SYSCALLS": "true",
 			})
 		}
-		if r.c.SeccompAgentEnabledForPerfSyscalls() {
+		if r.c.SeccompAgentEnabledForNetSyscalls() {
 			r.c.SetEnvs(map[string]string{
 				"TITUS_SECCOMP_AGENT_HANDLE_NET_SYSCALLS": "true",
+				"TITUS_SECCOMP_AGENT_TRANSITION_NETNS":    r.c.TaskID() + "trans-netns",
 			})
 		}
 	}
@@ -1741,6 +1742,9 @@ func setupNetworkingArgs(burst bool, c runtimeTypes.Container) []string {
 	}
 	if c.UseJumboFrames() {
 		args = append(args, "--jumbo=true")
+	}
+	if c.SeccompAgentEnabledForNetSyscalls() {
+		args = append(args, "--trans-netns="+c.TaskID()+"trans-netns")
 	}
 
 	return args

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/stretchr/testify v1.6.2-0.20201103103935-92707c0b2d50
 	github.com/virtual-kubelet/virtual-kubelet v1.0.0
 	github.com/vishvananda/netlink v1.0.1-0.20190930145447-2ec5bdc52b86
-	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc
+	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f
 	github.com/wercker/journalhook v0.0.0-20180428041537-5d0a5ae867b3
 	go.opencensus.io v0.22.3
 	go.uber.org/multierr v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -870,6 +870,8 @@ github.com/vishvananda/netlink v1.0.1-0.20190930145447-2ec5bdc52b86/go.mod h1:+S
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
+github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
+github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/wercker/journalhook v0.0.0-20180428041537-5d0a5ae867b3 h1:shC1HB1UogxN5Ech3Yqaaxj1X/P656PPCB4RbojIJqc=
 github.com/wercker/journalhook v0.0.0-20180428041537-5d0a5ae867b3/go.mod h1:XCsSkdKK4gwBMNrOCZWww0pX6AOt+2gYc5Z6jBRrNVg=
@@ -1061,6 +1063,7 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=

--- a/vpc/tool/container/setup_container.go
+++ b/vpc/tool/container/setup_container.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns interface{}, bandwidth uint64, burst, jumbo bool) error {
+func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns interface{}, withTrans bool, bandwidth uint64, burst, jumbo bool) error {
 	var allocation types.LegacyAllocation
 	err := json.NewDecoder(os.Stdin).Decode(&allocation)
 	if err != nil {
@@ -32,7 +32,7 @@ func SetupContainer(ctx context.Context, instanceIdentityProvider identity.Insta
 			return errors.Wrap(err, "Cannot get max network bps, and burst is set")
 		}
 	}
-	link, err := doSetupContainer(ctx, netns, bandwidth, ceil, jumbo, allocation)
+	link, err := doSetupContainer(ctx, netns, withTrans, bandwidth, ceil, jumbo, allocation)
 	if err != nil {
 		// warning: Errors unhandled.,LOW,HIGH (gosec)
 		_ = json.NewEncoder(os.Stdout).Encode(types.WiringStatus{Success: false, Error: err.Error()}) // nolint: gosec

--- a/vpc/tool/container/setup_container.go
+++ b/vpc/tool/container/setup_container.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns interface{}, withTrans bool, bandwidth uint64, burst, jumbo bool) error {
+func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns []interface{}, withTrans bool, bandwidth uint64, burst, jumbo bool) error {
 	var allocation types.LegacyAllocation
 	err := json.NewDecoder(os.Stdin).Decode(&allocation)
 	if err != nil {
@@ -32,7 +32,7 @@ func SetupContainer(ctx context.Context, instanceIdentityProvider identity.Insta
 			return errors.Wrap(err, "Cannot get max network bps, and burst is set")
 		}
 	}
-	link, err := doSetupContainer(ctx, netns, withTrans, bandwidth, ceil, jumbo, allocation)
+	links, err := doSetupContainer(ctx, netns, withTrans, bandwidth, ceil, jumbo, allocation)
 	if err != nil {
 		// warning: Errors unhandled.,LOW,HIGH (gosec)
 		_ = json.NewEncoder(os.Stdout).Encode(types.WiringStatus{Success: false, Error: err.Error()}) // nolint: gosec
@@ -49,7 +49,7 @@ func SetupContainer(ctx context.Context, instanceIdentityProvider identity.Insta
 	<-c
 
 	logger.G(ctx).WithField("allocation", allocation).Logger.Info("Beginning shutdown, and container teardown")
-	teardownNetwork(ctx, allocation, link, netns)
+	teardownNetwork(ctx, allocation, links, netns)
 	// TODO: Teardown turned up network namespace
 	logger.G(ctx).Info("Finished shutting down and deallocating")
 	return nil

--- a/vpc/tool/container/setup_container.go
+++ b/vpc/tool/container/setup_container.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns int, bandwidth uint64, burst, jumbo bool) error {
+func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns interface{}, bandwidth uint64, burst, jumbo bool) error {
 	var allocation types.LegacyAllocation
 	err := json.NewDecoder(os.Stdin).Decode(&allocation)
 	if err != nil {

--- a/vpc/tool/container/setup_container_linux.go
+++ b/vpc/tool/container/setup_container_linux.go
@@ -58,6 +58,7 @@ func doSetupContainer(ctx context.Context, netNS []interface{}, withTrans bool, 
 		}
 
 		netnsfd, isTransLink, err := getNsFd(ns)
+		logger.G(ctx).WithError(err).Error("setting up links for netnsfd")
 		if err != nil {
 			return nil, err
 		}

--- a/vpc/tool/container/setup_container_unsupported.go
+++ b/vpc/tool/container/setup_container_unsupported.go
@@ -9,9 +9,9 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func doSetupContainer(ctx context.Context, netns interface{}, withTrans bool, bandwidth, ceil uint64, jumbo bool, allocation types.LegacyAllocation) (netlink.Link, error) {
+func doSetupContainer(ctx context.Context, netns []interface{}, withTrans bool, bandwidth, ceil uint64, jumbo bool, allocation types.LegacyAllocation) ([]netlink.Link, error) {
 	return nil, types.ErrUnsupported
 }
 
-func teardownNetwork(ctx context.Context, allocation types.LegacyAllocation, link netlink.Link, netns interface{}) {
+func teardownNetwork(ctx context.Context, allocation types.LegacyAllocation, links []netlink.Link, netns []interface{}) {
 }

--- a/vpc/tool/container/setup_container_unsupported.go
+++ b/vpc/tool/container/setup_container_unsupported.go
@@ -9,7 +9,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func doSetupContainer(ctx context.Context, netns interface{}, bandwidth, ceil uint64, jumbo bool, allocation types.LegacyAllocation) (netlink.Link, error) {
+func doSetupContainer(ctx context.Context, netns interface{}, withTrans bool, bandwidth, ceil uint64, jumbo bool, allocation types.LegacyAllocation) (netlink.Link, error) {
 	return nil, types.ErrUnsupported
 }
 

--- a/vpc/tool/container/setup_container_unsupported.go
+++ b/vpc/tool/container/setup_container_unsupported.go
@@ -9,9 +9,9 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func doSetupContainer(ctx context.Context, netnsfd int, bandwidth, ceil uint64, jumbo bool, allocation types.LegacyAllocation) (netlink.Link, error) {
+func doSetupContainer(ctx context.Context, netns interface{}, bandwidth, ceil uint64, jumbo bool, allocation types.LegacyAllocation) (netlink.Link, error) {
 	return nil, types.ErrUnsupported
 }
 
-func teardownNetwork(ctx context.Context, allocation types.LegacyAllocation, link netlink.Link, netnsfd int) {
+func teardownNetwork(ctx context.Context, allocation types.LegacyAllocation, link netlink.Link, netns interface{}) {
 }

--- a/vpc/tool/container2/setup_container.go
+++ b/vpc/tool/container2/setup_container.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns int, bandwidth uint64, burst bool) error {
+func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns interface{}, bandwidth uint64, burst bool) error {
 	var allocation types.Allocation
 	err := json.NewDecoder(os.Stdin).Decode(&allocation)
 	if err != nil {

--- a/vpc/tool/container2/setup_container.go
+++ b/vpc/tool/container2/setup_container.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns interface{}, withTrans bool, bandwidth uint64, burst bool) error {
+func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns []interface{}, withTrans bool, bandwidth uint64, burst bool) error {
 	var allocation types.Allocation
 	err := json.NewDecoder(os.Stdin).Decode(&allocation)
 	if err != nil {
@@ -44,7 +44,7 @@ func SetupContainer(ctx context.Context, instanceIdentityProvider identity.Insta
 	return nil
 }
 
-func TeardownContainer(ctx context.Context, netnsfd interface{}) error {
+func TeardownContainer(ctx context.Context, netnsfd []interface{}) error {
 	var allocation types.Allocation
 	err := json.NewDecoder(os.Stdin).Decode(&allocation)
 	if err != nil {

--- a/vpc/tool/container2/setup_container.go
+++ b/vpc/tool/container2/setup_container.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns interface{}, bandwidth uint64, burst bool) error {
+func SetupContainer(ctx context.Context, instanceIdentityProvider identity.InstanceIdentityProvider, netns interface{}, withTrans bool, bandwidth uint64, burst bool) error {
 	var allocation types.Allocation
 	err := json.NewDecoder(os.Stdin).Decode(&allocation)
 	if err != nil {
@@ -30,7 +30,7 @@ func SetupContainer(ctx context.Context, instanceIdentityProvider identity.Insta
 			return errors.Wrap(err, "Cannot get max network bps, and burst is set")
 		}
 	}
-	err = DoSetupContainer(ctx, netns, bandwidth, ceil, allocation)
+	err = DoSetupContainer(ctx, netns, withTrans, bandwidth, ceil, allocation)
 	if err != nil {
 		// warning: Errors unhandled.,LOW,HIGH (gosec)
 		_ = json.NewEncoder(os.Stdout).Encode(types.WiringStatus{Success: false, Error: err.Error()}) // nolint: gosec
@@ -44,7 +44,7 @@ func SetupContainer(ctx context.Context, instanceIdentityProvider identity.Insta
 	return nil
 }
 
-func TeardownContainer(ctx context.Context, netnsfd int) error {
+func TeardownContainer(ctx context.Context, netnsfd interface{}) error {
 	var allocation types.Allocation
 	err := json.NewDecoder(os.Stdin).Decode(&allocation)
 	if err != nil {

--- a/vpc/tool/container2/setup_container_unsupported.go
+++ b/vpc/tool/container2/setup_container_unsupported.go
@@ -8,11 +8,11 @@ import (
 	"github.com/Netflix/titus-executor/vpc/types"
 )
 
-func DoSetupContainer(ctx context.Context, netnsfd int, bandwidth, ceil uint64, allocation types.Allocation) error {
+func DoSetupContainer(ctx context.Context, netns interface{}, bandwidth, ceil uint64, allocation types.Allocation) error {
 	return types.ErrUnsupported
 }
 
-func DoTeardownContainer(ctx context.Context, allocation types.Allocation, netnsfd int) error {
+func DoTeardownContainer(ctx context.Context, allocation types.Allocation, netns interface{}) error {
 	return types.ErrUnsupported
 }
 

--- a/vpc/tool/container2/setup_container_unsupported.go
+++ b/vpc/tool/container2/setup_container_unsupported.go
@@ -8,11 +8,11 @@ import (
 	"github.com/Netflix/titus-executor/vpc/types"
 )
 
-func DoSetupContainer(ctx context.Context, netns interface{}, withTrans bool, bandwidth, ceil uint64, allocation types.Allocation) error {
+func DoSetupContainer(ctx context.Context, netns []interface{}, withTrans bool, bandwidth, ceil uint64, allocation types.Allocation) error {
 	return types.ErrUnsupported
 }
 
-func DoTeardownContainer(ctx context.Context, allocation types.Allocation, netns interface{}) error {
+func DoTeardownContainer(ctx context.Context, allocation types.Allocation, netns []interface{}) error {
 	return types.ErrUnsupported
 }
 

--- a/vpc/tool/container2/setup_container_unsupported.go
+++ b/vpc/tool/container2/setup_container_unsupported.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Netflix/titus-executor/vpc/types"
 )
 
-func DoSetupContainer(ctx context.Context, netns interface{}, bandwidth, ceil uint64, allocation types.Allocation) error {
+func DoSetupContainer(ctx context.Context, netns interface{}, withTrans bool, bandwidth, ceil uint64, allocation types.Allocation) error {
 	return types.ErrUnsupported
 }
 


### PR DESCRIPTION
This change creates an ipvlan interface in the transition namespace when network system calls need to be intercepted in a container

1. check if network system calls have to be intercepted.
2. create an ipvlan interface in the transition namespace.
3. Assign IPv6 address to the interface in the container's namespace and IPv4 address to the interface in the transition namespace.