### PR TITLE
First pass MVP at titus-logviewer using HTTPS

### DIFF
--- a/logviewer/conf/conf.go
+++ b/logviewer/conf/conf.go
@@ -12,6 +12,8 @@ var (
 	ContainerID        = ""
 	RunningInContainer = false
 	ProxyMode          = true
+	CertFile           = ""
+	KeyFile            = ""
 )
 
 func init() {
@@ -32,10 +34,15 @@ func init() {
 		ProxyMode = false
 	}
 
+	CertFile = os.Getenv("TITUS_LOGVIEWER_CERT")
+	KeyFile = os.Getenv("TITUS_LOGVIEWER_KEY")
+
 	log.WithFields(log.Fields{
 		"ContainersHome":     ContainersHome,
 		"ContainerID":        ContainerID,
 		"RunningInContainer": RunningInContainer,
 		"ProxyMode":          ProxyMode,
+		"CertFile":           CertFile,
+		"KeyFile":            KeyFile,
 	}).Info("Config loaded")
 }

--- a/root/apps/titus-executor/bin/run-titus-logviewer.sh
+++ b/root/apps/titus-executor/bin/run-titus-logviewer.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -euo pipefail
-
+source /etc/titus-executor/config.sh
 exec /apps/titus-executor/bin/titus-logviewer


### PR DESCRIPTION
Since we use browsers to access this endpoint and read these files,
it is becoming increasingly more important to use HTTPS.

It this is a good approach (seems easy), I can add rotation triggers,
add the env variables to our local config in Netflix to point to
web-ready certs, and change the UI to point at https instead of
http.

I have verified that the web.certs we have *do* respond cleanly
to their IP:<ip>.
