### PR TITLE
Make titus-seccomp-agent die when a task finishes

### DIFF
--- a/root/lib/systemd/system/titus-seccomp-agent@.service
+++ b/root/lib/systemd/system/titus-seccomp-agent@.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Titus seccomp agent for container %i
+# PartOf ensures that it will shutdown as part of the main titus-executor when it stops
+PartOf=titus-executor@default__%i.service
 
 StartLimitIntervalSec=30
 StartLimitBurst=5
@@ -7,7 +9,7 @@ StartLimitBurst=5
 [Service]
 Type=notify
 EnvironmentFile=/var/lib/titus-environments/%i.env
-ExecStart=/usr/bin/tsa
+ExecStart=/usr/bin/tsa --titus-task-id=%i
 
 Restart=on-failure
 RestartSec=3


### PR DESCRIPTION
Unlike many other system sidecars we have, TSA doesn't
inject itself into the pid namespace of a container (yet)?
and doesn't die with the rest of the container "magically".

To make sure it terminates when titus-executor does, preventing
tsa's from hanging around, I make it PartOf titus-executor.

Also, I added a --titus-task-id= command line flag to TSA.
This is kinda a hack, because it is ignored by tsa itself,
but makes it super easy to know which TSA goes to which process
by simply running ps.
