### PR TITLE
Adjust titus-ssh to be compatible with scratch containers

### DIFF
--- a/hack/images/titus-sshd/Dockerfile
+++ b/hack/images/titus-sshd/Dockerfile
@@ -37,6 +37,8 @@ RUN for i in $(scanelf --recursive --mount --symlink --etype ET_DYN --perms 0700
 RUN /titus/sshd/usr/bin/ssh-keygen -A
 RUN ln -s /etc/resolv.conf /titus/sshd/etc/
 RUN ln -s /etc/passwd /titus/sshd/etc/
+RUN ln -s /titus/sshd/bin/busybox /titus/sshd/bin/sh
 RUN rm /titus/sshd/etc/ssh/sshd_config && ln -s /titus/etc/ssh/sshd_config /titus/sshd/etc/ssh/sshd_config
 FROM scratch
 COPY --from=builder /titus/sshd /titus/sshd
+ADD run-titus-sshd /titus/sshd/run-titus-sshd

--- a/hack/images/titus-sshd/run-titus-sshd
+++ b/hack/images/titus-sshd/run-titus-sshd
@@ -1,0 +1,55 @@
+#!/titus/sshd/bin/busybox sh
+
+# For security and portability we make sure we only use the busybox utilities
+# and make no assumptions about the path and what other binaries
+# might be deployed
+cat="/titus/sshd/bin/busybox cat"
+grep="/titus/sshd/bin/busybox grep"
+mkdir="/titus/sshd/bin/busybox mkdir"
+touch="/titus/sshd/bin/busybox touch"
+
+log() {
+  echo "titus-sshd: $*" >&2
+}
+
+write_etc_profile() {
+$cat > /etc/profile <<'EOF'
+if [ -d /etc/profile.d ]; then
+  for i in /etc/profile.d/*.sh; do
+    if [ -r $i ]; then
+      . $i
+    fi
+  done
+  unset i
+fi
+EOF
+}
+
+setup_files() {
+  # These are the bare minimum set of files that
+  # must exist for ssh to work
+  [ -f /etc/passwd ] || ($touch /etc/passwd && log "setting up /etc/passwd for ssh to work")
+  [ -d /var/log ] || ($mkdir -p /var/log && log "creating /var/log for ssh to work")
+  [ -f /var/log/lastlog ] || ($touch /var/log/lastlog && log "creating /var/log/lastlog for ssh to work")
+  [ -f /etc/profile ] || (write_etc_profile && log "creating /etc/profile for environment variables to work")
+}
+
+setup_users() {
+  # nfsuper is the standard user that netflix users to
+  # ssh containers. If it doesn't exist in /etc/passwd,
+  # then we might as well make it a 'root' (uid 0) user.
+  if ! $grep -q nfsuper /etc/passwd; then
+    log "Adding the 'nfsuper' user into /etc/passwd"
+    echo 'nfsuper:x:0:0:root:/root:/titus/sshd/bin/sh' >> /etc/passwd
+  fi
+  # Nobody is an ssh requirement for privilege separation
+  if ! $grep -q nobody /etc/passwd; then
+    log "Adding the 'nobody' user into /etc/passwd"
+    echo 'nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin' >> /etc/passwd
+  fi
+}
+
+setup_files
+setup_users
+
+exec /titus/sshd/usr/sbin/sshd "$@"

--- a/root/etc/apparmor.d/docker_fuse
+++ b/root/etc/apparmor.d/docker_fuse
@@ -43,9 +43,9 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
-/titus/sshd/usr/sbin/sshd Cx,
+/titus/sshd/usr/sbin/run-titus-sshd Cx,
 
-  profile sshd /titus/sshd/usr/sbin/sshd {
+  profile sshd /titus/sshd/usr/sbin/run-titus-sshd {
     signal (send,receive) peer=@{profile_name},
 
     network,

--- a/root/etc/apparmor.d/docker_titus
+++ b/root/etc/apparmor.d/docker_titus
@@ -31,9 +31,9 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
-  /titus/sshd/usr/sbin/sshd Cx,
+  /titus/sshd/usr/sbin/run-titus-sshd Cx,
 
-  profile sshd /titus/sshd/usr/sbin/sshd {
+  profile sshd /titus/sshd/usr/sbin/run-titus-sshd {
     # Allow signals from unconfined, usually systemd
     signal (receive) peer="unconfined",
     signal (send,receive) peer=@{profile_name},

--- a/root/lib/systemd/system/titus-sidecar-sshd@.service
+++ b/root/lib/systemd/system/titus-sidecar-sshd@.service
@@ -14,7 +14,7 @@ Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
 # get TSA help too. This environment variable ensures that will happen.
 Environment=TITUS_NSENTER_USE_TSA=true
 EnvironmentFile=/var/lib/titus-environments/%i.env
-ExecStart=/apps/titus-executor/bin/titus-nsenter /titus/sshd/usr/sbin/sshd -D -e
+ExecStart=/apps/titus-executor/bin/titus-nsenter /titus/sshd/usr/sbin/run-titus-sshd -D -e
 LimitNOFILE=65535
 ## TODO: Wire up more "lockdown" so this unit can't wreck havoc if it gets compromised
 PrivateTmp=yes


### PR DESCRIPTION
This allows titus-ssh to work on minimal containers
(tested with scratch & alpine).

And in general, will allow ssh to work on any wacky
container our users can come up with, and still
have "the titus experience" where they can ssh
to it and get at least some sort of shell.
