### PR TITLE
Added a new titus-mount-bind command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,8 +85,9 @@ checkstyle-result.xml
 /root/apps/titus-executor/bin/titus-reaper
 /root/apps/titus-executor/bin/titus-logviewer
 /root/apps/titus-executor/bin/titus-metadata-service
+/root/apps/titus-executor/bin/titus-mount-bind
 /root/apps/titus-executor/bin/titus-mount-block-device
-/root/apps/titus-executor/bin/titus-mount-block-ceph
+/root/apps/titus-executor/bin/titus-mount-ceph
 /root/apps/titus-executor/bin/titus-mount-nfs
 /root/apps/titus-executor/bin/tini-static
 /root/apps/titus-executor/bin/titus-inject-metadataproxy
@@ -94,6 +95,7 @@ checkstyle-result.xml
 /root/apps/titus-executor/bin/titus-vpc-tool
 /root/apps/titus-executor/bin/titus-nsenter
 
+/mount/titus-mount-bind
 /mount/titus-mount-block-device
 /mount/titus-mount-ceph
 /mount/titus-mount-nfs

--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -12,7 +12,9 @@ gox -gcflags="${GC_FLAGS:--N -l}" -osarch="linux/amd64 darwin/amd64" \
 
 # titus-mount helpers
 make -C mount all
+mv mount/titus-mount-bind build/bin/linux-amd64/
 mv mount/titus-mount-block-device build/bin/linux-amd64/
+mv mount/titus-mount-ceph build/bin/linux-amd64/
 mv mount/titus-mount-nfs build/bin/linux-amd64/
 
 # tini

--- a/mount/Makefile
+++ b/mount/Makefile
@@ -1,9 +1,12 @@
-all: titus-mount-nfs titus-mount-block-device titus-mount-ceph
+all: titus-mount-nfs titus-mount-block-device titus-mount-ceph titus-mount-bind
 
 titus-mount-nfs: titus-mount-nfs.c scm_rights.c common.h
 	# musl needs this extra path here
 	# so it can pick up our linux headers for syscalls
 	C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu/:/usr/include/:. musl-gcc -std=gnu11 -Wall -static -g -o titus-mount-nfs titus-mount-nfs.c scm_rights.c
+
+titus-mount-bind: titus-mount-bind.c scm_rights.c common.h
+	gcc -g -static -o titus-mount-bind titus-mount-bind.c scm_rights.c
 
 titus-mount-ceph: titus-mount-ceph.c scm_rights.c common.h
 	gcc -g -static -Wall -o titus-mount-ceph titus-mount-ceph.c scm_rights.c
@@ -11,11 +14,11 @@ titus-mount-ceph: titus-mount-ceph.c scm_rights.c common.h
 titus-mount-block-device: titus-mount-block-device.c scm_rights.c common.h
 	gcc -g -static -o titus-mount-block-device titus-mount-block-device.c scm_rights.c
 
-install: titus-mount-nfs titus-mount-ceph titus-mount-block-device
-	sudo rsync -a titus-mount-nfs titus-mount-block-device titus-mount-ceph /apps/titus-executor/bin/
+install: titus-mount-nfs titus-mount-ceph titus-mount-block-device titus-mount-bind
+	sudo rsync -a titus-mount-nfs titus-mount-block-device titus-mount-ceph titus-mount-bind /apps/titus-executor/bin/
 
 clean:
-	rm -f titus-mount-nfs titus-mount-block-device titus-mount-ceph
+	rm -f titus-mount-nfs titus-mount-block-device titus-mount-ceph titus-mount-bind 
 
 fmt:
 	clang-format -i *.c *.h

