### PR TITLE
Use a new cached cert provider so we don't load certs on every request

### DIFF
--- a/utils/tls/tls.go
+++ b/utils/tls/tls.go
@@ -2,6 +2,7 @@ package tls
 
 import (
 	"crypto/tls"
+	"sync"
 	"time"
 )
 
@@ -10,6 +11,7 @@ type CachedCertificateLoader struct {
 	KeyPath     string
 	certificate *tls.Certificate
 	nextReload  time.Time
+	lock        sync.Mutex
 }
 
 // Get Certificate uses the cachedCertificateLoader struct
@@ -22,6 +24,8 @@ func (c *CachedCertificateLoader) GetCertificate(nowFunc func() time.Time) (*tls
 		now = nowFunc()
 	}
 	if now.After(c.nextReload) {
+		c.lock.Lock()
+		defer c.lock.Unlock()
 		cert, err := tls.LoadX509KeyPair(c.CertPath, c.KeyPath)
 		if err != nil {
 			return nil, err

--- a/utils/tls/tls.go
+++ b/utils/tls/tls.go
@@ -1,0 +1,33 @@
+package tls
+
+import (
+	"crypto/tls"
+	"time"
+)
+
+type CachedCertificateLoader struct {
+	CertPath    string
+	KeyPath     string
+	certificate *tls.Certificate
+	nextReload  time.Time
+}
+
+// Get Certificate uses the cachedCertificateLoader struct
+// to automatically reload the certificate from disk every hour
+func (c *CachedCertificateLoader) GetCertificate(nowFunc func() time.Time) (*tls.Certificate, error) {
+	var now time.Time
+	if nowFunc == nil {
+		now = time.Now()
+	} else {
+		now = nowFunc()
+	}
+	if now.After(c.nextReload) {
+		cert, err := tls.LoadX509KeyPair(c.CertPath, c.KeyPath)
+		if err != nil {
+			return nil, err
+		}
+		c.certificate = &cert
+		c.nextReload = now.Add(1 * time.Hour)
+	}
+	return c.certificate, nil
+}


### PR DESCRIPTION
Use a cached TLS cert loader instead of loading cert on every request
    
It is not very performant to load our ssl certificates
on every request using the `GetCertificate` method.
    
This new wrapper is based of our internal Netflix version,
which reloads the cert once per hour.

I've applied it to the titus-vpc-service and logviewer.