### PR TITLE
Selectively install NO_NEW_PRIVS when adding a seccomp_filter

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -10,7 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install curl && 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     apt-get install -y build-essential make cmake g++ gcc libc6-dev pkg-config \
         libattr1-dev git curl wget jq ruby ruby-dev rubygems lintian unzip bison flex clang llvm musl-tools \
-        linux-libc-dev=5.9~rc4-1~exp1 && \
+        linux-libc-dev=5.9~rc4-1~exp1 libcap-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN gem install --no-ri --no-rdoc fpm

--- a/inject/CMakeLists.txt
+++ b/inject/CMakeLists.txt
@@ -22,4 +22,4 @@ add_executable(titus-inject-metadataproxy titus-inject-metadataproxy.c)
 target_link_libraries(titus-inject-metadataproxy "libnl-3.a" "libnl-route-3.a" pthread)
 
 add_executable(titus-nsenter titus-nsenter.c)
-target_link_libraries(titus-nsenter pthread seccomp-fd-notify)
+target_link_libraries(titus-nsenter pthread seccomp-fd-notify cap)

--- a/tini/CMakeLists.txt
+++ b/tini/CMakeLists.txt
@@ -80,11 +80,13 @@ configure_file (
 include_directories ("${PROJECT_BINARY_DIR}")
 
 add_executable (tini src/tini.c src/seccomp_fd_notify.c)
+target_link_libraries(tini seccomp-fd-notify cap)
 
 add_library (seccomp-fd-notify STATIC src/seccomp_fd_notify.c)
+target_link_libraries(seccomp-fd-notify cap)
 
 add_executable (tini-static src/tini.c src/seccomp_fd_notify.c)
-set_target_properties (tini-static PROPERTIES LINK_FLAGS "-Wl,--no-export-dynamic -static")
+target_link_libraries(tini-static seccomp-fd-notify cap -static)
 
 # Installation
 install (TARGETS tini DESTINATION bin)


### PR DESCRIPTION
Including NO_NEW_PRIVs is mostly incompatible with apparmor
profile-switching, which is cumbersome for ssh, but the bigger
showstoper is that sudo stops working.

(nfsuper) ~ $ sudo bash
sudo: effective uid is not 0, is /usr/bin/sudo on a file system with the 'nosuid' option set or an NFS file system without root privileges?

This is similar to what we saw in real kubelet, which had
NO_NEW_PRIVS on all the time.

But that is OK, we can have our cake and eat it too, but only
doing NO_NEW_PRIVS when we *don't* have CAP_SYSADMIN.

This means SSH can still be root, and get the seccomp_filter.

I don't know what the implications are of other workloads
at Netflix. I bet there are some workloads that are trying
to use setuid binaries (sudo), which will not work after this
is in place and they start using TSA.