--- a/mount/titus-mount-bind.c
+++ b/mount/titus-mount-bind.c
@@ -1,0 +1,186 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+/* getaddrinfo */
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <string.h>
+/* setns */
+#include <sched.h>
+/* for mount syscalls */
+#include <asm-generic/unistd.h>
+/* sys/mount MUST be included before linux/mount */
+#include <sys/mount.h>
+
+#include <linux/mount.h>
+/* fcntl */
+#include "scm_rights.h"
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+/* mkdir */
+#include <linux/limits.h>
+#include <signal.h>
+#include <sys/stat.h>
+
+#include "common.h"
+
+#define E(x)                                                                   \
+	do {                                                                   \
+		if ((x) == -1) {                                               \
+			perror(#x);                                            \
+			exit(1);                                               \
+		}                                                              \
+	} while (0)
+
+static void check_messages(int fd)
+{
+	char buf[4096];
+	int err, n;
+	err = errno;
+	for (;;) {
+		n = read(fd, buf, sizeof(buf));
+		if (n < 0)
+			break;
+		n -= 2;
+		switch (buf[0]) {
+		case 'e':
+			fprintf(stderr, "Error: %*.*s\n", n, n, buf + 2);
+			break;
+		case 'w':
+			fprintf(stderr, "Warning: %*.*s\n", n, n, buf + 2);
+			break;
+		case 'i':
+			fprintf(stderr, "Info: %*.*s\n", n, n, buf + 2);
+			break;
+		}
+	}
+	errno = err;
+}
+
+static __attribute__((noreturn)) void mount_error(int fd, const char *s)
+{
+	check_messages(fd);
+	fprintf(stderr, "titus-mount-bind mount error on '%s': %m\n", s);
+	exit(1);
+}
+
+static inline int pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(__NR_pidfd_open, pid, flags);
+}
+
+static inline int fsopen(const char *fs_name, unsigned int flags)
+{
+	return syscall(__NR_fsopen, fs_name, flags);
+}
+
+static inline int move_mount(int from_dfd, const char *from_pathname,
+			     int to_dfd, const char *to_pathname,
+			     unsigned int flags)
+{
+	return syscall(__NR_move_mount, from_dfd, from_pathname, to_dfd,
+		       to_pathname, flags);
+}
+
+static inline int sys_open_tree(int dfd, const char *filename,
+				unsigned int flags)
+{
+	return syscall(__NR_open_tree, dfd, filename, flags);
+}
+
+static inline int sys_mount_setattr(int dfd, const char *path,
+				    unsigned int flags, struct mount_attr *attr,
+				    size_t size)
+{
+	return syscall(__NR_mount_setattr, dfd, path, flags, attr, size);
+}
+
+static void switch_namespaces(int nsfd)
+{
+	int ret;
+	int mnt_fd = openat(nsfd, "mnt", O_RDONLY);
+	assert(mnt_fd != -1);
+	ret = setns(mnt_fd, CLONE_NEWNS);
+	if (ret == -1) {
+		perror("setns mnt");
+		exit(1);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	int nsfd, fsfd;
+	long int container_pid;
+	unsigned long flags_ul;
+	/*
+	 * We do this because parsing args is a bigger pain than passing
+	 * via environment variable, although passing via environment
+	 * variable has a "cost" in that they are limited in size
+	 */
+	const char *target = getenv("MOUNT_TARGET");
+	const char *source = getenv("MOUNT_HOST_PATH");
+	const char *flags = getenv("MOUNT_FLAGS");
+	const char *pid1dir = getenv("TITUS_PID_1_DIR");
+
+	if (!(target && flags && source && pid1dir)) {
+		fprintf(stderr,
+			"Usage: must provide MOUNT_TARGET, MOUNT_FLAGS, MOUNT_HOST_PATH, and TITUS_PID_1_DIR env vars");
+		return 1;
+	}
+
+	errno = 0;
+	flags_ul = strtoul(flags, NULL, 10);
+	if (errno) {
+		perror("flags");
+		return 1;
+	}
+
+	/* This nsfd is used to extract other namespaces to switch to, similar to a pidfd */
+	char pid1_ns_path[PATH_MAX];
+	snprintf(pid1_ns_path, PATH_MAX - 1, "%s/ns", pid1dir);
+	nsfd = open(pid1_ns_path, O_PATH);
+	if (nsfd == -1) {
+		perror("pidfd_open");
+		return 1;
+	}
+
+	/* source_dfd is an fd we use just for the sake of creating an open_tree fd */
+	int source_dfd = open(source, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+	if (source_dfd < 0) {
+		perror("open");
+		return 1;
+	}
+	/* fd_tree is like a mountfd, which can be manipulated and moved */
+	int fd_tree = sys_open_tree(source_dfd, ".",
+				    OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC |
+					    AT_EMPTY_PATH);
+	if (fd_tree < 0) {
+		perror("fd_tree open_tree");
+		return 1;
+	}
+
+	/* Now that we have a mountfd (an open_tree fd really), we can set mount flags */
+	sys_mount_setattr(fd_tree, "", AT_EMPTY_PATH, MOUNT_ATTR_RDONLY,
+			  MOUNT_ATTR_RDONLY);
+
+	/* Before we mount, we want to switch namespaces so that the move looks correct
+	and it will show up in the /proc/mounts of the container */
+	switch_namespaces(nsfd);
+	close(nsfd);
+
+	mkdir_p(target);
+	/* This final procedure moves the fd_tree onto the target directory, "mounting" it */
+	int to_dfd = open(source, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+	if (to_dfd < 0) {
+		perror("to_fd open");
+		exit(1);
+	}
+	E(move_mount(fd_tree, "", -EBADF, target, MOVE_MOUNT_F_EMPTY_PATH));
+
+	fprintf(stderr, "titus-mount-bind: All done, mounted on %s\n", target);
+	return 0;
+}


### PR DESCRIPTION
In the same family as the other titus-mount commands,
but for bind mounts.

In the future I want to be able to use this to generate
on-the-fly bind mounts on *running* containers.

This will be useful to do for debug mode, but also
for dynamic mounts from the titus-storage command for
ephemeral drives.

This uses the brand new open_tree, mount_setattr, and
move_mount syscalls.

----

Just opening this so I can find it later.

This PR won't be mergable till we have a kernel with mount_setattr on kernel 5.12