### PR TITLE
Renamed titus-mount to titus-mount-nfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ checkstyle-result.xml
 /root/apps/titus-executor/bin/titus-reaper
 /root/apps/titus-executor/bin/titus-logviewer
 /root/apps/titus-executor/bin/titus-metadata-service
-/root/apps/titus-executor/bin/titus-mount
+/root/apps/titus-executor/bin/titus-mount-nfs
 /root/apps/titus-executor/bin/titus-mount-block-device
 /root/apps/titus-executor/bin/tini-static
 /root/apps/titus-executor/bin/titus-inject-metadataproxy
@@ -92,7 +92,7 @@ checkstyle-result.xml
 /root/apps/titus-executor/bin/titus-vpc-tool
 /root/apps/titus-executor/bin/titus-nsenter
 
-/mount/titus-mount
+/mount/titus-mount-nfs
 /mount/titus-mount-block-device
 
 # unignore directories named titus-executor

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1574,7 +1574,7 @@ func (r *DockerRuntime) setupEFSMounts(parentCtx context.Context, c runtimeTypes
 		// because the parent window should be greater
 		ctx, cancel := context.WithTimeout(parentCtx, 5*time.Minute)
 		defer cancel()
-		cmd := exec.CommandContext(ctx, "/apps/titus-executor/bin/titus-mount", strconv.Itoa(int(cred.pid))) // nolint: gosec
+		cmd := exec.CommandContext(ctx, "/apps/titus-executor/bin/titus-mount-nfs", strconv.Itoa(int(cred.pid))) // nolint: gosec
 		flags := 0
 		if efsMountInfo.readWriteFlags == ro {
 			flags = flags | MS_RDONLY

--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -10,9 +10,8 @@ gox -gcflags="${GC_FLAGS:--N -l}" -osarch="linux/amd64 darwin/amd64" \
   -output="build/bin/{{.OS}}-{{.Arch}}/{{.Dir}}" -verbose ./cmd/...
 
 # titus-mount helpers
-make -C mount titus-mount
-mv mount/titus-mount build/bin/linux-amd64/
-make -C mount titus-mount-block-device
+make -C mount all
+mv mount/titus-mount-nfs build/bin/linux-amd64/
 mv mount/titus-mount-block-device build/bin/linux-amd64/
 
 # tini

--- a/mount/Dockerfile
+++ b/mount/Dockerfile
@@ -1,6 +1,6 @@
 FROM scratch
 ADD resolv.conf /etc/resolv.conf
-ADD titus-mount titus-mount
+ADD titus-mount-nfs titus-mount-nfs
 ENV MOUNT_OPTIONS=foo,bar
 ENV MOUNT_FLAGS=""
 ENV MOUNT_NFS_HOSTNAME=example.com

--- a/mount/Makefile
+++ b/mount/Makefile
@@ -1,19 +1,19 @@
-all: titus-mount titus-mount-block-device
+all: titus-mount-nfs titus-mount-block-device
 
-titus-mount: mount.c scm_rights.c
+titus-mount-nfs: titus-mount-nfs.c scm_rights.c
 	# musl needs this extra path here
 	# so it can pick up our linux headers for syscalls
-	C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu/:/usr/include/:. musl-gcc -std=gnu11 -Wall -static -g -o titus-mount mount.c scm_rights.c
+	C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu/:/usr/include/:. musl-gcc -std=gnu11 -Wall -static -g -o titus-mount-nfs titus-mount-nfs.c scm_rights.c
 
 titus-mount-block-device: titus-mount-block-device.c scm_rights.c
 	gcc -g -static -o titus-mount-block-device titus-mount-block-device.c scm_rights.c
 
 
-install: titus-mount titus-mount-block-device
-	sudo rsync -a titus-mount titus-mount-block-device /apps/titus-executor/bin/
+install: titus-mount-nfs titus-mount-block-device
+	sudo rsync -a titus-mount-nfs titus-mount-block-device /apps/titus-executor/bin/
 
 clean:
-	rm -f titus-mount titus-mount-block-device
+	rm -f titus-mount-nfs titus-mount-block-device
 
 fmt:
 	clang-format -i *.c *.h

--- a/mount/test.sh
+++ b/mount/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # This is a test harness for experimenting with
-# the statically-linked titus-mount command
+# the statically-linked titus-mount-nfs command
 # in a scratch container.
 set -vxeu
 make
-sudo docker run $(sudo docker build -q . ) ./titus-mount
+sudo docker run $(sudo docker build -q . ) ./titus-mount-nfs

--- a/mount/titus-mount-block-device.c
+++ b/mount/titus-mount-block-device.c
@@ -58,7 +58,7 @@ static void check_messages(int fd)
 static __attribute__((noreturn)) void mount_error(int fd, const char *s)
 {
 	check_messages(fd);
-	fprintf(stderr, "titus-mount mount error on '%s': %m\n", s);
+	fprintf(stderr, "titus-mount-block-device mount error on '%s': %m\n", s);
 	exit(1);
 }
 
@@ -106,7 +106,7 @@ static void process_option(char *option, int fsfd)
 	key = strtok_r(option, "=", &saveptr);
 	option = NULL;
 	value = strtok_r(option, "=", &saveptr);
-	fprintf(stderr, "titus-mount: Setting filesystem mount option %s=%s\n",
+	fprintf(stderr, "titus-mount-block-device: Setting filesystem mount option %s=%s\n",
 		key, value);
 	E_fsconfig(fsfd, FSCONFIG_SET_STRING, key, value, 0);
 }
@@ -254,7 +254,7 @@ int main(int argc, char *argv[])
 	/* First we need to get a fsfd, but it must be created inside the user namespace */
 	fsfd = fork_and_get_fsfd(nsfd, fstype);
 
-	fprintf(stderr, "titus-mount: user-inputed options: %s\n", options);
+	fprintf(stderr, "titus-mount-block-device: user-inputed options: %s\n", options);
 
 	/* Now we can do the fs_config calls and actual mount
 	This isn't possible *inside* the conatiner, because it can't see the device */
@@ -267,6 +267,6 @@ int main(int argc, char *argv[])
 	mkdir(target, 0777);
 	mount_and_move(fsfd, target, flags_ul);
 
-	fprintf(stderr, "titus-mount: All done, mounted on %s\n", target);
+	fprintf(stderr, "titus-mount-block-device: All done, mounted on %s\n", target);
 	return 0;
 }

--- a/mount/titus-mount-nfs.c
+++ b/mount/titus-mount-nfs.c
@@ -34,22 +34,22 @@ static int dns_lookup(const char *hostname, struct sockaddr_in *addr)
 
 	if (inet_aton(hostname, &addr->sin_addr)) {
 		fprintf(stderr,
-			"titus-mount: %s is already an IP. Not doing a DNS lookup\n",
+			"titus-mount-nfs: %s is already an IP. Not doing a DNS lookup\n",
 			hostname);
 		return 0;
 	}
 	fprintf(stderr,
-		"titus-mount: Decoding and resolving dns hostname for %s\n",
+		"titus-mount-nfs: Decoding and resolving dns hostname for %s\n",
 		hostname);
 	hp = gethostbyname(hostname);
 	if (hp == NULL) {
 		int err_ret = h_errno;
-		fprintf(stderr, "titus-mount: can't get address for %s: %s\n",
+		fprintf(stderr, "titus-mount-nfs: can't get address for %s: %s\n",
 			hostname, hstrerror(err_ret));
 		return -1;
 	}
 	if (hp->h_length > (int)sizeof(struct in_addr)) {
-		fprintf(stderr, "titus-mount: got bad hp->h_length");
+		fprintf(stderr, "titus-mount-nfs: got bad hp->h_length");
 		return -1;
 	}
 	memcpy(&addr->sin_addr, hp->h_addr, hp->h_length);
@@ -64,14 +64,14 @@ static void compose_final_options(const char *nfs_mount_hostname,
 	char *ip_string;
 
 	if (dns_lookup(nfs_mount_hostname, &server_addr)) {
-		fprintf(stderr, "titus-mount: DNS lookup failed for %s",
+		fprintf(stderr, "titus-mount-nfs: DNS lookup failed for %s",
 			nfs_mount_hostname);
 		exit(1);
 	}
 	ip_string = inet_ntoa(server_addr.sin_addr);
 	strcat(final_options, ",addr=");
 	strcat(final_options, ip_string);
-	fprintf(stderr, "titus-mount: using these nfs mount options: %s\n",
+	fprintf(stderr, "titus-mount-nfs: using these nfs mount options: %s\n",
 		final_options);
 }
 
@@ -103,7 +103,7 @@ static void check_messages(int fd)
 static __attribute__((noreturn)) void mount_error(int fd, const char *s)
 {
 	check_messages(fd);
-	fprintf(stderr, "titus-mount mount error on '%s': %m\n", s);
+	fprintf(stderr, "titus-mount-nfs mount error on '%s': %m\n", s);
 	exit(1);
 }
 
@@ -151,7 +151,7 @@ static void process_option(char *option, int fsfd)
 	key = strtok_r(option, "=", &saveptr);
 	option = NULL;
 	value = strtok_r(option, "=", &saveptr);
-	fprintf(stderr, "titus-mount: Setting filesystem mount option %s=%s\n",
+	fprintf(stderr, "titus-mount-nfs: Setting filesystem mount option %s=%s\n",
 		key, value);
 	E_fsconfig(fsfd, FSCONFIG_SET_STRING, key, value, 0);
 }
@@ -305,15 +305,15 @@ int main(int argc, char *argv[])
 
 	/* Now we can switch net/mount namespaces so we can lookup the ip and eventually mount */
 	switch_namespaces(pidfd);
-	fprintf(stderr, "titus-mount: user-inputed options: %s\n", options);
+	fprintf(stderr, "titus-mount-nfs: user-inputed options: %s\n", options);
 	compose_final_options(nfs_mount_hostname, final_options);
-	fprintf(stderr, "titus-mount: computed final_options: %s\n",
+	fprintf(stderr, "titus-mount-nfs: computed final_options: %s\n",
 		final_options);
 
 	/* Now we can do the fs_config calls and actual mount */
 	do_fsconfigs(fsfd, final_options);
 	mount_and_move(fsfd, target, pidfd, flags_ul);
 
-	fprintf(stderr, "titus-mount: All done, mounted on %s\n", target);
+	fprintf(stderr, "titus-mount-nfs: All done, mounted on %s\n", target);
 	return 0;
 }


### PR DESCRIPTION
A (theoretically) noop change to make it more clear that the `titus-mount` command is only for NFS.
I think each new storage mounter we add will have its own special sauce.

Ooo or would you like me to do the existing Unix convention of titus-mount.nfs4, titus-mount.block ?