### PR TITLE
Remove custom sslTitusAgentCA logic from titus-vpc-service

### DIFF
--- a/vpc/service/auth.go
+++ b/vpc/service/auth.go
@@ -2,21 +2,11 @@ package service
 
 import (
 	"context"
-	x509 "crypto/x509"
-	"fmt"
-
-	"github.com/pkg/errors"
-
-	"google.golang.org/grpc/credentials"
 
 	"github.com/Netflix/titus-executor/logger"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-)
-
-var (
-	errNoAuth = errors.New("No authentication")
 )
 
 func (*vpcService) authFunc(ctx context.Context) (context.Context, error) {
@@ -39,30 +29,7 @@ type titusVPCAgentServiceAuthFuncOverride struct {
 }
 
 func (vpcService *titusVPCAgentServiceAuthFuncOverride) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
-	peer, ok := peer.FromContext(ctx)
-	if !ok {
-		return ctx, status.Error(codes.Internal, "Could not retrieve peer from context")
-	}
-	if peer.AuthInfo == nil {
-		// TODO: Log this
-		return ctx, errNoAuth
-	}
-
-	tlsInfo, ok := peer.AuthInfo.(credentials.TLSInfo)
-	if !ok {
-		return ctx, fmt.Errorf("Received unexpected authentication type: %s", peer.AuthInfo.AuthType())
-	}
-	sv := tlsInfo.GetSecurityValue().(*credentials.TLSChannelzSecurityValue)
-	cert, err := x509.ParseCertificate(sv.RemoteCertificate)
-	if err != nil {
-		return ctx, errors.Wrap(err, "Cannot parse remote certificate")
-	}
-	_, err = cert.Verify(x509.VerifyOptions{
-		Roots:     vpcService.TitusAgentCACertPool,
-		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to verify client cert")
-	}
+	// TODO: Authn happens via the normal TLS verification, here is where
+	// we can add additional verification, like looking at the CN.
 	return ctx, nil
 }

--- a/vpc/service/service.go
+++ b/vpc/service/service.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"database/sql"
 	"fmt"
 	"net"
@@ -89,8 +88,6 @@ type vpcService struct {
 
 	refreshLock *semaphore.Weighted
 
-	TitusAgentCACertPool *x509.CertPool
-
 	dbRateLimiter *rate.Limiter
 
 	trunkNetworkInterfaceDescription  string
@@ -170,7 +167,6 @@ type Config struct {
 	ReconcileInterval     time.Duration
 	RefreshInterval       time.Duration
 	TLSConfig             *tls.Config
-	TitusAgentCACertPool  *x509.CertPool
 
 	EnabledLongLivedTasks []string
 	EnabledTaskLoops      []string
@@ -223,8 +219,6 @@ func Run(ctx context.Context, config *Config) error {
 		refreshInterval: config.RefreshInterval,
 
 		refreshLock: semaphore.NewWeighted(config.MaxConcurrentRefresh),
-
-		TitusAgentCACertPool: config.TitusAgentCACertPool,
 
 		dbRateLimiter: rate.NewLimiter(1000, 1),
 

--- a/vpc/service/service_test.go
+++ b/vpc/service/service_test.go
@@ -49,7 +49,6 @@ func TestService(t *testing.T) {
 			ReconcileInterval:     5 * time.Minute,
 			RefreshInterval:       30 * time.Second,
 			TLSConfig:             nil,
-			TitusAgentCACertPool:  nil,
 			EnabledTaskLoops:      []string{},
 			EnabledLongLivedTasks: []string{},
 			WorkerRole:            "testWorkerRole",


### PR DESCRIPTION
This sslTitusAgentCA logic was a mistake, I didn't really
understand how mutualtls worked on grpc, and thought
we needed to do additional verification on the certificates
in this auth function.

This auth function used the 'web.crt', which happened to have
the intermediate CA, so it "worked". However, when that
intermediate CA rolled, there was mistmatch between the
client and server, so this verification function failed.

It failed, *even though* the golang tls stuff was doing its
job by verifying that the 'web.crt' was *actually valid* by
traversing all the way up to the normal SSL CA stuff.

This PR removes my not-needed verification in favor of
the normal stuff. A different PR (#427) will fix the todo
and add *authz* to complement the mtls authn.
