### PR TITLE
Always run stop sequence on failed titus-storage starts

### DIFF
--- a/cmd/titus-storage/ebs.go
+++ b/cmd/titus-storage/ebs.go
@@ -27,11 +27,16 @@ func ebsRunner(ctx context.Context, command string, config MountConfig) error {
 	ec2Session := getEC2Session()
 	ec2Client := getEc2Client(ec2Session)
 	ec2InstanceID := getEC2InstanceID(ec2Session)
+	l := logger.GetLogger(ctx)
 	var err error
 
 	switch command {
 	case "start":
 		err = ebsStart(ctx, ec2Client, config, ec2InstanceID)
+		if err != nil {
+			l.Error("Failed to start. Running stop sequence now as we wont get a stop command later on TASK_LOST")
+			_ = ebsStop(ctx, ec2Client, config, ec2InstanceID)
+		}
 	case "stop":
 		err = ebsStop(ctx, ec2Client, config, ec2InstanceID)
 	default:


### PR DESCRIPTION
Normally we get a 'stop' command when a container dies
or gets killed.

But if the container never even starts up completely,
titus-storage will never get a 'stop' command,
because we the `titus-container` target was never reached
in the first place!

Running the 'stop' sequence if there is any error ensures
we do any cleanup we need here.

----

This isn't a 100% solution, someday we will still need some super garbage collector, but this covers the 99%.