### PR TITLE
Make titus-nsenter (sshd) play well with seccomp notify

### DIFF
--- a/root/etc/apparmor.d/docker_fuse
+++ b/root/etc/apparmor.d/docker_fuse
@@ -1,5 +1,8 @@
 #include <tunables/global>
 
+# DEBUGGING THIS FILE!? :)
+# See the top note in the docker_titus file.
+
 profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
@@ -9,6 +12,8 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
   umount,
   mount,
 
+  # Allow signals send to titus-sshd, usually systemd-shutdown ends up sending these out on shutdown
+  signal (send) peer="docker_titus//sshd",
   signal (send,receive) peer=@{profile_name},
 
   deny mount fstype=tmpfs,
@@ -43,9 +48,11 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
-/titus/sshd/usr/sbin/sshd Cx,
+  /titus/sshd/usr/sbin/sshd Cx,
 
   profile sshd /titus/sshd/usr/sbin/sshd {
+    # Allow signals from unconfined, usually systemd on the host
+    signal (receive) peer="unconfined",
     signal (send,receive) peer=@{profile_name},
 
     network,

--- a/root/etc/apparmor.d/docker_titus
+++ b/root/etc/apparmor.d/docker_titus
@@ -1,5 +1,16 @@
 #include <tunables/global>
 
+# DEBUGGING THIS FILE!? :)
+# Try putting it into complain mode:
+# $ sudo apt-get -y install apparmor-utils
+# $ sudo aa-complain /etc/apparmor.d/docker_titus
+# Do something! What 'would have been DENIED and why?' Check the logs with:
+# $ sudo tail -f /var/log/syslog  | grep apparmor
+# Then reparse the file after changes
+# $ sudo apparmor_parser -r /etc/apparmor.d/docker_titus
+# Then re-enable enforcing to see if you fixed it
+# $ sudo aa-enforce /etc/apparmor.d/docker_titus
+
 profile docker_titus flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
@@ -8,6 +19,8 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  # Allow signals send to titus-sshd, usually systemd-shutdown ends up sending these out on shutdown
+  signal (send) peer="docker_titus//sshd",
   signal (send,receive) peer=@{profile_name},
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
@@ -34,7 +47,7 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
   /titus/sshd/usr/sbin/sshd Cx,
 
   profile sshd /titus/sshd/usr/sbin/sshd {
-    # Allow signals from unconfined, usually systemd
+    # Allow signals from unconfined, usually systemd on the host
     signal (receive) peer="unconfined",
     signal (send,receive) peer=@{profile_name},
 


### PR DESCRIPTION
If you use no_new_privs, like you get when you get a
seccomp-notify filter for TSA, you are not allowed
to switch AppArmor profiles on exec.

You can have an AppArmor profile installed, it just has
to be the exact same profile that you get after
you fork.

This is because the kernel can't be 100% sure that you
wont get new privileges after exec, AppArmor just denies you.

Also expanded the profile to include signals to systemd-shutdown.
