### PR TITLE
Disable uploads using noop backend.

### DIFF
--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -45,6 +45,7 @@ const (
 	titusJobIDKey            = "TITUS_JOB_ID"
 
 	// Passthrough params
+	disableUploadsParam                     = "titusParameter.agent.log.disableUploads"
 	s3WriterRoleParam                       = "titusParameter.agent.log.s3WriterRole"
 	s3BucketNameParam                       = "titusParameter.agent.log.s3BucketName"
 	s3PathPrefixParam                       = "titusParameter.agent.log.s3PathPrefix"
@@ -444,6 +445,13 @@ func (c *TitusInfoContainer) updateLogAttributes(titusInfo *titus.ContainerInfo)
 			return err
 		}
 		c.logUploadRegexp = uploadRegexp
+	}
+
+	if param, ok := titusInfo.GetPassthroughAttributes()[disableUploadsParam]; ok {
+		val, err := strconv.ParseBool(param)
+		if err != nil {
+			c.logUploaderConfig.DisableUpload = val
+		}
 	}
 
 	if param, ok := titusInfo.GetPassthroughAttributes()[s3WriterRoleParam]; ok {

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -22,15 +22,20 @@ type Uploader struct {
 
 // Config specifies the config for the uploader
 type Config struct {
-	S3WriterRole string
-	S3BucketName string
-	S3PathPrefix string
+	DisableUpload bool
+	S3WriterRole  string
+	S3BucketName  string
+	S3PathPrefix  string
 }
 
 // The upload always prefers s3, then copy, and will use a black hole sink if nothing else is configured. The first
 // s3 location or copy destination specified is used. Rest are ignored.
 func NewUploader(config *config.Config, uploaderConfig *Config, iamRole string, taskID string, m metrics.Reporter) (*Uploader, error) {
 	bucketName, useTitusRole := "", true
+
+	if uploaderConfig.DisableUpload {
+		return NewUploaderWithBackend(NewNoopBackend()), nil
+	}
 
 	if len(config.S3Uploaders) > 0 {
 		bucketName = config.S3Uploaders[0]


### PR DESCRIPTION
Allows security sensitive workloads to disable log uploads.