### PR TITLE
Removed init command functionality from system sidecars

### DIFF
--- a/root/lib/systemd/system/titus-metatron-sync@.service
+++ b/root/lib/systemd/system/titus-metatron-sync@.service
@@ -9,6 +9,7 @@ StartLimitBurst=10
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
 # Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work
+ExecStartPre=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/metatron/bin/titus-metatrond --init
 ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/metatron/bin/titus-metatrond
 
 Restart=on-failure


### PR DESCRIPTION
Trying to simplify system sidecars a bit.

I think we can get away with this instead of having an "init command" or an "init container".

On staging, this works. However, the second time it runs I get this:

```
time="2021-03-10T03:46:12Z" level=error msg="exec failed: container_linux.go:349: starting container process caused \"read init-p: connection rese...
```
Which me think it should *not* work? But I guess the init command is saving the day.