### PR TITLE
Allow arbitrary EFS hostnames

### DIFF
--- a/executor/runtime/docker/docker_test.go
+++ b/executor/runtime/docker/docker_test.go
@@ -252,3 +252,15 @@ func TestFlags(t *testing.T) {
 	_, flags := NewConfig()
 	properties.ConvertFlagsForAltSrc(flags)
 }
+
+func TestIsEFSID(t *testing.T) {
+	var actual bool
+	actual, _ = isEFSID("fs-123450")
+	assert.True(t, actual)
+
+	actual, _ = isEFSID("fs-123450.efs.us-west-1.amazonaws.com")
+	assert.False(t, actual)
+
+	actual, _ = isEFSID("nfs.example.com")
+	assert.False(t, actual)
+}


### PR DESCRIPTION
This is change to allow one to bypass the standard
EFS hostname interpolation, and instead pass in
your own NFS hostname as the "EFS ID".

A hack, but for the usecase where you just have an
NFS hostname you want, this will work.

----

This is a rebase of @rgulewich 's changes.