### PR TITLE
Homogenize titus systemd template service files

### DIFF
--- a/root/lib/systemd/system/atlas-titus-agent@.service
+++ b/root/lib/systemd/system/atlas-titus-agent@.service
@@ -3,9 +3,8 @@ Description=Metrics Pod for %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 ConditionPathExists=!/etc/disable-atlas-titus-agent
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
@@ -14,3 +13,4 @@ LimitNOFILE=65535
 PrivateTmp=yes
 
 Restart=on-failure
+RestartSec=3

--- a/root/lib/systemd/system/titus-abmetrix@.service
+++ b/root/lib/systemd/system/titus-abmetrix@.service
@@ -2,9 +2,8 @@
 Description=Titus abmetrix for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
@@ -12,5 +11,5 @@ EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE --cwd /titus/abmetrix ${TITUS_CONTAINER_ID} /titus/abmetrix/start
 
 Restart=on-failure
-RestartSec=1
+RestartSec=3
 KillMode=mixed

--- a/root/lib/systemd/system/titus-atlasd@.service
+++ b/root/lib/systemd/system/titus-atlasd@.service
@@ -2,9 +2,8 @@
 Description=Atlas for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
@@ -12,5 +11,5 @@ EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/atlas-titus-agent/start-atlas-titus-agent
 
 Restart=on-failure
-RestartSec=1
+RestartSec=3
 KillMode=mixed

--- a/root/lib/systemd/system/titus-logviewer@.service
+++ b/root/lib/systemd/system/titus-logviewer@.service
@@ -2,9 +2,8 @@
 Description=Titus logviewer for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
@@ -12,5 +11,5 @@ EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE --cwd /titus/adminlogs ${TITUS_CONTAINER_ID} bin/adminlogs
 
 Restart=on-failure
-RestartSec=1
+RestartSec=3
 KillMode=mixed

--- a/root/lib/systemd/system/titus-metadata-proxy@.service
+++ b/root/lib/systemd/system/titus-metadata-proxy@.service
@@ -2,9 +2,8 @@
 Description=Metadata proxy pod container for %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 After=titus-salt-generator.service
 Wants=titus-salt-generator.service

--- a/root/lib/systemd/system/titus-metatron-sync@.service
+++ b/root/lib/systemd/system/titus-metatron-sync@.service
@@ -2,9 +2,8 @@
 Description=Metatron sync for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
@@ -12,5 +11,5 @@ EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/metatron/bin/titus-metatrond
 
 Restart=on-failure
-RestartSec=1
+RestartSec=3
 KillMode=mixed

--- a/root/lib/systemd/system/titus-seccomp-agent@.service
+++ b/root/lib/systemd/system/titus-seccomp-agent@.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Titus seccomp agent for container %i
-# If the service restarts more than 10 times in 30 seconds, let it die
+
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 Type=notify
@@ -10,5 +10,5 @@ EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/usr/bin/tsa
 
 Restart=on-failure
-RestartSec=1
+RestartSec=3
 KillMode=mixed

--- a/root/lib/systemd/system/titus-servicemesh@.service
+++ b/root/lib/systemd/system/titus-servicemesh@.service
@@ -2,9 +2,8 @@
 Description=Titus service mesh sidecar for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
@@ -13,5 +12,5 @@ LimitNOFILE=65536
 ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/proxyd/launcher
 
 Restart=on-failure
-RestartSec=1
+RestartSec=3
 KillMode=mixed

--- a/root/lib/systemd/system/titus-spectatord@.service
+++ b/root/lib/systemd/system/titus-spectatord@.service
@@ -2,9 +2,8 @@
 Description=Spectatord for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
@@ -12,5 +11,5 @@ EnvironmentFile=/var/lib/titus-environments/%i.env
 ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/spectatord/start-spectatord
 
 Restart=on-failure
-RestartSec=1
+RestartSec=3
 KillMode=mixed

--- a/root/lib/systemd/system/titus-sshd@.service
+++ b/root/lib/systemd/system/titus-sshd@.service
@@ -2,9 +2,8 @@
 Description=SSHD for container %s
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
@@ -18,6 +17,7 @@ LimitNOFILE=65535
 ## TODO: Wire up more "lockdown" so this unit can't wreck havoc if it gets compromised
 PrivateTmp=yes
 
+RestartSec=3
 Restart=on-failure
 KillMode=mixed
 

--- a/root/lib/systemd/system/titus-storage@.service
+++ b/root/lib/systemd/system/titus-storage@.service
@@ -4,9 +4,8 @@ ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 # PartOf ensures that titus-storage will shutdown as part of the main titus-executor unit
 PartOf=titus-executor@default__%i.service
 
-# If the service restarts more than 10 times in 30 seconds, let it die
 StartLimitIntervalSec=30
-StartLimitBurst=10
+StartLimitBurst=5
 
 [Service]
 # This command is oneshot, it runs once, mounts and returns


### PR DESCRIPTION
This is two changes:
1. Make sure we are doing RestartSec=3 on every unit
There is no unit that doesn't need to cool down after
crashing. 3 seconds is fine, just *something* so
it doesn't restart literally as fast as it can.

2. Reduce the StartLimitBurst to 5 on all services.
If it didn't start the first 5 times, I don't think it
10 times will help in that same 30s period. Especially
with a RestartSec=3.
