### PR TITLE
Don't fail a task start if a non-required system service fails

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -810,9 +810,12 @@ func (r *DockerRuntime) createVolumeContainerFunc(sOpts *runtimeTypes.ServiceOpt
 
 		createErr := r.createVolumeContainer(ctx, &sOpts.ContainerName, cfg, hostConfig)
 		if createErr != nil {
-			return errors.Wrapf(createErr, "Unable to setup %s container '%s'", sOpts.ServiceName, sOpts.ContainerName)
+			if sOpts.Required {
+				return errors.Wrapf(createErr, "Unable to setup required %s container '%s'", sOpts.ServiceName, sOpts.ContainerName)
+			}
+			logger.G(ctx).WithField("serviceName", sOpts.ServiceName).Warnf("Unable to setup optional %s container '%s': %s", sOpts.ServiceName, sOpts.ContainerName, createErr)
+			return nil
 		}
-
 		return nil
 	}
 }


### PR DESCRIPTION
We have the notion of `Required` on a system service, which
currently checks to make sure the return of `systemctl start`
is good.

This new change makes it so we also don't bother if creating
the volume container for that system service in the first place
fails!

This makes it so that someone can push a non-existant image of say, `abmetrix`
and titus containers will still launch OK.
