### PR TITLE
Always mkdir when asked to mount in Titus

### DIFF
--- a/mount/Makefile
+++ b/mount/Makefile
@@ -1,11 +1,11 @@
 all: titus-mount-nfs titus-mount-block-device
 
-titus-mount-nfs: titus-mount-nfs.c scm_rights.c
+titus-mount-nfs: titus-mount-nfs.c scm_rights.c common.h
 	# musl needs this extra path here
 	# so it can pick up our linux headers for syscalls
 	C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu/:/usr/include/:. musl-gcc -std=gnu11 -Wall -static -g -o titus-mount-nfs titus-mount-nfs.c scm_rights.c
 
-titus-mount-block-device: titus-mount-block-device.c scm_rights.c
+titus-mount-block-device: titus-mount-block-device.c scm_rights.c common.h
 	gcc -g -static -o titus-mount-block-device titus-mount-block-device.c scm_rights.c
 
 

--- a/mount/common.h
+++ b/mount/common.h
@@ -1,0 +1,30 @@
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+void mkdir_p(const char *dir)
+{
+	char tmp[PATH_MAX];
+	char *p = NULL;
+	size_t len;
+	struct stat st = { 0 };
+
+	snprintf(tmp, sizeof(tmp), "%s", dir);
+	len = strlen(tmp);
+	if (tmp[len - 1] == '/')
+		tmp[len - 1] = 0;
+	for (p = tmp + 1; *p; p++) {
+		if (*p == '/') {
+			*p = 0;
+			if (stat(tmp, &st) == -1) {
+				mkdir(tmp, 0777);
+			}
+			*p = '/';
+		}
+	}
+	if (stat(tmp, &st) == -1) {
+		mkdir(tmp, 0777);
+	}
+}

--- a/mount/titus-mount-block-device.c
+++ b/mount/titus-mount-block-device.c
@@ -22,6 +22,8 @@
 #include <signal.h>
 #include <sys/stat.h>
 
+#include "common.h"
+
 #define E(x)                                                                   \
 	do {                                                                   \
 		if ((x) == -1) {                                               \
@@ -264,7 +266,7 @@ int main(int argc, char *argv[])
 	looks right from the container's perspective */
 	switch_namespaces(nsfd);
 	close(nsfd);
-	mkdir(target, 0777);
+	mkdir_p(target);
 	mount_and_move(fsfd, target, flags_ul);
 
 	fprintf(stderr, "titus-mount-block-device: All done, mounted on %s\n", target);

--- a/mount/titus-mount-nfs.c
+++ b/mount/titus-mount-nfs.c
@@ -18,6 +18,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include "common.h"
+
 char nfs4[] = "nfs4";
 #define E(x)                                                                   \
 	do {                                                                   \
@@ -312,6 +314,7 @@ int main(int argc, char *argv[])
 
 	/* Now we can do the fs_config calls and actual mount */
 	do_fsconfigs(fsfd, final_options);
+	mkdir_p(target);
 	mount_and_move(fsfd, target, pidfd, flags_ul);
 
 	fprintf(stderr, "titus-mount-nfs: All done, mounted on %s\n", target);


### PR DESCRIPTION
In kubernetes, if you ask to mount storage, it will
create the folder for you if it doesn't exist.

I think we should match this behavior, on nfs *and* ebs.
