### PR TITLE
Update ssh apparmor profiles a bit

### DIFF
--- a/executor/runtime/docker/docker_ssh.go
+++ b/executor/runtime/docker/docker_ssh.go
@@ -85,7 +85,7 @@ AcceptEnv LANG LC_*
 
 Subsystem sftp /titus/sshd/usr/lib64/misc/sftp-server
 
-PidFile /run/sshd.pid
+PidFile /dev/null
 `
 
 func addContainerSSHDConfig(c runtimeTypes.Container, tw *tar.Writer, cfg config.Config) error {

--- a/root/etc/apparmor.d/docker_titus
+++ b/root/etc/apparmor.d/docker_titus
@@ -34,6 +34,8 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
   /titus/sshd/usr/sbin/sshd Cx,
 
   profile sshd /titus/sshd/usr/sbin/sshd {
+    # Allow signals from unconfined, usually systemd
+    signal (receive) peer="unconfined",
     signal (send,receive) peer=@{profile_name},
 
     network,


### PR DESCRIPTION
1. Remove pid. apparmor was denying it, but we dont need it anyway
2. Allow unconfined signals. This is to allow it to be
actually killed by something, anything. Mostly systemd.
This is to enable restarting the sshd daemon, if not just
for debug purposes.

----
We've probably all seen
```
Mar 11 00:45:50 titusagent-devkyleacell001-m524xlarge000-i-09ddb9b9159899a2e audit[2890106]: AVC apparmor="ALLOWED" operation="open" profile="docker_titus//sshd" name="/run/sshd.pid" pid=2890106 comm="sshd" requested_mask="wc" denied_mask="wc" fsuid=10000 ouid=10000
```
