### PR TITLE
Implemented first MVP of multi-container user workloads (pods)

### DIFF
--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -62,7 +63,7 @@ func (r *runtimeMock) Prepare(ctx context.Context) error {
 	return nil
 }
 
-func (r *runtimeMock) Start(ctx context.Context) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
+func (r *runtimeMock) Start(ctx context.Context, pod *v1.Pod) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
 	r.t.Log("runtimeMock.Start", r.c.TaskID())
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1336,7 +1336,7 @@ func (r *DockerRuntime) Start(parentCtx context.Context, pod *v1.Pod) (string, *
 		return "", nil, statusMessageChan, err
 	}
 
-	logDir, err := r.waitForTini(ctx, listener, efsMountInfos, r.c)
+	logDir, err := r.waitForTini(ctx, listener, r.c)
 	if err != nil {
 		eventCancel()
 		err = fmt.Errorf("container prestart error: %w", err)

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1437,6 +1437,7 @@ func k8sContainerToDockerConfigs(v1Container v1.Container, mainContainerID strin
 		WorkingDir: v1Container.WorkingDir,
 		Entrypoint: v1Container.Command,
 		Labels:     labels,
+		Env:        v1ConatinerEnvToList(v1Container.Env),
 	}
 	dockerHostConfig := &container.HostConfig{
 		NetworkMode: container.NetworkMode("container:" + mainContainerID),
@@ -1459,6 +1460,14 @@ func k8sContainerToDockerConfigs(v1Container v1.Container, mainContainerID strin
 	// Nothing extra is needed here, because networking is defined in the HostConfig referencing the main container
 	dockerNetworkConfig := &network.NetworkingConfig{}
 	return dockerContainerConfig, dockerHostConfig, dockerNetworkConfig
+}
+
+func v1ConatinerEnvToList(v1Env []v1.EnvVar) []string {
+	envList := []string{}
+	for _, e := range v1Env {
+		envList = append(envList, e.Name+"="+e.Value)
+	}
+	return envList
 }
 
 // return true to exit

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -206,9 +206,6 @@ func NewTitusInfoContainer(taskID string, titusInfo *titus.ContainerInfo, resour
 	}
 
 	if pod != nil {
-		if l := len(pod.Spec.Containers); l != 1 {
-			return nil, fmt.Errorf("Pod has unexpected number of containers (not 1): %d", l)
-		}
 		c.pod = pod.DeepCopy()
 	}
 

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -444,7 +444,7 @@ type Runtime interface {
 	// NOT per-operation
 	Prepare(containerCtx context.Context) error
 	// Start a container -- Returns an optional Log Directory if an external Logger is desired
-	Start(containerCtx context.Context) (string, *Details, <-chan StatusMessage, error)
+	Start(containerCtx context.Context, pod *corev1.Pod) (string, *Details, <-chan StatusMessage, error)
 	// Kill a container. MUST be idempotent.
 	Kill(ctx context.Context) error
 	// Cleanup can be called to tear down resources after a container has been Killed or has naturally

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0
-	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
 	github.com/ftrvxmtrx/fd v0.0.0-20150925145434-c6d800382fff
 	github.com/gogo/protobuf v1.3.1
@@ -42,6 +42,7 @@ require (
 	github.com/karlseguin/ccache/v2 v2.0.7-0.20200814031513-0dbf3f125f13
 	github.com/leanovate/gopter v0.0.0-20170420174722-9e6101e5a875
 	github.com/lib/pq v1.3.0
+	github.com/moby/sys/mount v0.2.0
 	github.com/mvisonneau/go-ebsnvme v0.0.0-20201026165225-e63797fabc2f
 	github.com/myitcv/gobin v0.0.9
 	github.com/netflix-skunkworks/opencensus-go-exporter-datadog v0.0.0-20190911150647-ef71dde58796

--- a/go.sum
+++ b/go.sum
@@ -618,6 +618,10 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/moby v0.0.0-20190408150954-50ebe4562dfc h1:dMVHdifQDHYbnCNL8WzPpTJ1OV8JIeiOYbgtf2pgO3k=
 github.com/moby/moby v0.0.0-20190408150954-50ebe4562dfc/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
+github.com/moby/sys v0.0.0-20210311035424-40883be4345c h1:EWILMjCOIbZO3KfT0Nx+5L0+6MRrLkFMtPNAP/+Rg60=
+github.com/moby/sys/mount v0.2.0 h1:WhCW5B355jtxndN5ovugJlMFJawbUODuW8fSnEH6SSM=
+github.com/moby/sys/mount v0.2.0/go.mod h1:aAivFE2LB3W4bACsUXChRHQ0qKWsetY4Y9V7sxOougM=
+github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -1101,6 +1105,8 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200602100848-8d3cce7afc34 h1:u6CI7A++8r4SItZHYe2cWeAEndN4p1p+3Oum/Ft2EzM=
 golang.org/x/sys v0.0.0-20200602100848-8d3cce7afc34/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200922070232-aee5d888a860/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=

--- a/hack/run-pod-locally.sh
+++ b/hack/run-pod-locally.sh
@@ -39,12 +39,18 @@ docker run -ti --privileged --security-opt seccomp=unconfined -v /sys/fs/cgroup:
   -e METATRON_SERVICE_IMAGE="/ps/titus-metatron-identity" \
   -e PROXYD_SERVICE_IMAGE="/ipc/proxyd-rootless-candidate@sha256:9d5e5292015856b60cfcca51024cdceba1b07f9fe952b96ccac4b741aab43708" \
   -e ABMETRIX_SERVICE_IMAGE="/baseos/nflx-abmetrix-titus@sha256:0b01b2d74b9b62c7ad85007da0491d40c1f80e5812676667bedcade2448f24e3" \
+  -e TITUS_EXECUTOR_TINI_PATH="${PWD}/build/bin/linux-amd64/tini-static" \
   --rm --name "$docker_container_name" \
   -d \
   -e SHORT_CIRCUIT_QUITELITE=true --label "$run_id" titusoss/titus-agent
 
 log "Copying test metatron certs to their correct location"
 docker exec "$docker_container_name" /metatron/certificates/setup-metatron-certs.sh
+
+if [[ -e ${PWD}/build/bin/linux-amd64/tini-static ]]; then
+  log "Copying the linux tini binary out for use"
+  docker cp "$docker_container_name":/apps/titus-executor/bin/tini-static ${PWD}/build/bin/linux-amd64/tini-static
+fi
 
 log "Running titus-standalone in $docker_container_name"
 docker exec "$docker_container_name" /apps/titus-executor/bin/titus-standalone \

--- a/hack/run-pod-locally.sh
+++ b/hack/run-pod-locally.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -eu -o pipefail
+POD_TASK_ID=$(jq -r .metadata.name pod.json)
+run_id=$(od -N 16 -x /dev/urandom | head -1 | awk '{OFS="-"; print $2$3,$4,$5,$6,$7$8$9}')
+log() {
+    echo -e "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $1" >&2
+}
+
+docker_container_name="titus-standalone-${run_id}"
+terminate_titus_docker() {
+    log "## Titus standalone run exited. Terminating docker container"
+    docker logs $POD_TASK_ID || true
+    docker exec "$docker_container_name" journalctl > titus-standalone.log || true
+    log "## Dumpped logs to 'titus-standalone.log'"
+    docker logs -f $docker_container_name &
+    log "Stopping container: $docker_container_name"
+    docker stop "$docker_container_name" 2>/dev/null || true
+    log "Container stopped (rc: $?)"
+}
+
+trap terminate_titus_docker EXIT
+
+if ! [[ -f "${PWD}/pod.json" ]]; then
+  echo "This script requires ${PWD}/pod.json to exist, please run from the root directory"
+  exit 1
+fi
+
+log "Running a docker daemon named $docker_container_name"
+docker stop "/$POD_TASK_ID" || true
+docker rm "/$POD_TASK_ID" || true
+docker run -ti --privileged --security-opt seccomp=unconfined -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+  -w / -v ${PWD}:/work \
+  -v ${PWD}/pod.json:/etc/titus-executor/pod.json \
+  -v ${PWD}/build/bin/linux-amd64/:/apps/titus-executor/bin/:ro \
+  -v /var/run/docker.sock:/var/run/docker.sock:rw \
+  -e DOCKER_REGISTRY="registry.us-east-1.streamingtest.titus.netflix.net:7002" \
+  -e LOGVIEWER_SERVICE_IMAGE="/baseos/nflx-adminlogs@sha256:fe27edfe317163b59e3afaad9a0b5e93e4d731b03bf79650abb4490b8a0fece6" \
+  -e SSHD_SERVICE_IMAGE="/titusoss/titus-sshd@sha256:6f6f89250771a50e13d5a3559712defc256c37b144ca22e46c69f35f06d848a0" \
+  -e METATRON_SERVICE_IMAGE="/ps/titus-metatron-identity" \
+  -e PROXYD_SERVICE_IMAGE="/ipc/proxyd-rootless-candidate@sha256:9d5e5292015856b60cfcca51024cdceba1b07f9fe952b96ccac4b741aab43708" \
+  -e ABMETRIX_SERVICE_IMAGE="/baseos/nflx-abmetrix-titus@sha256:0b01b2d74b9b62c7ad85007da0491d40c1f80e5812676667bedcade2448f24e3" \
+  --rm --name "$docker_container_name" \
+  -d \
+  -e SHORT_CIRCUIT_QUITELITE=true --label "$run_id" titusoss/titus-agent
+
+log "Copying test metatron certs to their correct location"
+docker exec "$docker_container_name" /metatron/certificates/setup-metatron-certs.sh
+
+log "Running titus-standalone in $docker_container_name"
+docker exec "$docker_container_name" /apps/titus-executor/bin/titus-standalone \
+   --log-level=debug \
+   -pod /etc/titus-executor/pod.json || true
+
+log "press enter to finish"
+read foo

--- a/pod.json
+++ b/pod.json
@@ -1,0 +1,130 @@
+{
+  "metadata": {
+    "name": "843863f1-41a2-4a73-89bc-89c506bc1e14",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/pods/843863f1-41a2-4a73-89bc-89c506bc1e14",
+    "uid": "44b4c3df-9fa6-4792-831a-f40bdd597e08",
+    "resourceVersion": "3177086735",
+    "creationTimestamp": "2021-02-12T07:20:00Z",
+    "labels": {
+      "pod.titus.netflix.com/byteUnits": "true",
+      "titus.netflix.com/capacity-group": "default",
+      "v3.job.titus.netflix.com/job-id": "34fe318e-c7b6-4fee-a213-ab4f57bb03e6",
+      "v3.job.titus.netflix.com/task-id": "843863f1-41a2-4a73-89bc-89c506bc1e14"
+    },
+    "annotations": {
+      "containerInfo": "CgZ1YnVudHUiBmxhdGVzdGoOL2Jpbi9zbGVlcCAzMDByBnVidW50dXoAggEAigE4YXJuOmF3czppYW06OjE3OTcyNzEwMTE5NDpyb2xlL1RpdHVzQ29udGFpbmVyRGVmYXVsdFJvbGWSATAKATAaC3NnLWYwZjE5NDk0GgtzZy1mMmYxOTQ5NhoLc2ctOGUxZDI4ZTgggAEqATCaAQCgAQDKATQKDFRJVFVTX0pPQl9JRBIkMzRmZTMxOGUtYzdiNi00ZmVlLWEyMTMtYWI0ZjU3YmIwM2U2ygE1Cg1USVRVU19UQVNLX0lEEiQ4NDM4NjNmMS00MWEyLTRhNzMtODliYy04OWM1MDZiYzFlMTTKARkKEE5FVEZMSVhfRVhFQ1VUT1ISBXRpdHVzygE7ChNORVRGTElYX0lOU1RBTkNFX0lEEiQ4NDM4NjNmMS00MWEyLTRhNzMtODliYy04OWM1MDZiYzFlMTTKAT4KFlRJVFVTX1RBU0tfSU5TVEFOQ0VfSUQSJDg0Mzg2M2YxLTQxYTItNGE3My04OWJjLTg5YzUwNmJjMWUxNMoBPgoWVElUVVNfVEFTS19PUklHSU5BTF9JRBIkODQzODYzZjEtNDFhMi00YTczLTg5YmMtODljNTA2YmMxZTE0ygEVChBUSVRVU19UQVNLX0lOREVYEgEw0gFHc2hhMjU2OjA0MmEwMDUzMTIyODg3OWU4MmI3YWYxYjQwNTFmNTkxYzJkZWRiZGI3MjIwZjZjM2ViYjFjNWQwNTUwNDE3YjTYAQDgAQroAQHwAQD6AT5yZWdpc3RyeS51cy1lYXN0LTEuc3RyZWFtaW5ndGVzdC50aXR1cy5uZXRmbGl4Lm5ldDo3MDAyL3VidW50dYACAIgCAKoCagocdGl0dXNQYXJhbWV0ZXIuYWdlbnQuc3VibmV0cxJKc3VibmV0LTBmMDNjNWM0NzdjZGM2YTBjLHN1Ym5ldC0wZDJkMzFlNjJmMTFlNWI1OSxzdWJuZXQtMDRmY2E1ZGQ0YmJmMjIxY2KqAi4KHnRpdHVzUGFyYW1ldGVyLmFnZW50LmFjY291bnRJZBIMMTc5NzI3MTAxMTk0qgJoCiV0aXR1c1BhcmFtZXRlci5hZ2VudC5sb2cuczNXcml0ZXJSb2xlEj9hcm46YXdzOmlhbTo6MTc5NzI3MTAxMTk0OnJvbGUvdGl0dXNhZ2VudERlZmF1bHRMb2dVcGxvYWRlclJvbGWqAkkKJXRpdHVzUGFyYW1ldGVyLmFnZW50LmxvZy5zM0J1Y2tldE5hbWUSIHVzLWVhc3QtMS5uZXRmbGl4LnMzLmdlbnBvcC50ZXN0qgIsChZ0aXR1cy5hZ2VudC5vd25lckVtYWlsEhJzYXJndW5AbmV0ZmxpeC5jb22qAhwKE3RpdHVzLmFnZW50LmpvYlR5cGUSBUJBVENIqgI5ChF0aXR1cy5hZ2VudC5qb2JJZBIkMzRmZTMxOGUtYzdiNi00ZmVlLWEyMTMtYWI0ZjU3YmIwM2U2qgIlCht0aXR1cy5hZ2VudC5hcHBsaWNhdGlvbk5hbWUSBnVidW50daoCrAIKJ3RpdHVzLmFnZW50LnJ1bnRpbWVQcmVkaWN0aW9uc0F2YWlsYWJsZRKAAjAuMDU9MC4wOzAuMT0wLjA7MC4xNT03LjE1MjU2RS02OzAuMj0xLjQzMDUxRS01OzAuMjU9Mi44NjEwMkUtNTswLjM9NS43MjIwNEUtNTswLjM1PTEuNDMwNTFFLTQ7MC40PTUuMzY0MzlFLTQ7MC40NT0wLjAwMTU1MjA4OzAuNT0wLjAwNDI4NDIzOzAuNTU9MC4wMTIwNTg7MC42PTAuMDM3OTAzNzswLjY1PTAuMTY5OTY4OzAuNz0wLjkwODYzNDswLjc1PTQuNjE2OTg7MC44PTE3LjMwMjQ7MC44NT01OS44MDk7MC45PTIwMi4xODM7MC45NT02MTIuMzTAAkDQAui+8aj5Lg==",
+      "iam.amazonaws.com/role": "arn:aws:iam::179727101194:role/TitusContainerDefaultRole",
+      "jobDescriptor": "H4sIAAAAAAAAAK1WS2/cNhC+51cIe2qBXZmk3ttLncZpDWRbIw/0kPZAkdSatURtScrOJvB/75B67tpBcqgBA8tvhvP8ZqgvL4Jg1T4ooVfb4Asc4GgFba4aKmuAVobqfad+VsJWtfwUsrZZgdbj2t2jh0MtGbWyVb/TRjj1ruyU7VZezOiBMmmPv+q2Ozjhq6vXlx/evO+l/7SlF1yrqp19G0vZndP1SgBwYYdIRsSIfzuhmHe3iMVaLcvOCrNIRNrOhKpVEDVESpUNe3MmpIy1EOk1v1T8XVdCeua1oLbTAvR/aRVoQU0un2o5r5M8mMwEVPGLVgfGawVs1pjiCqgWgWgO9nghISJlpLFC2TGtPlimIQrBXx6/Uvv1NzMzgnV6rLp5C8WSWnDQfXcicPZHJNh7KFCtDYyYIjJtp/sye3ed/A7vXBrdHRwjXnZ8L2xYiz1lx53ca88TZ021QTOeg0MLFDoGP5TUstsASPHjqRcN5ZWNuIEcJHM3wqblor7mzhLLCc0jXGxQFFebOGNsUzI4FnEqigyXKE3JqbmJX8BvhfC3fN0LbYao70mIv6MAkjZv21os6n7dI87G9eUu0PD7vNLP2Kt6Nvo+Pd/S9Zmr9Xnt118n+bfypveQDC37qFGIkr86hCIOv35CIT45DKIMfpEkvdqkAJIew2EcoQRfbRKHDYokzFOMSA9GPZaEGSEoHrDk7HYMYDwqRmkcFQM2R4VwkhCUA7jAYpLHJHLYDGKCEqeWTkiUFfDvoEkLp0WROq1sRAqUp5HzmQ1KcZiCltPJh2izMELEqeSDSlKEOSoAKIbEETAod/EUg0aKSRjFZwtA1PXMT3dC5zQ1VEkrP/v5Cc2dPByAZ0966OdWd2JekdNSmjckEMwP+bw0nd6hgyMO0XpE9h6Zz41oWn3cvQQwwWSCgYB3HsQI/iYYePfQ6rtd6bcOJvkkoXXdwvshrm9AUNHaiEkkKrNz5HVXPv49wea2eSc/C+8ljWdY7pXgl5xDQuaytwo16C97pcfp9ehn6Ua3lfT8nvI25wvy48rsNxWqcBEX0KbAH4k/psMxF5iTXOSrOUQ5zzvVaksfzBag7RZnRUYyjDDc37otcPHetXN6TF6Jina19XfnCj191iCXk4xkQ/cneainb3HPHrp3cA0FN3a16Nrend2euaUwwlsYHIpQEmFC8jwrRE7KjFa4jGEaq6TAjHDBS166ma1SFomyxCzhKElQjLMyXp2E92wGPZNvqIZQrdAhZAA7z8xPbP9zgyoUsYTFWcY4Syli61HACY+wSKEbWCRlUkyCuGI04Twuy4oQzMpF/s/5nHak87ps0WkWoKqPN61U1vPiopTqwtRCHBwPIoTG/sOQNQ18CyxYC3fvp9QnGraVhc4bq6H39nT8noUf58n4dHAsH0b8NMxbqvn/aXbaHf55XnymwQy6WR7cDsvnjWykhY8KZyBKoSijWPjiuYd+GRE84/Qo+AJybHa7jdavnGznqYCmDo53etwtmaXIeZGeZdGzc+Kj+EO9XcQ6bp0pzfMndJGxqKsdVUCaZcBgdNw178FoH1gcEbf/TjsDnzvig6qd14WFUeoi+lMq3j4s9928sX8TtLa3sLPuJYdPknGtPb54/A/pAGwawQsAAA==",
+      "kubernetes.io/egress-bandwidth": "128M",
+      "kubernetes.io/ingress-bandwidth": "128M",
+      "network.titus.netflix.com/securityGroups": "sg-f0f19494,sg-f2f19496,sg-8e1d28e8",
+      "pod.titus.netflix.com/accountId": "179727101194",
+      "pod.titus.netflix.com/subnets": "subnet-0f03c5c477cdc6a0c,subnet-0d2d31e62f11e5b59,subnet-04fca5dd4bbf221cb",
+      "titus.agent.applicationName": "ubuntu",
+      "titus.agent.jobId": "34fe318e-c7b6-4fee-a213-ab4f57bb03e6",
+      "titus.agent.jobType": "BATCH",
+      "titus.agent.ownerEmail": "sargun@netflix.com",
+      "titusParameter.agent.accountId": "179727101194",
+      "titusParameter.agent.log.s3BucketName": "us-east-1.netflix.s3.genpop.test",
+      "titusParameter.agent.log.s3WriterRole": "arn:aws:iam::179727101194:role/titusagentDefaultLogUploaderRole",
+      "titusParameter.agent.subnets": "subnet-0f03c5c477cdc6a0c,subnet-0d2d31e62f11e5b59,subnet-04fca5dd4bbf221cb"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "843863f1-41a2-4a73-89bc-89c506bc1e14",
+        "image": "kylea/kylea-test-app:latest",
+        "env": [
+          {
+            "name": "EC2_OWNER_ID",
+            "value": "179727101194"
+          },
+          {
+            "name": "TITUS_TASK_ORIGINAL_ID",
+            "value": "843863f1-41a2-4a73-89bc-89c506bc1e14"
+          },
+          {
+            "name": "NETFLIX_INSTANCE_ID",
+            "value": "843863f1-41a2-4a73-89bc-89c506bc1e14"
+          },
+          {
+            "name": "TITUS_TASK_INDEX",
+            "value": "0"
+          },
+          {
+            "name": "TITUS_TASK_INSTANCE_ID",
+            "value": "843863f1-41a2-4a73-89bc-89c506bc1e14"
+          },
+          {
+            "name": "TITUS_TASK_ID",
+            "value": "843863f1-41a2-4a73-89bc-89c506bc1e14"
+          },
+          {
+            "name": "NETFLIX_EXECUTOR",
+            "value": "titus"
+          },
+          {
+            "name": "NETFLIX_ACCOUNT_ID",
+            "value": "179727101194"
+          },
+          {
+            "name": "TITUS_JOB_ID",
+            "value": "34fe318e-c7b6-4fee-a213-ab4f57bb03e6"
+          },
+          {
+            "name": "NETFLIX_ACCOUNT",
+            "value": "test"
+          }
+        ],
+        "resources": {
+          "limits": {
+            "cpu": "1",
+            "ephemeral-storage": "10000Mi",
+            "memory": "512Mi",
+            "nvidia.com/gpu": "0",
+            "titus/network": "128M"
+          },
+          "requests": {
+            "cpu": "1",
+            "ephemeral-storage": "10000Mi",
+            "memory": "512Mi",
+            "nvidia.com/gpu": "0",
+            "titus/network": "128M"
+          }
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File",
+        "imagePullPolicy": "IfNotPresent"
+      },
+      {
+        "name": "843863f1-41a2-4a73-89bc-89c506bc1e14-nginx",
+        "image": "nginx",
+        "command": [],
+        "env": [{
+		"name": "YOUR_THE_SIDECAR_NOW_DOG",
+		"value": "true"}],
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File",
+        "imagePullPolicy": "IfNotPresent"
+      },
+      {
+        "name": "843863f1-41a2-4a73-89bc-89c506bc1e14-mysql",
+        "image": "mysql",
+        "command": [],
+        "env": [{
+		"name": "MYSQL_ALLOW_EMPTY_PASSWORD",
+		"value": "true"
+	}],
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File",
+        "imagePullPolicy": "IfNotPresent"
+      }
+   ],
+    "restartPolicy": "Never",
+    "terminationGracePeriodSeconds": 600,
+    "dnsPolicy": "Default",
+    "securityContext": {}
+  }
+}

--- a/pod.json
+++ b/pod.json
@@ -99,7 +99,7 @@
         "imagePullPolicy": "IfNotPresent"
       },
       {
-        "name": "843863f1-41a2-4a73-89bc-89c506bc1e14-nginx",
+        "name": "nginx",
         "image": "nginx",
         "command": [],
         "env": [{
@@ -110,9 +110,8 @@
         "imagePullPolicy": "IfNotPresent"
       },
       {
-        "name": "843863f1-41a2-4a73-89bc-89c506bc1e14-mysql",
+        "name": "mysql",
         "image": "mysql",
-        "command": [],
         "env": [{
 		"name": "MYSQL_ALLOW_EMPTY_PASSWORD",
 		"value": "true"


### PR DESCRIPTION
This is an MVP of multi-container workloads on Titus (pods).
It uses the "Country & Western" approach, which treats the
first container as the "main" one, which holds all the namespaces.

The lifecycle of a pod in this MVP is:

1. Start up, but pause (via tini) the main container
2. Start up the Titus system services (Country style)
3. Start up the Other containers (Western style)
4. Unpause the main container.

The main advantage to this design is that when there is only
1 container, step 3 is a noop. This provides backwards
compatibility with our existing workloads while we iterate
on the nuances and functionality of step 3 (ordering, volumes,
healthchecks, logs, etc)

----

With this change, the `Runner` struct in the executor
now holds the whole pod object. This allows the container
creation to have all the information it needs to properly
launch (Run) the main workload *and* all the sidecars.

I think eventually we'll need to tease out the `container`
object from the `Runner`, separating the settings that
are for the whole *task* (network stuff, global params),
and then have an *array* of container objects, instead
of the singleton, but I would like to do that refactor
on another pass, for when we need more direct access
to the extra container objects.
