### PR TITLE
Enable titus-seccomp-agent for sshd

### DIFF
--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -17,7 +17,7 @@ mv mount/titus-mount-block-device build/bin/linux-amd64/
 
 # tini
 (
-    mkdir -p build/tini
+    rm -rf build/tini && mkdir -p build/tini
     cd build/tini
     # TODO(sargun): RELWITHDEBINFO
     cmake -DCMAKE_BUILD_TYPE=Release ../../tini
@@ -27,10 +27,10 @@ mv build/tini/tini-static build/bin/linux-amd64
 
 # metadata service injector
 (
-	mkdir -p build/inject
-	cd build/inject
-	cmake ../../inject
-	make V=1
+    rm -rf build/inject && mkdir -p build/inject
+    cd build/inject
+    TINI_INCLUDE_DIR=../tini/src TINI_LIBRARY_DIR=../build/tini cmake ../../inject
+    make V=1
 )
 mv build/inject/titus-inject-metadataproxy build/bin/linux-amd64
 mv build/inject/titus-nsenter build/bin/linux-amd64

--- a/inject/CMakeLists.txt
+++ b/inject/CMakeLists.txt
@@ -18,5 +18,5 @@ SET(CMAKE_C_STANDARD 11)
 add_executable(titus-inject-metadataproxy titus-inject-metadataproxy.c)
 target_link_libraries(titus-inject-metadataproxy "libnl-3.a" "libnl-route-3.a" pthread)
 
-add_executable(titus-nsenter titus-nsenter.c)
+add_executable(titus-nsenter titus-nsenter.c ../tini/src/seccomp_fd_notify.c)
 target_link_libraries(titus-nsenter pthread)

--- a/inject/CMakeLists.txt
+++ b/inject/CMakeLists.txt
@@ -11,6 +11,9 @@ pkg_check_modules(LIBNL_ROUTE REQUIRED libnl-route-3.0>=3.0)
 link_directories(${LIBNL_ROUTE_LIBRARY_DIRS})
 include_directories(${LIBNL_ROUTE_INCLUDE_DIRS})
 
+link_directories($ENV{TINI_LIBRARY_DIR})
+include_directories($ENV{TINI_INCLUDE_DIR})
+
 SET(CMAKE_BUILD_TYPE RELWITHDEBINFO)
 SET(CMAKE_C_FLAGS "-Wall -Werror -D_GNU_SOURCE=1")
 SET(CMAKE_C_STANDARD 11)
@@ -18,5 +21,5 @@ SET(CMAKE_C_STANDARD 11)
 add_executable(titus-inject-metadataproxy titus-inject-metadataproxy.c)
 target_link_libraries(titus-inject-metadataproxy "libnl-3.a" "libnl-route-3.a" pthread)
 
-add_executable(titus-nsenter titus-nsenter.c ../tini/src/seccomp_fd_notify.c)
-target_link_libraries(titus-nsenter pthread)
+add_executable(titus-nsenter titus-nsenter.c)
+target_link_libraries(titus-nsenter pthread seccomp-fd-notify)

--- a/inject/titus-nsenter.c
+++ b/inject/titus-nsenter.c
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #include "shared.h"
-#include "../tini/src/seccomp_fd_notify.h"
+#include "seccomp_fd_notify.h"
 
 struct namespace {
 	int nstype;

--- a/root/lib/systemd/system/titus-sshd@.service
+++ b/root/lib/systemd/system/titus-sshd@.service
@@ -8,6 +8,10 @@ StartLimitBurst=10
 
 [Service]
 Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
+# TSA is used in the main container processes to handle certain syscalls
+# To ensure a sane user experience, we want sshd-spawned processes to
+# get TSA help too. This environment variable ensures that will happen.
+Environment=TITUS_NSENTER_USE_TSA=true
 EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/apps/titus-executor/bin/titus-nsenter /titus/sshd/usr/sbin/sshd -D -e
 LimitNOFILE=65535

--- a/tini/CMakeLists.txt
+++ b/tini/CMakeLists.txt
@@ -81,6 +81,8 @@ include_directories ("${PROJECT_BINARY_DIR}")
 
 add_executable (tini src/tini.c src/seccomp_fd_notify.c)
 
+add_library (seccomp-fd-notify STATIC src/seccomp_fd_notify.c)
+
 add_executable (tini-static src/tini.c src/seccomp_fd_notify.c)
 set_target_properties (tini-static PROPERTIES LINK_FLAGS "-Wl,--no-export-dynamic -static")
 

--- a/tini/src/seccomp_fd_notify.c
+++ b/tini/src/seccomp_fd_notify.c
@@ -1,5 +1,6 @@
 #include <sys/prctl.h>
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -12,7 +13,7 @@
 
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 
 #include "seccomp_fd_notify.h"
 

--- a/tini/src/seccomp_fd_notify.c
+++ b/tini/src/seccomp_fd_notify.c
@@ -109,22 +109,36 @@ void maybe_setup_seccomp_notifer() {
 	if (socket_path) {
 
 		int sock_fd = -1;
-		sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+		// Sometimes things are not perfect, and the socket is not ready at first
+		// Instead of enforcing strict ordering, we can be defensive and retry.
+		int attempts = 10;
+		for (int i=1; i<=attempts; i++) {
+			sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+			if (sock_fd != -1) {
+				break;
+			}
+			PRINT_INFO("Titus seccomp socket unix socket not ready yet on attempt %d, Sleeping 1 second", attempts);
+			sleep(1);
+		}
 		if (sock_fd == -1) {
-			PRINT_WARNING("Unable to open unix socket for seccomp handoff: %s", strerror(errno));
+			PRINT_WARNING("Unable to open unix socket for seccomp handoff after %d attempts: %s", attempts, strerror(errno));
 			return;
 		}
 
 		struct sockaddr_un addr = {0};
 		addr.sun_family = AF_UNIX;
 		strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path)-1);
-		if (connect(sock_fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
-			PRINT_WARNING("Unable to connect on unix socket (%s) for seccomp handoff: %s", socket_path, strerror(errno));
-			return;
+		int result = -1;
+		for (int i=1; i<=attempts; i++) {
+			result = connect(sock_fd, (struct sockaddr*)&addr, sizeof(addr));
+			if (result != -1) {
+				break;
+			}
+			PRINT_INFO("Titus seccomp socket unix socket not ready yet on attempt %d, Sleeping 1 second", attempts);
+			sleep(1);
 		}
-
-		if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
-			PRINT_WARNING("Couldn't prctl to no new privs: %s", strerror(errno));
+		if (result == -1) {
+			PRINT_WARNING("Unable to connect on unix socket (%s) for seccomp handoff after %d attempts: %s", socket_path, attempts, strerror(errno));
 			return;
 		}
 

--- a/tini/src/tini.c
+++ b/tini/src/tini.c
@@ -24,7 +24,7 @@
 #include <sys/resource.h>
 #include <fcntl.h>
 #include <sys/types.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 
 #include "tiniConfig.h"
 #include "tiniLicense.h"


### PR DESCRIPTION
titus-seccomp-agent is used to intercept syscalls
for the main process of a container.

It would be confusing if, when you ssh'd to that container
those same syscalls didn't work!

This change makes it so sshd-spawned processes behave the same.

Maybe in the future we'll have other nsentered processes
also utilize TSA.

This makes the seccomp notification slighty more robust, instead
of needing full sidecar ordering.
