### PR TITLE
Move to standard k8s pod spec fields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	// Docker returns the Docker-specific configuration settings
 	DockerHost     string
 	DockerRegistry string
+	// What region we're running in
+	AwsRegion string
 
 	// MetatronEnabled returns if Metatron is enabled
 	MetatronEnabled      bool
@@ -148,6 +150,12 @@ func NewConfig() (*Config, []cli.Flag) {
 			Value:       "docker.io",
 			Destination: &cfg.DockerRegistry,
 			EnvVar:      "DOCKER_REGISTRY",
+		},
+		cli.StringFlag{
+			Name:        "aws-region",
+			Value:       "",
+			Destination: &cfg.AwsRegion,
+			EnvVar:      "EC2_REGION",
 		},
 		cli.StringFlag{
 			Name:        "metatron-service-image",

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -192,7 +192,7 @@ func (r *Runner) runContainer(ctx context.Context, startTime time.Time, updateCh
 	logDir, details, statusChan, err := r.runtime.Start(ctx)
 	if err != nil { // nolint: vetshadow
 		r.metrics.Counter("titus.executor.launchTaskFailed", 1, nil)
-		logger.G(ctx).Info("start container: ", err)
+		logger.G(ctx).WithError(err).Error("error starting container")
 
 		switch err.(type) {
 		case *runtimeTypes.BadEntryPointError:
@@ -368,7 +368,13 @@ func (r *Runner) maybeSetupExternalLogger(ctx context.Context, logDir string) er
 	}
 	logger.G(ctx).Info("Starting external logger")
 
-	wConf := filesystems.NewWatchConfig(logDir, r.container.UploadDir("logs"), r.container.LogUploadRegexp(), *r.container.LogUploadCheckInterval(), *r.container.LogUploadThresholdTime(), *r.container.LogStdioCheckInterval(), r.container.LogKeepLocalFileAfterUpload())
+	wConf := filesystems.NewWatchConfig(logDir,
+		r.container.UploadDir("logs"),
+		r.container.LogUploadRegexp(),
+		*r.container.LogUploadCheckInterval(),
+		*r.container.LogUploadThresholdTime(),
+		*r.container.LogStdioCheckInterval(),
+		r.container.LogKeepLocalFileAfterUpload())
 	uploader, err := uploader.NewUploader(&r.config, r.container.LogUploaderConfig(), *r.container.IamRole(), r.container.TaskID(), r.metrics)
 	if err != nil {
 		return err

--- a/executor/runtime/docker/capabilities_test.go
+++ b/executor/runtime/docker/capabilities_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
+	podCommon "github.com/Netflix/titus-kube-common/pod"
 	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDefaultProfile(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := runtimeTypes.ContainerTestArgs()
+func TestDefaultProfileContainerInfo(t *testing.T) {
+	taskID, titusInfo, resources, _, conf, err := runtimeTypes.ContainerTestArgs()
 	assert.NoError(t, err)
 	c, err := runtimeTypes.NewContainer(taskID, titusInfo, *resources, *conf)
 	assert.NoError(t, err)
@@ -23,13 +24,50 @@ func TestDefaultProfile(t *testing.T) {
 	assert.Len(t, hostConfig.SecurityOpt, 2)
 }
 
-func TestFuseProfile(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := runtimeTypes.ContainerTestArgs()
+func TestDefaultProfile(t *testing.T) {
+	pod, conf, err := runtimeTypes.PodContainerTestArgs()
+	assert.NoError(t, err)
+	c, err := runtimeTypes.NewPodContainer(pod, *conf)
+	assert.NoError(t, err)
+	hostConfig := container.HostConfig{}
+
+	assert.NoError(t, setupAdditionalCapabilities(c, &hostConfig))
+
+	assert.Len(t, hostConfig.CapAdd, 0)
+	assert.Len(t, hostConfig.CapDrop, 0)
+	assert.Contains(t, hostConfig.SecurityOpt, "apparmor:docker_titus")
+	assert.Len(t, hostConfig.SecurityOpt, 2)
+}
+
+func TestFuseProfileContainerInfo(t *testing.T) {
+	taskID, titusInfo, resources, _, conf, err := runtimeTypes.ContainerTestArgs()
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[runtimeTypes.FuseEnabledParam] = "true"
 	c, err := runtimeTypes.NewContainer(taskID, titusInfo, *resources, *conf)
 	assert.NoError(t, err)
 	hostConfig := container.HostConfig{}
+
+	assert.NoError(t, setupAdditionalCapabilities(c, &hostConfig))
+
+	assert.Contains(t, hostConfig.CapAdd, "SYS_ADMIN")
+	assert.Len(t, hostConfig.CapDrop, 0)
+	assert.Len(t, hostConfig.SecurityOpt, 2)
+	assert.Contains(t, hostConfig.SecurityOpt, "apparmor:docker_fuse")
+}
+
+func TestFuseProfile(t *testing.T) {
+	pod, conf, err := runtimeTypes.PodContainerTestArgs()
+	assert.NoError(t, err)
+	pod.Annotations[podCommon.AnnotationKeyPodFuseEnabled] = "true"
+	pod.Annotations[podCommon.AnnotationKeyPrefixAppArmor+"/"+pod.ObjectMeta.Name] = "docker_fuse"
+	c, err := runtimeTypes.NewPodContainer(pod, *conf)
+	assert.NoError(t, err)
+	hostConfig := container.HostConfig{}
+
+	// Using the full pod spec, the apparmor profile is specified in an annotation
+	assert.NotNil(t, c.AppArmorProfile())
+	assert.Equal(t, *c.AppArmorProfile(), "docker_fuse")
+	assert.True(t, c.FuseEnabled())
 
 	assert.NoError(t, setupAdditionalCapabilities(c, &hostConfig))
 

--- a/executor/runtime/docker/docker_test.go
+++ b/executor/runtime/docker/docker_test.go
@@ -246,15 +246,3 @@ func TestFlags(t *testing.T) {
 	_, flags := NewConfig()
 	properties.ConvertFlagsForAltSrc(flags)
 }
-
-func TestIsEFSID(t *testing.T) {
-	var actual bool
-	actual, _ = isEFSID("fs-123450")
-	assert.True(t, actual)
-
-	actual, _ = isEFSID("fs-123450.efs.us-west-1.amazonaws.com")
-	assert.False(t, actual)
-
-	actual, _ = isEFSID("nfs.example.com")
-	assert.False(t, actual)
-}

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -22,7 +22,6 @@ import (
 	podCommon "github.com/Netflix/titus-kube-common/pod"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/util/maps"
 	ptr "k8s.io/utils/pointer"
@@ -33,6 +32,7 @@ const (
 	commandLabelKey          = "com.netflix.titus.command"
 	entrypointLabelKey       = "com.netflix.titus.entrypoint"
 	cpuLabelKey              = "com.netflix.titus.cpu"
+	iamRoleLabelKey          = "ec2.iam.role"
 	memLabelKey              = "com.netflix.titus.mem"
 	diskLabelKey             = "com.netflix.titus.disk"
 	networkLabelKey          = "com.netflix.titus.network"
@@ -41,7 +41,7 @@ const (
 	ownerEmailPassThroughKey = "titus.agent.ownerEmail"
 	jobTypeLabelKey          = "com.netflix.titus.job.type"
 	jobTypePassThroughKey    = "titus.agent.jobType"
-	titusTaskInstanceIDKey   = "TITUS_TASK_INSTANCE_ID"
+	TitusTaskInstanceIDKey   = "TITUS_TASK_INSTANCE_ID"
 	titusJobIDKey            = "TITUS_JOB_ID"
 
 	// Passthrough params
@@ -161,6 +161,7 @@ type TitusInfoContainer struct {
 	fuseEnabled bool
 	// KvmEnabled determines whether the container has KVM exposed to it
 	kvmEnabled                         bool
+	nfsMounts                          []NFSMount
 	requireIMDSToken                   string
 	seccompAgentEnabledForNetSyscalls  bool
 	seccompAgentEnabledForPerfSyscalls bool
@@ -177,30 +178,30 @@ func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources Resou
 }
 
 // NewContainerWithPod allocates and initializes a new container struct object. Pod can be optionally passed. If nil, ignored
-func NewContainerWithPod(taskID string, titusInfo *titus.ContainerInfo, resources Resources, cfg config.Config, pod *corev1.Pod) (*TitusInfoContainer, error) {
+func NewContainerWithPod(taskID string, titusInfo *titus.ContainerInfo, resources Resources, cfg config.Config, pod *corev1.Pod) (Container, error) {
+	if pod != nil {
+		schemaVer, err := podCommon.PodSchemaVersion(pod)
+		if err != nil {
+			return nil, err
+		}
+
+		if schemaVer > 0 {
+			return NewPodContainer(pod, cfg)
+		}
+	}
+
+	return NewTitusInfoContainer(taskID, titusInfo, resources, cfg, pod)
+}
+
+// NewTitusInfoContainer creates a new container backed by a pod with a ContainerInfo annotation
+func NewTitusInfoContainer(taskID string, titusInfo *titus.ContainerInfo, resources Resources, cfg config.Config, pod *corev1.Pod) (*TitusInfoContainer, error) {
 	networkCfgParams := titusInfo.GetNetworkConfigInfo()
-
-	labels := map[string]string{
-		models.ExecutorPidLabel: fmt.Sprintf("%d", os.Getpid()),
-		models.TaskIDLabel:      taskID,
-	}
-
-	if len(titusInfo.GetIamProfile()) > 0 {
-		labels["ec2.iam.role"] = titusInfo.GetIamProfile()
-	}
-
-	labels[cpuLabelKey] = itoa(resources.CPU)
-	labels[memLabelKey] = itoa(resources.Mem)
-	labels[diskLabelKey] = itoa(resources.Disk)
-	labels[networkLabelKey] = itoa(resources.Network)
-	addLabels(titusInfo, labels)
 
 	c := &TitusInfoContainer{
 		taskID:       taskID,
 		titusInfo:    titusInfo,
 		resources:    resources,
 		envOverrides: map[string]string{},
-		labels:       labels,
 		config:       cfg,
 	}
 
@@ -346,26 +347,47 @@ func NewContainerWithPod(taskID string, titusInfo *titus.ContainerInfo, resource
 		c.serviceMeshEnabled = &svcMeshEnabled
 	}
 
+	err = c.parseContainerInfoNfsMounts()
+	if err != nil {
+		return c, fmt.Errorf("error parsing NFS mounts: %w", err)
+	}
+
 	// This depends on a number of the other fields being populated, so run it last
 	cEnv := c.Env()
-	c.labels[titusTaskInstanceIDKey] = cEnv[titusTaskInstanceIDKey]
+	c.labels = addLabels(taskID, c, &resources)
 	c.jobID = cEnv[titusJobIDKey]
 
 	return c, nil
 }
 
-func addLabels(containerInfo *titus.ContainerInfo, labels map[string]string) map[string]string {
-	labels = addContainerLabels(containerInfo, labels)
-	labels = addPassThroughLabels(containerInfo, labels)
-	labels = addProcessLabels(containerInfo, labels)
+func addLabels(taskID string, c Container, resources *Resources) map[string]string {
+	labels := map[string]string{
+		models.ExecutorPidLabel: fmt.Sprintf("%d", os.Getpid()),
+		models.TaskIDLabel:      taskID,
+		TitusTaskInstanceIDKey:  taskID,
+	}
+
+	iamRole := c.IamRole()
+	if iamRole != nil {
+		labels[iamRoleLabelKey] = *iamRole
+	}
+
+	labels[cpuLabelKey] = itoa(resources.CPU)
+	labels[memLabelKey] = itoa(resources.Mem)
+	labels[diskLabelKey] = itoa(resources.Disk)
+	labels[networkLabelKey] = itoa(resources.Network)
+
+	labels = addContainerLabels(c, labels)
+	labels = addPassThroughLabels(c, labels)
+	labels = addProcessLabels(c, labels)
 	return labels
 }
 
-func addContainerLabels(containerInfo *titus.ContainerInfo, labels map[string]string) map[string]string {
-	labels[appNameLabelKey] = containerInfo.GetAppName()
+func addContainerLabels(c Container, labels map[string]string) map[string]string {
+	labels[appNameLabelKey] = c.AppName()
 
 	workloadType := StaticWorkloadType
-	if containerInfo.GetAllowCpuBursting() {
+	if c.AllowCPUBursting() {
 		workloadType = BurstWorkloadType
 	}
 
@@ -374,36 +396,35 @@ func addContainerLabels(containerInfo *titus.ContainerInfo, labels map[string]st
 	return labels
 }
 
-func addPassThroughLabels(containerInfo *titus.ContainerInfo, labels map[string]string) map[string]string {
-	ownerEmail := ""
-	jobType := ""
+func addPassThroughLabels(c Container, labels map[string]string) map[string]string {
+	ownerEmailStr := ""
+	jobTypeStr := ""
 
-	passthroughAttributes := containerInfo.GetPassthroughAttributes()
-	if passthroughAttributes != nil {
-		ownerEmail = passthroughAttributes[ownerEmailPassThroughKey]
-		jobType = passthroughAttributes[jobTypePassThroughKey]
+	jobType := c.JobType()
+	if jobType != nil {
+		jobTypeStr = *jobType
+	}
+	email := c.OwnerEmail()
+	if email != nil {
+		ownerEmailStr = *email
 	}
 
-	labels[ownerEmailLabelKey] = ownerEmail
-	labels[jobTypeLabelKey] = jobType
+	labels[ownerEmailLabelKey] = ownerEmailStr
+	labels[jobTypeLabelKey] = jobTypeStr
 
 	return labels
 }
 
-func addProcessLabels(containerInfo *titus.ContainerInfo, labels map[string]string) map[string]string {
-	process := containerInfo.GetProcess()
-	if process != nil {
-		entryPoint := process.GetEntrypoint()
-		if entryPoint != nil {
-			entryPointStr := strings.Join(entryPoint[:], " ")
-			labels[entrypointLabelKey] = entryPointStr
-		}
+func addProcessLabels(c Container, labels map[string]string) map[string]string {
+	entryPoint, command := c.Process()
+	if entryPoint != nil {
+		entryPointStr := strings.Join(entryPoint[:], " ")
+		labels[entrypointLabelKey] = entryPointStr
+	}
 
-		command := process.GetCommand()
-		if command != nil {
-			commandStr := strings.Join(command[:], " ")
-			labels[commandLabelKey] = commandStr
-		}
+	if command != nil {
+		commandStr := strings.Join(command[:], " ")
+		labels[commandLabelKey] = commandStr
 	}
 
 	return labels
@@ -481,6 +502,14 @@ func (c *TitusInfoContainer) AllowNetworkBursting() bool {
 	return c.titusInfo.GetAllowNetworkBursting()
 }
 
+func (c *TitusInfoContainer) AppArmorProfile() *string {
+	if c.FuseEnabled() {
+		return ptr.StringPtr("docker_fuse")
+	}
+
+	return nil
+}
+
 func (c *TitusInfoContainer) AppName() string {
 	return c.titusInfo.GetAppName()
 }
@@ -514,16 +543,9 @@ func (c *TitusInfoContainer) BatchPriority() *string {
 	return &trueStr
 }
 
-// CombinedAppStackDetails is a port of the combineAppStackDetails method from frigga.
-// See: https://github.com/Netflix/frigga/blob/v0.17.0/src/main/java/com/netflix/frigga/NameBuilder.java
 func (c *TitusInfoContainer) CombinedAppStackDetails() string {
-	if c.JobGroupDetail() != "" {
-		return fmt.Sprintf("%s-%s-%s", c.AppName(), c.JobGroupStack(), c.JobGroupDetail())
-	}
-	if c.JobGroupStack() != "" {
-		return fmt.Sprintf("%s-%s", c.AppName(), c.JobGroupStack())
-	}
-	return c.AppName()
+	return combinedAppStackDetails(c)
+
 }
 
 // Config returns the container config with all necessary fields for validating its identity with Metatron
@@ -531,12 +553,21 @@ func (c *TitusInfoContainer) ContainerInfo() (*titus.ContainerInfo, error) {
 	return c.titusInfo, nil
 }
 
-func (c *TitusInfoContainer) Capabilities() *titus.ContainerInfo_Capabilities {
-	return c.titusInfo.GetCapabilities()
-}
+func (c *TitusInfoContainer) Capabilities() *corev1.Capabilities {
+	cInfoCap := c.titusInfo.GetCapabilities()
+	if cInfoCap == nil {
+		return nil
+	}
 
-func (c *TitusInfoContainer) EfsConfigInfo() []*titus.ContainerInfo_EfsConfigInfo {
-	return c.titusInfo.GetEfsConfigInfo()
+	cp := corev1.Capabilities{}
+	for _, add := range cInfoCap.GetAdd() {
+		cp.Add = append(cp.Add, corev1.Capability(add.String()))
+	}
+	for _, drop := range cInfoCap.GetDrop() {
+		cp.Drop = append(cp.Drop, corev1.Capability(drop.String()))
+	}
+
+	return &cp
 }
 
 func (c *TitusInfoContainer) EBSInfo() EBSInfo {
@@ -563,55 +594,23 @@ func (c *TitusInfoContainer) ElasticIPs() *string {
 }
 
 func (c *TitusInfoContainer) Env() map[string]string {
-	// Order goes (least priority, to highest priority:
-	// -Hard coded environment variables
-	// -Copied environment variables from the host
-	// -Resource env variables
-	// -User provided environment in POD (if pod unset, then fall back to containerinfo)
-	// -Network Config
-	// -Executor overrides
-
-	// Hard coded (in executor config)
-	env := c.config.GetHardcodedEnv()
-
-	// Env copied from host
-	for key, value := range c.config.GetEnvFromHost() {
-		env[key] = value
-	}
-
-	resources := c.Resources()
-	// Resource environment variables
-	env["TITUS_NUM_MEM"] = itoa(resources.Mem)
-	env["TITUS_NUM_CPU"] = itoa(resources.CPU)
-	env["TITUS_NUM_DISK"] = itoa(resources.Disk)
-	env["TITUS_NUM_NETWORK_BANDWIDTH"] = itoa(resources.Network)
-
-	cluster := c.CombinedAppStackDetails()
-	env["NETFLIX_CLUSTER"] = cluster
-	env["NETFLIX_STACK"] = c.JobGroupStack()
-	env["NETFLIX_DETAIL"] = c.JobGroupDetail()
-
-	var asgName string
-	if seq := c.JobGroupSequence(); seq == "" {
-		asgName = cluster + "-v000"
-	} else {
-		asgName = cluster + "-" + seq
-	}
-	env["NETFLIX_AUTO_SCALE_GROUP"] = asgName
-	env["NETFLIX_APP"] = c.AppName()
-
 	// passed environment
 	passedEnv := func() map[string]string {
 		containerInfoEnv := map[string]string{
 			"TITUS_ENV_FROM": "containerInfo",
 		}
+		podEnv := map[string]string{
+			"TITUS_ENV_FROM": "pod",
+		}
 		for key, value := range c.titusInfo.GetUserProvidedEnv() {
 			if value != "" {
-				env[key] = value
+				containerInfoEnv[key] = value
+				podEnv[key] = value
 			}
 		}
 		for key, value := range c.titusInfo.GetTitusProvidedEnv() {
-			env[key] = value
+			containerInfoEnv[key] = value
+			podEnv[key] = value
 		}
 
 		if c.pod == nil {
@@ -626,13 +625,10 @@ func (c *TitusInfoContainer) Env() map[string]string {
 			return containerInfoEnv
 		}
 
-		podEnv := map[string]string{
-			"TITUS_ENV_FROM": "pod",
-		}
 		for _, val := range c.pod.Spec.Containers[0].Env {
 			podEnv[val.Name] = val.Value
 		}
-		if val, ok := podEnv[titusTaskInstanceIDKey]; !ok {
+		if val, ok := podEnv[TitusTaskInstanceIDKey]; !ok {
 			// We need to have the pod env have this variable
 			return containerInfoEnv
 		} else if val == "" {
@@ -641,79 +637,14 @@ func (c *TitusInfoContainer) Env() map[string]string {
 		return podEnv
 	}()
 
-	for key, value := range passedEnv {
-		env[key] = value
-	}
+	return populateContainerEnv(c, c.config, passedEnv)
+}
 
-	// These environment variables may be looked at things like sidecars and they should override user environment
-	if name := c.ImageName(); name != nil {
-		env["TITUS_IMAGE_NAME"] = *name
-	}
-	if tag := c.ImageVersion(); tag != nil {
-		env["TITUS_IMAGE_TAG"] = *tag
-	}
-	if digest := c.ImageDigest(); digest != nil {
-		env["TITUS_IMAGE_DIGEST"] = *digest
-	}
-
-	// The control plane should set this environment variable.
-	// If it doesn't, we should set it. It shouldn't create
-	// any problems if it is set to an "incorrect" value
-	if _, ok := env["EC2_OWNER_ID"]; !ok {
-		env["EC2_OWNER_ID"] = ptr.StringPtrDerefOr(c.VPCAccountID(), "")
-	}
-
-	env["TITUS_IAM_ROLE"] = ptr.StringPtrDerefOr(c.IamRole(), "")
-
-	if c.config.MetatronEnabled {
-		// When set, the metadata service will return signed identity documents suitable for bootstrapping Metatron
-		env[metadataserverTypes.TitusMetatronVariableName] = True
-	} else {
-		env[metadataserverTypes.TitusMetatronVariableName] = False
-	}
-
-	if c.vpcAllocation.IPV4Address != nil {
-		env[metadataserverTypes.EC2IPv4EnvVarName] = c.vpcAllocation.IPV4Address.Address.Address
-	}
-
-	if c.vpcAllocation.IPV6Address != nil {
-		env[metadataserverTypes.EC2IPv6sEnvVarName] = c.vpcAllocation.IPV6Address.Address.Address
-	}
-
-	if c.vpcAllocation.ElasticAddress != nil {
-		env[metadataserverTypes.EC2PublicIPv4EnvVarName] = c.vpcAllocation.ElasticAddress.Ip
-		env[metadataserverTypes.EC2PublicIPv4sEnvVarName] = c.vpcAllocation.ElasticAddress.Ip
-	}
-
-	// Heads up, this doesn't work in generation v1 instances of VPC Service
-	env["EC2_VPC_ID"] = c.vpcAllocation.BranchENIVPC
-	env["EC2_INTERFACE_ID"] = c.vpcAllocation.BranchENIID
-	env["EC2_SUBNET_ID"] = c.vpcAllocation.BranchENISubnet
-
-	if batch := c.BatchPriority(); batch != nil {
-		env["TITUS_BATCH"] = *batch
-	}
-
-	if reqIMDSToken := c.RequireIMDSToken(); reqIMDSToken != nil {
-		env["TITUS_IMDS_REQUIRE_TOKEN"] = *reqIMDSToken
-	}
-
+func (c *TitusInfoContainer) EnvOverrides() map[string]string {
 	c.envLock.Lock()
 	envOverrides := maps.CopySS(c.envOverrides)
 	c.envLock.Unlock()
-
-	for key, value := range envOverrides {
-		env[key] = value
-	}
-
-	if gpuInfo := c.GPUInfo(); gpuInfo != nil {
-		for key, value := range gpuInfo.Env() {
-			env[key] = value
-		}
-	}
-
-	env[TitusRuntimeEnvVariableName] = c.Runtime()
-	return env
+	return envOverrides
 }
 
 func (c *TitusInfoContainer) FuseEnabled() bool {
@@ -790,6 +721,19 @@ func (c *TitusInfoContainer) JobID() *string {
 	return &c.jobID
 }
 
+func (c *TitusInfoContainer) JobType() *string {
+	passthroughAttributes := c.titusInfo.GetPassthroughAttributes()
+	if passthroughAttributes == nil {
+		return nil
+	}
+
+	jobVal, ok := passthroughAttributes[jobTypePassThroughKey]
+	if !ok {
+		return nil
+	}
+	return &jobVal
+}
+
 func (c *TitusInfoContainer) KillWaitSeconds() *uint32 {
 	val := c.titusInfo.GetKillWaitSeconds()
 	if val != 0 {
@@ -834,7 +778,6 @@ func (c *TitusInfoContainer) LogUploaderConfig() *uploader.Config {
 
 func (c *TitusInfoContainer) LogUploadRegexp() *regexp.Regexp {
 	return c.logUploadRegexp
-
 }
 
 // LogUploadThresholdTime indicates how long since a file was modified before we should upload it and delete it
@@ -850,6 +793,10 @@ func (c *TitusInfoContainer) MetatronCreds() *titus.ContainerInfo_MetatronCreds 
 	return c.titusInfo.GetMetatronCreds()
 }
 
+func (c *TitusInfoContainer) NFSMounts() []NFSMount {
+	return c.nfsMounts
+}
+
 func (c *TitusInfoContainer) NormalizedENIIndex() *int {
 	return &c.normalizedENIIndex
 }
@@ -861,6 +808,19 @@ func (c *TitusInfoContainer) OomScoreAdj() *int32 {
 	}
 
 	return nil
+}
+
+func (c *TitusInfoContainer) OwnerEmail() *string {
+	passthroughAttributes := c.titusInfo.GetPassthroughAttributes()
+	if passthroughAttributes == nil {
+		return nil
+	}
+
+	emailVal, ok := passthroughAttributes[ownerEmailPassThroughKey]
+	if !ok {
+		return nil
+	}
+	return &emailVal
 }
 
 // Process returns entrypoint and command for the container
@@ -981,10 +941,11 @@ func (c *TitusInfoContainer) ShmSizeMiB() *uint32 {
 
 func (c *TitusInfoContainer) SidecarConfigs() ([]*ServiceOpts, error) {
 	svcMeshImage := ""
+	sideCarPtrs := []*ServiceOpts{}
 	if c.ServiceMeshEnabled() {
 		img, err := c.serviceMeshImageName()
 		if err != nil {
-			return sideCars, err
+			return sideCarPtrs, err
 		}
 		svcMeshImage = img
 	}
@@ -999,12 +960,14 @@ func (c *TitusInfoContainer) SidecarConfigs() ([]*ServiceOpts, error) {
 		SidecarServiceAtlasd:      c.config.AtlasdServiceImage,
 	}
 
-	for _, sc := range sideCars {
+	for _, scOrig := range sideCars {
+		// Make a copy to avoid mutating the original
+		sc := scOrig
 		sc.Image = path.Join(c.config.DockerRegistry, imageMap[sc.ServiceName])
-		log.Infof("sidecar name=%s image=%s", sc.ServiceName, sc.Image)
+		sideCarPtrs = append(sideCarPtrs, &sc)
 	}
 
-	return sideCars, nil
+	return sideCarPtrs, nil
 }
 
 func (c *TitusInfoContainer) SignedAddressAllocationUUID() *string {
@@ -1017,20 +980,10 @@ func (c *TitusInfoContainer) SignedAddressAllocationUUID() *string {
 
 // GetSortedEnvArray returns the list of environment variables set for the container as a sorted Key=Value list
 func (c *TitusInfoContainer) SortedEnvArray() []string {
-	env := c.Env()
-	retEnv := make([]string, 0, len(env))
-	keys := make([]string, 0, len(env))
-	for k := range env {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		retEnv = append(retEnv, key+"="+env[key])
-	}
-	return retEnv
+	return sortedEnv(c.Env())
 }
 
-func (c *TitusInfoContainer) SubnetIDs() *string {
+func (c *TitusInfoContainer) SubnetIDs() *[]string {
 	if c.subnetIDs == "" {
 		return nil
 	}
@@ -1038,8 +991,7 @@ func (c *TitusInfoContainer) SubnetIDs() *string {
 	for idx, subnetID := range subnetIDs {
 		subnetIDs[idx] = strings.TrimSpace(subnetID)
 	}
-	joinedSubnetIDString := strings.Join(subnetIDs, ",")
-	return &joinedSubnetIDString
+	return &subnetIDs
 }
 
 func (c *TitusInfoContainer) TaskID() string {
@@ -1146,4 +1098,209 @@ func (c *TitusInfoContainer) parseLogStdioCheckInterval(logStdioCheckIntervalStr
 		return 0, errors.Wrap(err, "Cannot parse log stdio check interval")
 	}
 	return duration, nil
+}
+
+func populateContainerEnv(c Container, config config.Config, userEnv map[string]string) map[string]string {
+	// Order goes (least priority, to highest priority:
+	// -Hard coded environment variables
+	// -Copied environment variables from the host
+	// -Resource env variables
+	// -User provided environment in POD (if pod unset, then fall back to containerinfo)
+	// -Network Config
+	// -Executor overrides
+
+	// Hard coded (in executor config)
+	env := config.GetHardcodedEnv()
+
+	// Env copied from host
+	for key, value := range config.GetEnvFromHost() {
+		env[key] = value
+	}
+
+	resources := c.Resources()
+	// Resource environment variables
+	env["TITUS_NUM_MEM"] = itoa(resources.Mem)
+	env["TITUS_NUM_CPU"] = itoa(resources.CPU)
+	env["TITUS_NUM_DISK"] = itoa(resources.Disk)
+	env["TITUS_NUM_NETWORK_BANDWIDTH"] = itoa(resources.Network)
+
+	cluster := c.CombinedAppStackDetails()
+	env["NETFLIX_CLUSTER"] = cluster
+	env["NETFLIX_STACK"] = c.JobGroupStack()
+	env["NETFLIX_DETAIL"] = c.JobGroupDetail()
+
+	var asgName string
+	if seq := c.JobGroupSequence(); seq == "" {
+		asgName = cluster + "-v000"
+	} else {
+		asgName = cluster + "-" + seq
+	}
+	env["NETFLIX_AUTO_SCALE_GROUP"] = asgName
+	env["NETFLIX_APP"] = c.AppName()
+
+	for key, value := range userEnv {
+		env[key] = value
+	}
+
+	// These environment variables may be looked at things like sidecars and they should override user environment
+	if name := c.ImageName(); name != nil {
+		env["TITUS_IMAGE_NAME"] = *name
+	}
+	if tag := c.ImageVersion(); tag != nil {
+		env["TITUS_IMAGE_TAG"] = *tag
+	}
+	if digest := c.ImageDigest(); digest != nil {
+		env["TITUS_IMAGE_DIGEST"] = *digest
+	}
+
+	// The control plane should set this environment variable.
+	// If it doesn't, we should set it. It shouldn't create
+	// any problems if it is set to an "incorrect" value
+	if _, ok := env["EC2_OWNER_ID"]; !ok {
+		env["EC2_OWNER_ID"] = ptr.StringPtrDerefOr(c.VPCAccountID(), "")
+	}
+
+	env["TITUS_IAM_ROLE"] = ptr.StringPtrDerefOr(c.IamRole(), "")
+
+	if config.MetatronEnabled {
+		// When set, the metadata service will return signed identity documents suitable for bootstrapping Metatron
+		env[metadataserverTypes.TitusMetatronVariableName] = True
+	} else {
+		env[metadataserverTypes.TitusMetatronVariableName] = False
+	}
+
+	vpcAllocation := c.VPCAllocation()
+	if vpcAllocation != nil {
+		if vpcAllocation.IPV4Address != nil {
+			env[metadataserverTypes.EC2IPv4EnvVarName] = vpcAllocation.IPV4Address.Address.Address
+		}
+
+		if vpcAllocation.IPV6Address != nil {
+			env[metadataserverTypes.EC2IPv6sEnvVarName] = vpcAllocation.IPV6Address.Address.Address
+		}
+
+		if vpcAllocation.ElasticAddress != nil {
+			env[metadataserverTypes.EC2PublicIPv4EnvVarName] = vpcAllocation.ElasticAddress.Ip
+			env[metadataserverTypes.EC2PublicIPv4sEnvVarName] = vpcAllocation.ElasticAddress.Ip
+		}
+
+		// Heads up, this doesn't work in generation v1 instances of VPC Service
+		env["EC2_VPC_ID"] = vpcAllocation.BranchENIVPC
+		env["EC2_INTERFACE_ID"] = vpcAllocation.BranchENIID
+		env["EC2_SUBNET_ID"] = vpcAllocation.BranchENISubnet
+	}
+
+	if batch := c.BatchPriority(); batch != nil {
+		env["TITUS_BATCH"] = *batch
+	}
+
+	if reqIMDSToken := c.RequireIMDSToken(); reqIMDSToken != nil {
+		env["TITUS_IMDS_REQUIRE_TOKEN"] = *reqIMDSToken
+	}
+
+	envOverrides := c.EnvOverrides()
+	for key, value := range envOverrides {
+		env[key] = value
+	}
+
+	if gpuInfo := c.GPUInfo(); gpuInfo != nil {
+		for key, value := range gpuInfo.Env() {
+			env[key] = value
+		}
+	}
+
+	env[TitusRuntimeEnvVariableName] = c.Runtime()
+
+	return env
+}
+
+func sortedEnv(env map[string]string) []string {
+	retEnv := make([]string, 0, len(env))
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		retEnv = append(retEnv, key+"="+env[key])
+	}
+	return retEnv
+}
+
+// combinedAppStackDetails is a port of the combineAppStackDetails method from frigga.
+// See: https://github.com/Netflix/frigga/blob/v0.17.0/src/main/java/com/netflix/frigga/NameBuilder.java
+func combinedAppStackDetails(c Container) string {
+	if c.JobGroupDetail() != "" {
+		return fmt.Sprintf("%s-%s-%s", c.AppName(), c.JobGroupStack(), c.JobGroupDetail())
+	}
+	if c.JobGroupStack() != "" {
+		return fmt.Sprintf("%s-%s", c.AppName(), c.JobGroupStack())
+	}
+	return c.AppName()
+}
+
+func (c *TitusInfoContainer) parseContainerInfoNfsMounts() error {
+	efsConfigs := c.titusInfo.GetEfsConfigInfo()
+	c.nfsMounts = []NFSMount{}
+	if efsConfigs == nil {
+		return nil
+	}
+
+	for _, efs := range efsConfigs {
+		var readOnly bool
+		switch efs.GetMntPerms() {
+		case titus.ContainerInfo_EfsConfigInfo_RW:
+			readOnly = false
+		case titus.ContainerInfo_EfsConfigInfo_RO:
+			readOnly = true
+		case titus.ContainerInfo_EfsConfigInfo_WO:
+			readOnly = false
+		default:
+			return fmt.Errorf("Invalid EFS mount (read/write flag): %+v", efs)
+		}
+
+		efsFsID := efs.GetEfsFsId()
+		if efsFsID == "" {
+			return fmt.Errorf("Invalid EFS mount (empty FS ID): %+v", efs)
+		}
+
+		isRealEfsID, err := isEFSID(efsFsID)
+		if err != nil {
+			return err
+		}
+
+		if c.config.AwsRegion == "" {
+			return errors.New("AWS region unset")
+		}
+
+		nm := NFSMount{
+			ServerPath: filepath.Clean(efs.GetEfsFsRelativeMntPoint()),
+			MountPoint: filepath.Clean(efs.GetMountPoint()),
+			ReadOnly:   readOnly,
+		}
+		if isRealEfsID {
+			nm.Server = fmt.Sprintf("%s.efs.%s.amazonaws.com", efsFsID, c.config.AwsRegion)
+		} else {
+			// Non-EFS ID: pass in the hostname for the NFS server right on through
+			// We are just abusing the "efsID" field to just be the hostname.
+			nm.Server = efsFsID
+		}
+
+		if nm.ServerPath == "" {
+			nm.ServerPath = "/"
+		}
+
+		c.nfsMounts = append(c.nfsMounts, nm)
+	}
+
+	return nil
+}
+
+func isEFSID(FsID string) (bool, error) {
+	matched, err := regexp.MatchString(`^fs-[0-9a-f]+$`, FsID)
+	if err != nil {
+		// The only type of errors that might hit this are regex compile errors
+		return false, fmt.Errorf("Something went really wrong determining if '%s' is an EFS ID: %s", FsID, err)
+	}
+	return matched, nil
 }

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -2,161 +2,418 @@ package types
 
 import (
 	"encoding/base64"
-	"regexp"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Netflix/titus-executor/api/netflix/titus"
+	"github.com/Netflix/titus-executor/config"
+	"github.com/Netflix/titus-executor/models"
 	"github.com/Netflix/titus-executor/uploader"
-	vpcTypes "github.com/Netflix/titus-executor/vpc/types"
-	"github.com/golang/protobuf/proto" // nolint: staticcheck
+	vpcapi "github.com/Netflix/titus-executor/vpc/api"
+	vpcTypes "github.com/Netflix/titus-executor/vpc/types" // nolint: staticcheck
+	podCommon "github.com/Netflix/titus-kube-common/pod"   // nolint: staticcheck
+	"github.com/docker/go-units"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ptr "k8s.io/utils/pointer"
 )
 
 var (
-	taskID = "taskid"
+	stringNil           *string
+	imageName           = "titusoss/alpine"
+	imageFullWithLatest = "docker.io/titusoss/alpine:latest"
+	testDigest          = "sha256:58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4"
 )
 
-func addContainerInfoToPod(t *testing.T, pod *corev1.Pod, cInfo *titus.ContainerInfo) {
-	pObj, err := proto.Marshal(cInfo)
-	assert.NilError(t, err)
-	b64str := base64.StdEncoding.EncodeToString(pObj)
-
-	if pod.Annotations == nil {
-		pod.Annotations = map[string]string{}
+func addPodAnnotations(pod *corev1.Pod, annotations map[string]string) {
+	for k, v := range annotations {
+		pod.ObjectMeta.Annotations[k] = v
 	}
-	pod.Annotations["containerInfo"] = b64str
+}
+
+func TestPodImageNameWithTag(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	uc := podCommon.GetUserContainer(pod)
+	uc.Image = imageFullWithLatest
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	assert.Equal(t, c.QualifiedImageName(), imageFullWithLatest)
+	assert.DeepEqual(t, c.ImageName(), ptr.StringPtr("titusoss/alpine"))
+	assert.DeepEqual(t, c.ImageVersion(), ptr.StringPtr("latest"))
+	assert.DeepEqual(t, c.ImageDigest(), stringNil)
+}
+
+func TestPodImageTagOmitLatest(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	// TODO: is this the behaviour we want?
+	expected := "docker.io/titusoss/alpine"
+	uc := podCommon.GetUserContainer(pod)
+	uc.Image = expected
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	assert.Equal(t, c.QualifiedImageName(), expected)
+}
+
+func TestPodImageByDigest(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	expected := "docker.io/" + imageName + "@" + testDigest
+
+	uc := podCommon.GetUserContainer(pod)
+	uc.Image = expected
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	assert.Equal(t, c.QualifiedImageName(), expected)
+	assert.DeepEqual(t, c.ImageName(), ptr.StringPtr(imageName))
+	assert.DeepEqual(t, c.ImageVersion(), stringNil)
+	assert.DeepEqual(t, c.ImageDigest(), ptr.StringPtr(testDigest))
 }
 
 func TestNewPodContainer(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+	taskID := pod.ObjectMeta.Name
+
 	ipAddr := "1.2.3.4"
 	expectedCommand := []string{"cmd", "arg0", "arg1"}
 	expectedEntrypoint := []string{"entrypoint", "arg0", "arg1"}
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: taskID,
+	imgName := "titusoss/alpine"
+	imgDigest := "sha256:58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4"
+	expectedImage := "docker.io/" + imgName + "@" + imgDigest
+	expAppName := "appName"
+	expAppOwner := "user@example.com"
+	expBwLimit := int64(128 * units.MB)
+	expCapabilities := &corev1.Capabilities{
+		Add:  []corev1.Capability{"NET_ADMIN"},
+		Drop: []corev1.Capability{"SYS_TIME"},
+	}
+	expKillWaitSec := uint32(11)
+	expNFSMounts := []NFSMount{
+		{
+			MountPoint: "/efs1",
+			Server:     "fs-abcdef.efs.us-east-1.amazonaws.com",
+			ServerPath: "/remote-dir",
+			ReadOnly:   true,
 		},
 	}
+	expOomScoreAdj := int32(99)
+	expResources := &Resources{
+		CPU:     2,
+		GPU:     1,
+		Mem:     512,
+		Disk:    10000,
+		Network: 128,
+	}
+	expSGs := []string{"sg-1", "sg-2"}
+	expShmSize := uint32(256)
+	expSubnets := []string{"subnet-1", "subnet-2"}
+	expSvcMeshImage := "docker.io/titusoss/servicemesh:latest"
+	expVPCalloc := &vpcTypes.HybridAllocation{
+		IPV4Address: &vpcapi.UsableAddress{
+			PrefixLength: 32,
+			Address: &vpcapi.Address{
+				Address: ipAddr,
+			},
+		},
+		BranchENIID:     "eni-abcde",
+		BranchENISubnet: "subnet-abcde",
+		BranchENIVPC:    "vpc-abcde",
+		ElasticAddress: &vpcapi.ElasticAddress{
+			Ip: "1.2.3.5",
+		},
+	}
+
+	addPodAnnotations(pod, map[string]string{
+		podCommon.AnnotationKeyAppName:                  expAppName,
+		podCommon.AnnotationKeyAppDetail:                "appDetail",
+		podCommon.AnnotationKeyAppOwnerEmail:            expAppOwner,
+		podCommon.AnnotationKeyAppStack:                 "appStack",
+		podCommon.AnnotationKeyAppSequence:              "appSeq",
+		podCommon.AnnotationKeyIAMRole:                  testIamRole,
+		podCommon.AnnotationKeyJobID:                    "jobid",
+		podCommon.AnnotationKeyJobType:                  "service",
+		podCommon.AnnotationKeyLogKeepLocalFile:         True,
+		podCommon.AnnotationKeyLogStdioCheckInterval:    "11m",
+		podCommon.AnnotationKeyLogUploadCheckInterval:   "12m",
+		podCommon.AnnotationKeyLogUploadThresholdTime:   "8h",
+		podCommon.AnnotationKeyLogUploadRegexp:          ".*.foo",
+		podCommon.AnnotationKeyNetworkAccountID:         "123456",
+		podCommon.AnnotationKeyNetworkAssignIPv6Address: True,
+		podCommon.AnnotationKeyNetworkBurstingEnabled:   True,
+		// In a real job, both the pool and IP list wouldn't be set
+		podCommon.AnnotationKeyNetworkElasticIPPool:          "pool1",
+		podCommon.AnnotationKeyNetworkElasticIPs:             "eipalloc-001,eipalloc-002",
+		podCommon.AnnotationKeyNetworkIMDSRequireToken:       "token",
+		podCommon.AnnotationKeyPodCPUBurstingEnabled:         True,
+		podCommon.AnnotationKeyPodFuseEnabled:                True,
+		podCommon.AnnotationKeyPodKvmEnabled:                 True,
+		podCommon.AnnotationKeyPodOomScoreAdj:                "99",
+		podCommon.AnnotationKeyPodSchedPolicy:                "idle",
+		podCommon.AnnotationKeyPodSeccompAgentNetEnabled:     True,
+		podCommon.AnnotationKeyPodSeccompAgentPerfEnabled:    True,
+		podCommon.AnnotationKeyNetworkSecurityGroups:         "sg-1,sg-2",
+		podCommon.AnnotationKeyNetworkSubnetIDs:              strings.Join(expSubnets, ","),
+		podCommon.AnnotationKeyNetworkJumboFramesEnabled:     True,
+		podCommon.AnnotationKeyNetworkStaticIPAllocationUUID: "static-ip-uuid",
+		// Add servicemesh sidecar
+		podCommon.AnnotationKeyServicePrefix + "/servicemesh.v1.enabled": True,
+		podCommon.AnnotationKeyServicePrefix + "/servicemesh.v1.image":   "titusoss/servicemesh:latest",
+	})
+
+	uc := podCommon.GetUserContainer(pod)
+	uc.Args = expectedCommand
+	uc.Command = expectedEntrypoint
+	uc.Image = expectedImage
+	pod.Spec.TerminationGracePeriodSeconds = ptr.Int64Ptr(11)
+
 	cInfo := &titus.ContainerInfo{
 		Process: &titus.ContainerInfo_Process{
 			Command:    expectedCommand,
 			Entrypoint: expectedEntrypoint,
 		},
 	}
-	startTime := time.Now()
-
-	addContainerInfoToPod(t, pod, cInfo)
-	c, err := NewPodContainer(pod, &ipAddr)
+	err = AddContainerInfoToPod(pod, cInfo)
 	assert.NilError(t, err)
 
+	// Add EFS mounts
+	uc.VolumeMounts = []corev1.VolumeMount{
+		{
+			Name:      "efs-fs-abcdef-rwm.subdir1",
+			MountPath: "/efs1",
+		},
+		{
+			Name:      "dev-shm",
+			MountPath: "/dev/shm",
+		},
+	}
+	shmRes := resource.MustParse("256Mi")
+	pod.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "efs-fs-abcdef-rwm.subdir1",
+			VolumeSource: corev1.VolumeSource{
+				NFS: &corev1.NFSVolumeSource{
+					Server:   "fs-abcdef.efs.us-east-1.amazonaws.com",
+					Path:     "/remote-dir",
+					ReadOnly: true,
+				},
+			},
+		},
+		{
+			Name: "dev-shm",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium:    corev1.StorageMediumMemory,
+					SizeLimit: &shmRes,
+				},
+			},
+		},
+	}
+
+	uc.SecurityContext = &corev1.SecurityContext{
+		Capabilities: expCapabilities,
+	}
+	uc.TTY = true
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	c.SetVPCAllocation(expVPCalloc)
+	c.SetID(taskID)
+
 	assert.Equal(t, c.TaskID(), taskID)
-	assert.Equal(t, c.IPv4Address(), &ipAddr)
-	assert.DeepEqual(t, c.HostnameStyle(), ptr.StringPtr(""))
+	assert.DeepEqual(t, c.IPv4Address(), &ipAddr)
+	assert.DeepEqual(t, c.HostnameStyle(), stringNil)
 
 	entrypoint, cmd := c.Process()
 	assert.DeepEqual(t, entrypoint, expectedEntrypoint)
 	assert.DeepEqual(t, cmd, expectedCommand)
 
-	actCinfo, err := c.ContainerInfo()
-	assert.NilError(t, err)
-	assert.Assert(t, proto.Equal(cInfo, actCinfo))
-
-	cConf, err := ContainerConfig(c, startTime)
-	assert.NilError(t, err)
-	assert.Assert(t, cConf != nil)
-
-	launchTime := uint64(startTime.Unix())
-	cInfo.RunState = &titus.RunningContainerInfo{
-		LaunchTimeUnixSec: &launchTime,
-		TaskId:            &taskID,
-		HostName:          &taskID,
-	}
-	assert.Assert(t, cConf.RunState != nil) // nolint: staticcheck
-	assert.Assert(t, proto.Equal(cInfo, cConf))
-
-	// Fields from the interface that aren't implemented right now
-	var intNil *int
-	var int32Nil *int32
-	var int64Nil *int64
-	var uint32Nil *uint32
-	var stringNil *string
-	var durationNil *time.Duration
-	var capNil *titus.ContainerInfo_Capabilities
-	var efsNil []*titus.ContainerInfo_EfsConfigInfo
 	var gpuNil GPUContainer
-	var uploaderConfNil *uploader.Config
-	var regexpNil *regexp.Regexp
 	var metatronCredsNil *titus.ContainerInfo_MetatronCreds
-	var resourcesNil *Resources
-	var stringsNil *[]string
-	var vpcAllocNil *vpcTypes.HybridAllocation
 
-	assert.Equal(t, c.AllowCPUBursting(), false)
-	assert.Equal(t, c.AllowNetworkBursting(), false)
-	assert.Equal(t, c.AppName(), "")
-	assert.Equal(t, c.AssignIPv6Address(), false)
-	assert.Equal(t, c.BandwidthLimitMbps(), int64Nil)
-	assert.Equal(t, c.BatchPriority(), stringNil)
-	assert.Equal(t, c.Capabilities(), capNil)
-	assert.Equal(t, c.CombinedAppStackDetails(), "")
-	assert.DeepEqual(t, c.EfsConfigInfo(), efsNil)
-	assert.DeepEqual(t, c.Env(), map[string]string{})
-	assert.Equal(t, c.ElasticIPPool(), stringNil)
-	assert.Equal(t, c.ElasticIPs(), stringNil)
-	assert.Equal(t, c.FuseEnabled(), false)
+	assert.Equal(t, c.AllowCPUBursting(), true)
+	assert.Equal(t, c.AllowNetworkBursting(), true)
+	assert.Equal(t, c.AppName(), "appName")
+	assert.Equal(t, c.AssignIPv6Address(), true)
+	assert.DeepEqual(t, c.BandwidthLimitMbps(), &expBwLimit)
+	assert.DeepEqual(t, c.BatchPriority(), ptr.StringPtr("idle"))
+	assert.DeepEqual(t, c.Capabilities(), expCapabilities)
+	assert.Equal(t, c.CombinedAppStackDetails(), "appName-appStack-appDetail")
+	assert.DeepEqual(t, c.NFSMounts(), expNFSMounts)
+
+	expEnv := map[string]string{
+		"AWS_METADATA_SERVICE_NUM_ATTEMPTS": "3",
+		"AWS_METADATA_SERVICE_TIMEOUT":      "5",
+		"EC2_DOMAIN":                        "amazonaws.com",
+		"EC2_INTERFACE_ID":                  "eni-abcde",
+		"EC2_LOCAL_IPV4":                    "1.2.3.4",
+		"EC2_PUBLIC_IPV4":                   "1.2.3.5",
+		"EC2_PUBLIC_IPV4S":                  "1.2.3.5",
+		"EC2_OWNER_ID":                      "123456",
+		"EC2_SUBNET_ID":                     "subnet-abcde",
+		"EC2_VPC_ID":                        "vpc-abcde",
+		"NETFLIX_APP":                       "appName",
+		"NETFLIX_APPUSER":                   "appuser",
+		"NETFLIX_AUTO_SCALE_GROUP":          "appName-appStack-appDetail-appSeq",
+		"NETFLIX_CLUSTER":                   "appName-appStack-appDetail",
+		"NETFLIX_DETAIL":                    "appDetail",
+		"NETFLIX_STACK":                     "appStack",
+		"TITUS_BATCH":                       "idle",
+		"TITUS_CONTAINER_ID":                taskID,
+		"TITUS_IAM_ROLE":                    testIamRole,
+		"TITUS_IMAGE_DIGEST":                imgDigest,
+		"TITUS_IMAGE_NAME":                  "titusoss/alpine",
+		"TITUS_IMDS_REQUIRE_TOKEN":          "token",
+		"TITUS_METATRON_ENABLED":            True,
+		"TITUS_NUM_CPU":                     "2",
+		"TITUS_NUM_DISK":                    "10000",
+		"TITUS_NUM_MEM":                     "512",
+		"TITUS_NUM_NETWORK_BANDWIDTH":       "128",
+		"TITUS_OCI_RUNTIME":                 DefaultOciRuntime,
+		"USER_SET_ENV1":                     "var1",
+		"USER_SET_ENV2":                     "var2",
+		"USER_SET_ENV3":                     "var3",
+	}
+
+	expEnvArray := []string{}
+	for k, v := range expEnv {
+		expEnvArray = append(expEnvArray, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(expEnvArray)
+
+	c.SetEnv("USER_SET_ENV1", "var1")
+	c.SetEnvs(map[string]string{
+		"USER_SET_ENV2": "var2",
+		"USER_SET_ENV3": "var3",
+	})
+	assert.DeepEqual(t, c.Env(), expEnv)
+	assert.DeepEqual(t, c.SortedEnvArray(), expEnvArray)
+
+	assert.DeepEqual(t, c.ElasticIPPool(), ptr.StringPtr("pool1"))
+	assert.DeepEqual(t, c.ElasticIPs(), ptr.StringPtr("eipalloc-001,eipalloc-002"))
+	assert.Equal(t, c.FuseEnabled(), true)
 	assert.Equal(t, c.GPUInfo(), gpuNil)
-	assert.Equal(t, c.IamRole(), stringNil)
-	assert.Equal(t, c.ID(), "")
-	assert.Equal(t, c.ImageDigest(), stringNil)
-	assert.Equal(t, c.ImageName(), stringNil)
+	assert.DeepEqual(t, c.IamRole(), ptr.StringPtr(testIamRole))
+	assert.Equal(t, c.ID(), taskID)
+	assert.DeepEqual(t, c.ImageDigest(), ptr.StringPtr(imgDigest))
+	assert.DeepEqual(t, c.ImageName(), ptr.StringPtr("titusoss/alpine"))
 	assert.Equal(t, c.ImageVersion(), stringNil)
-	assert.DeepEqual(t, c.ImageTagForMetrics(), map[string]string{})
-	assert.Equal(t, c.IsSystemD(), false)
-	assert.Equal(t, c.JobGroupDetail(), "")
-	assert.Equal(t, c.JobGroupStack(), "")
-	assert.Equal(t, c.JobGroupSequence(), "")
-	assert.Equal(t, c.JobID(), stringNil)
-	assert.Equal(t, c.KillWaitSeconds(), uint32Nil)
-	assert.Equal(t, c.KvmEnabled(), false)
-	assert.DeepEqual(t, c.Labels(), map[string]string{})
-	assert.Equal(t, c.LogKeepLocalFileAfterUpload(), false)
-	assert.Equal(t, c.LogStdioCheckInterval(), durationNil)
-	assert.Equal(t, c.LogUploadCheckInterval(), durationNil)
-	assert.Equal(t, c.LogUploaderConfig(), uploaderConfNil)
-	assert.Equal(t, c.LogUploadRegexp(), regexpNil)
-	assert.Equal(t, c.LogUploadThresholdTime(), durationNil)
+	assert.DeepEqual(t, c.ImageTagForMetrics(), map[string]string{
+		"image": imageName,
+	})
+	c.SetSystemD(true)
+	assert.Equal(t, c.IsSystemD(), true)
+	assert.Equal(t, c.JobGroupDetail(), "appDetail")
+	assert.Equal(t, c.JobGroupStack(), "appStack")
+	assert.Equal(t, c.JobGroupSequence(), "appSeq")
+	assert.DeepEqual(t, c.JobID(), ptr.StringPtr("jobid"))
+	assert.DeepEqual(t, c.JobType(), ptr.StringPtr("service"))
+	assert.DeepEqual(t, c.KillWaitSeconds(), &expKillWaitSec)
+	assert.Equal(t, c.KvmEnabled(), true)
+	assert.DeepEqual(t, c.Labels(), map[string]string{
+		appNameLabelKey:         expAppName,
+		commandLabelKey:         strings.Join(expectedCommand, " "),
+		entrypointLabelKey:      strings.Join(expectedEntrypoint, " "),
+		ownerEmailLabelKey:      expAppOwner,
+		jobTypeLabelKey:         "service",
+		cpuLabelKey:             strconv.Itoa(int(expResources.CPU)),
+		iamRoleLabelKey:         testIamRole,
+		memLabelKey:             strconv.Itoa(int(expResources.Mem)),
+		diskLabelKey:            strconv.Itoa(int(expResources.Disk)),
+		networkLabelKey:         strconv.Itoa(int(expResources.Network)),
+		TitusTaskInstanceIDKey:  taskID,
+		workloadTypeLabelKey:    string(BurstWorkloadType),
+		models.ExecutorPidLabel: strconv.Itoa(os.Getpid()),
+		models.TaskIDLabel:      taskID,
+	})
+	assert.Equal(t, c.LogKeepLocalFileAfterUpload(), true)
+
+	expStdioCheckInterval, _ := time.ParseDuration("11m")
+	expUploadCheckInterval, _ := time.ParseDuration("12m")
+	expUploadThreshold, _ := time.ParseDuration("8h")
+	assert.DeepEqual(t, c.LogStdioCheckInterval(), &expStdioCheckInterval)
+	assert.DeepEqual(t, c.LogUploadCheckInterval(), &expUploadCheckInterval)
+	assert.DeepEqual(t, c.LogUploaderConfig(), &uploader.Config{
+		S3WriterRole: "",
+		S3BucketName: "",
+		S3PathPrefix: "",
+	})
+
+	logUploadRegExp := c.LogUploadRegexp()
+	assert.Assert(t, logUploadRegExp != nil)
+	assert.Equal(t, logUploadRegExp.String(), ".*.foo")
+	assert.DeepEqual(t, c.LogUploadThresholdTime(), &expUploadThreshold)
+
 	assert.Equal(t, c.MetatronCreds(), metatronCredsNil)
-	assert.Equal(t, c.NormalizedENIIndex(), intNil)
-	assert.Equal(t, c.OomScoreAdj(), int32Nil)
-	assert.Equal(t, c.QualifiedImageName(), "")
-	assert.Equal(t, c.Resources(), resourcesNil)
-	assert.Equal(t, c.RequireIMDSToken(), stringNil)
-	assert.Equal(t, c.Runtime(), "")
-	assert.DeepEqual(t, c.SecurityGroupIDs(), stringsNil)
-	assert.Equal(t, c.ServiceMeshEnabled(), false)
-	assert.Equal(t, c.ShmSizeMiB(), uint32Nil)
+	zero := int(0)
+	assert.DeepEqual(t, c.NormalizedENIIndex(), &zero)
+	assert.DeepEqual(t, c.OomScoreAdj(), &expOomScoreAdj)
+	assert.Equal(t, c.QualifiedImageName(), expectedImage)
+
+	assert.DeepEqual(t, c.Resources(), expResources)
+	assert.DeepEqual(t, c.RequireIMDSToken(), ptr.StringPtr("token"))
+	assert.Equal(t, c.Runtime(), "runc")
+	assert.Equal(t, c.SeccompAgentEnabledForNetSyscalls(), true)
+	assert.Equal(t, c.SeccompAgentEnabledForPerfSyscalls(), true)
+	assert.DeepEqual(t, c.SecurityGroupIDs(), &expSGs)
+	assert.Equal(t, c.ServiceMeshEnabled(), true)
+	assert.DeepEqual(t, c.ShmSizeMiB(), &expShmSize)
 
 	sidecars, err := c.SidecarConfigs()
 	assert.NilError(t, err)
-	assert.DeepEqual(t, sidecars, []*ServiceOpts{})
+	//sort.Slice(sidecars, func(i, j int) bool { return sidecars[i].ServiceName < sidecars[j].ServiceName })
+	sidecarNames := []string{}
+	svcMeshImage := ""
+	for _, sc := range sidecars {
+		sidecarNames = append(sidecarNames, sc.ServiceName)
+		if sc.ServiceName == SidecarServiceServiceMesh {
+			svcMeshImage = sc.Image
+		}
+	}
+	assert.DeepEqual(t, sidecarNames,
+		[]string{
+			SidecarTitusContainer,
+			SidecarServiceSpectatord,
+			SidecarServiceAtlasd,
+			SidecarServiceAtlasAgent,
+			SidecarServiceSshd,
+			SidecarServiceMetadataProxy,
+			SidecarServiceMetatron,
+			SidecarServiceLogViewer,
+			SidecarServiceServiceMesh,
+			SidecarServiceAbMetrix,
+			SidecarSeccompAgent,
+			SidecarTitusStorage,
+		})
+	assert.Equal(t, svcMeshImage, expSvcMeshImage)
 
-	assert.Equal(t, c.SignedAddressAllocationUUID(), stringNil)
-	assert.DeepEqual(t, c.SortedEnvArray(), []string{})
-	assert.Equal(t, c.SubnetIDs(), stringNil)
-	assert.Equal(t, c.TTYEnabled(), false)
-	assert.Equal(t, c.UploadDir("foo"), "")
-	assert.Equal(t, c.UseJumboFrames(), false)
-	assert.Equal(t, c.VPCAllocation(), vpcAllocNil)
-	assert.Equal(t, c.VPCAccountID(), stringNil)
+	assert.DeepEqual(t, c.SignedAddressAllocationUUID(), ptr.StringPtr("static-ip-uuid"))
+	assert.DeepEqual(t, c.SubnetIDs(), &expSubnets)
+	assert.Equal(t, c.TTYEnabled(), true)
+	assert.Equal(t, c.UploadDir("foo"), "titan/mainvpc/foo/"+taskID)
+	assert.Equal(t, c.UseJumboFrames(), true)
+	assert.DeepEqual(t, c.VPCAllocation(), expVPCalloc)
+	assert.DeepEqual(t, c.VPCAccountID(), ptr.StringPtr("123456"))
 }
 
 func TestNewPodContainerErrors(t *testing.T) {
-	ipAddr := ""
-	_, err := NewPodContainer(nil, &ipAddr)
+	goodPod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+	taskID := goodPod.ObjectMeta.Name
+
+	_, err = NewPodContainer(nil, *conf)
 	assert.Error(t, err, "missing pod")
 
 	pod := &corev1.Pod{
@@ -164,48 +421,757 @@ func TestNewPodContainerErrors(t *testing.T) {
 			Name: taskID,
 		},
 	}
-	_, err = NewPodContainer(pod, nil)
-	assert.Error(t, err, "missing ipv4 address")
+	_, err = NewPodContainer(pod, *conf)
+	assert.Error(t, err, "no containers found in pod")
 
-	_, err = NewPodContainer(pod, &ipAddr)
-	assert.Error(t, err, "unable to find containerInfo annotation")
-
-	pod.Annotations = map[string]string{
-		"containerInfo": "0",
-	}
-	_, err = NewPodContainer(pod, &ipAddr)
-	assert.Error(t, err, "unable to base64 decode containerInfo annotation: illegal base64 data at input byte 0")
-
-	pod.Annotations["containerInfo"] = base64.StdEncoding.EncodeToString([]byte("blah"))
-	_, err = NewPodContainer(pod, &ipAddr)
-	assert.Error(t, err, "unable to decode containerInfo protobuf: unexpected EOF")
-
-	cInfo := &titus.ContainerInfo{
-		PassthroughAttributes: map[string]string{
-			hostnameStyleParam: "invalid",
-		},
-	}
-	addContainerInfoToPod(t, pod, cInfo)
-	_, err = NewPodContainer(pod, &ipAddr)
-	assert.Error(t, err, "unknown hostname style: invalid")
-}
-
-func TestNewPodContainerHostnameStyle(t *testing.T) {
-	ipAddr := "1.2.3.4"
-
-	pod := &corev1.Pod{
+	pod = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: taskID,
 		},
-	}
-	cInfo := &titus.ContainerInfo{
-		PassthroughAttributes: map[string]string{
-			hostnameStyleParam: "ec2",
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: taskID,
+				},
+			},
 		},
 	}
 
-	addContainerInfoToPod(t, pod, cInfo)
-	c, err := NewPodContainer(pod, &ipAddr)
+	_, err = NewPodContainer(pod, *conf)
+	assert.ErrorContains(t, err, "pod did not contain network resource limit")
+
+	pod.Spec.Containers[0].Resources = goodPod.Spec.Containers[0].Resources
+	_, err = NewPodContainer(pod, *conf)
+	assert.ErrorContains(t, err, "unable to find containerInfo annotation")
+
+	pod.Annotations = map[string]string{
+		podCommon.AnnotationKeyPodTitusContainerInfo: "0",
+	}
+	_, err = NewPodContainer(pod, *conf)
+	assert.ErrorContains(t, err, "unable to base64 decode containerInfo annotation: illegal base64 data")
+
+	pod.Annotations[podCommon.AnnotationKeyPodTitusContainerInfo] = base64.StdEncoding.EncodeToString([]byte("blah"))
+	_, err = NewPodContainer(pod, *conf)
+	assert.Error(t, err, "unable to decode containerInfo protobuf: unexpected EOF")
+
+	err = AddContainerInfoToPod(pod, &titus.ContainerInfo{})
+	assert.NilError(t, err)
+
+	_, err = NewPodContainer(pod, *conf)
+	assert.ErrorContains(t, err, "error parsing docker image \"\"")
+
+	pod.Spec.Containers[0].Image = testImageWithTag
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:      "dev-shm",
+		MountPath: ShmMountPath,
+	})
+	_, err = NewPodContainer(pod, *conf)
+	assert.Error(t, err, "error parsing EmptyDir mounts: container volume mount found with unmatched pod volume: dev-shm")
+}
+
+func TestNewPodContainerHostnameStyle(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	addPodAnnotations(pod, map[string]string{
+		podCommon.AnnotationKeyPodHostnameStyle: "ec2",
+	})
+
+	c, err := NewPodContainer(pod, *conf)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, c.HostnameStyle(), ptr.StringPtr("ec2"))
 }
+
+func TestNewPodContainerMetatronDisabled(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	conf.MetatronEnabled = false
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	assert.Equal(t, c.Env()["TITUS_METATRON_ENABLED"], "false")
+}
+
+func TestPodContainerClusterName(t *testing.T) {
+	fixtures := []struct {
+		appName        string
+		jobGroupStack  string
+		jobGroupDetail string
+		expected       string
+	}{
+		{
+			appName:        "app1",
+			jobGroupStack:  "somestack",
+			jobGroupDetail: "details",
+			expected:       "app1-somestack-details",
+		},
+		{
+			// no details
+			appName:       "app2",
+			jobGroupStack: "somestack",
+			expected:      "app2-somestack",
+		},
+		{
+			// no stack
+			appName:        "app3",
+			jobGroupDetail: "details",
+			expected:       "app3--details",
+		},
+		{
+			// no stack no details
+			appName:  "app4",
+			expected: "app4",
+		},
+	}
+
+	for _, f := range fixtures {
+		pod, conf, err := PodContainerTestArgs()
+		assert.NilError(t, err)
+
+		if f.appName != "" {
+			pod.Annotations[podCommon.AnnotationKeyAppName] = f.appName
+		}
+		if f.jobGroupDetail != "" {
+			pod.Annotations[podCommon.AnnotationKeyAppDetail] = f.jobGroupDetail
+		}
+		if f.jobGroupStack != "" {
+			pod.Annotations[podCommon.AnnotationKeyAppStack] = f.jobGroupStack
+		}
+
+		c, err := NewPodContainer(pod, *conf)
+		assert.NilError(t, err)
+
+		got := c.CombinedAppStackDetails()
+		assert.Equal(t, f.expected, got)
+	}
+}
+
+func TestPodContainerEnvBasedOnTaskInfo(t *testing.T) {
+	type input struct {
+		annotations, env                        map[string]string
+		cpu, mem, disk, image, networkBandwidth string
+	}
+	check := func(name string, input input, want map[string]string) func(*testing.T) {
+		return func(t *testing.T) {
+			var err error
+			var resources Resources
+
+			pod, conf, err := PodContainerTestArgs()
+			assert.NilError(t, err)
+
+			conf.SSHAccountID = "config"
+			conf.GetHardcodedEnv()
+
+			if input.cpu == "" {
+				input.cpu = "1"
+				if _, ok := want["TITUS_NUM_CPU"]; !ok {
+					want["TITUS_NUM_CPU"] = input.cpu
+				}
+			}
+			if input.mem == "" {
+				input.mem = "333"
+				if _, ok := want["TITUS_NUM_MEM"]; !ok {
+					want["TITUS_NUM_MEM"] = input.mem
+				}
+			}
+			if input.disk == "" {
+				input.disk = "1000"
+				if _, ok := want["TITUS_NUM_DISK"]; !ok {
+					want["TITUS_NUM_DISK"] = input.disk
+				}
+			}
+			if input.networkBandwidth == "" {
+				input.networkBandwidth = "100"
+				if _, ok := want["TITUS_NUM_NETWORK_BANDWIDTH"]; !ok {
+					want["TITUS_NUM_NETWORK_BANDWIDTH"] = input.networkBandwidth
+				}
+			}
+
+			if input.image != "" {
+				pod.Spec.Containers[0].Image = input.image
+			}
+
+			resources.Mem, err = strconv.ParseInt(input.mem, 10, 64)
+			assert.NilError(t, err)
+
+			resources.CPU, err = strconv.ParseInt(input.cpu, 10, 64)
+			assert.NilError(t, err)
+
+			resources.Disk, err = strconv.ParseInt(input.disk, 10, 64)
+			assert.NilError(t, err)
+
+			resources.Network, err = strconv.ParseInt(input.networkBandwidth, 10, 64)
+			assert.NilError(t, err)
+
+			resourceReqs := ResourcesToPodResourceRequirements(&resources)
+			pod.Spec.Containers[0].Resources = resourceReqs
+
+			for k, v := range input.annotations {
+				pod.Annotations[k] = v
+			}
+			for k, v := range input.env {
+				pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
+					Name:  k,
+					Value: v,
+				})
+			}
+
+			if _, ok := pod.Annotations[podCommon.AnnotationKeyIAMRole]; !ok {
+				pod.Annotations[podCommon.AnnotationKeyIAMRole] = testIamRole
+			}
+			container, err := NewPodContainer(pod, *conf)
+			assert.NilError(t, err)
+			containerEnv := container.Env()
+			// Checks if everything in want is in containerEnv
+			// basically, makes sure want is a subset of containerEnv
+			// We merge the maps so we can use assert.equals
+			for key, value := range containerEnv {
+				if _, ok := want[key]; !ok {
+					want[key] = value
+				}
+			}
+			assert.DeepEqual(t, want, containerEnv)
+		}
+	}
+
+	fixtures := []struct {
+		name  string
+		input input
+		want  map[string]string
+	}{
+		{
+			name: "Full",
+			input: input{
+				annotations: map[string]string{
+					podCommon.AnnotationKeyAppName:     "app1",
+					podCommon.AnnotationKeyAppStack:    "stack1",
+					podCommon.AnnotationKeyAppDetail:   "detail1",
+					podCommon.AnnotationKeyAppSequence: "v001",
+				},
+				image:            "titusops/image1@" + testDigest,
+				cpu:              "1",
+				mem:              "100",
+				disk:             "1000",
+				networkBandwidth: "100",
+			},
+			want: map[string]string{
+				"NETFLIX_APP":                 "app1",
+				"NETFLIX_STACK":               "stack1",
+				"NETFLIX_DETAIL":              "detail1",
+				"NETFLIX_CLUSTER":             "app1-stack1-detail1",
+				"NETFLIX_AUTO_SCALE_GROUP":    "app1-stack1-detail1-v001",
+				"TITUS_NUM_CPU":               "1",
+				"TITUS_NUM_MEM":               "100",
+				"TITUS_NUM_DISK":              "1000",
+				"TITUS_NUM_NETWORK_BANDWIDTH": "100",
+				"TITUS_IMAGE_NAME":            "titusops/image1",
+				"TITUS_IMAGE_DIGEST":          testDigest,
+			},
+		},
+		{
+			name: "NoName",
+			input: input{
+				annotations: map[string]string{
+					podCommon.AnnotationKeyAppName:     "image1",
+					podCommon.AnnotationKeyAppStack:    "stack1",
+					podCommon.AnnotationKeyAppDetail:   "detail1",
+					podCommon.AnnotationKeyAppSequence: "v001",
+				},
+				image:            "titusops/image1:latest",
+				cpu:              "2",
+				mem:              "200",
+				disk:             "2000",
+				networkBandwidth: "200",
+			},
+			want: map[string]string{
+				"NETFLIX_APP":                 "image1",
+				"NETFLIX_STACK":               "stack1",
+				"NETFLIX_DETAIL":              "detail1",
+				"NETFLIX_CLUSTER":             "image1-stack1-detail1",
+				"NETFLIX_AUTO_SCALE_GROUP":    "image1-stack1-detail1-v001",
+				"TITUS_NUM_CPU":               "2",
+				"TITUS_NUM_MEM":               "200",
+				"TITUS_NUM_DISK":              "2000",
+				"TITUS_NUM_NETWORK_BANDWIDTH": "200",
+				"TITUS_IMAGE_NAME":            "titusops/image1",
+				"TITUS_IMAGE_TAG":             "latest",
+			},
+		},
+		{
+			name: "NoStack",
+			input: input{
+				annotations: map[string]string{
+					podCommon.AnnotationKeyAppName:     "app1",
+					podCommon.AnnotationKeyAppDetail:   "detail1",
+					podCommon.AnnotationKeyAppSequence: "v001",
+				},
+				image:            "titusops/image1:latest",
+				cpu:              "3",
+				mem:              "300",
+				disk:             "3000",
+				networkBandwidth: "300",
+			},
+			want: map[string]string{
+				"NETFLIX_APP":                 "app1",
+				"NETFLIX_DETAIL":              "detail1",
+				"NETFLIX_STACK":               "",
+				"NETFLIX_CLUSTER":             "app1--detail1",
+				"NETFLIX_AUTO_SCALE_GROUP":    "app1--detail1-v001",
+				"TITUS_NUM_CPU":               "3",
+				"TITUS_NUM_MEM":               "300",
+				"TITUS_NUM_DISK":              "3000",
+				"TITUS_NUM_NETWORK_BANDWIDTH": "300",
+				"TITUS_IMAGE_NAME":            "titusops/image1",
+				"TITUS_IMAGE_TAG":             "latest",
+			},
+		},
+		{
+			name: "NoDetail",
+			input: input{
+				annotations: map[string]string{
+					podCommon.AnnotationKeyAppName:     "app1",
+					podCommon.AnnotationKeyAppStack:    "stack1",
+					podCommon.AnnotationKeyAppSequence: "v001",
+				},
+				image:            "titusops/image1:latest",
+				cpu:              "4",
+				mem:              "400",
+				disk:             "4000",
+				networkBandwidth: "400",
+			},
+			want: map[string]string{
+				"NETFLIX_APP":                 "app1",
+				"NETFLIX_STACK":               "stack1",
+				"NETFLIX_DETAIL":              "",
+				"NETFLIX_CLUSTER":             "app1-stack1",
+				"NETFLIX_AUTO_SCALE_GROUP":    "app1-stack1-v001",
+				"TITUS_NUM_CPU":               "4",
+				"TITUS_NUM_MEM":               "400",
+				"TITUS_NUM_DISK":              "4000",
+				"TITUS_NUM_NETWORK_BANDWIDTH": "400",
+				"TITUS_IMAGE_NAME":            "titusops/image1",
+				"TITUS_IMAGE_TAG":             "latest",
+			},
+		},
+		{
+			name: "NoSequence",
+			input: input{
+				annotations: map[string]string{
+					podCommon.AnnotationKeyAppName:   "app1",
+					podCommon.AnnotationKeyAppStack:  "stack1",
+					podCommon.AnnotationKeyAppDetail: "detail1",
+				},
+				image:            "titusops/image1:latest",
+				cpu:              "5",
+				mem:              "500",
+				disk:             "5000",
+				networkBandwidth: "500",
+			},
+			want: map[string]string{
+				"NETFLIX_APP":                 "app1",
+				"NETFLIX_STACK":               "stack1",
+				"NETFLIX_DETAIL":              "detail1",
+				"NETFLIX_CLUSTER":             "app1-stack1-detail1",
+				"NETFLIX_AUTO_SCALE_GROUP":    "app1-stack1-detail1-v000",
+				"TITUS_NUM_CPU":               "5",
+				"TITUS_NUM_MEM":               "500",
+				"TITUS_NUM_DISK":              "5000",
+				"TITUS_NUM_NETWORK_BANDWIDTH": "500",
+				"TITUS_IMAGE_NAME":            "titusops/image1",
+				"TITUS_IMAGE_TAG":             "latest",
+			},
+		},
+		{
+			name: "NoStackNoDetail",
+			input: input{
+				annotations: map[string]string{
+					podCommon.AnnotationKeyAppName:     "app1",
+					podCommon.AnnotationKeyAppSequence: "v001",
+				},
+				image:            "titusops/image1:latest",
+				cpu:              "6",
+				mem:              "600",
+				disk:             "6000",
+				networkBandwidth: "600",
+			},
+			want: map[string]string{
+				"NETFLIX_APP":                 "app1",
+				"NETFLIX_STACK":               "",
+				"NETFLIX_DETAIL":              "",
+				"NETFLIX_CLUSTER":             "app1",
+				"NETFLIX_AUTO_SCALE_GROUP":    "app1-v001",
+				"TITUS_NUM_CPU":               "6",
+				"TITUS_NUM_MEM":               "600",
+				"TITUS_NUM_DISK":              "6000",
+				"TITUS_NUM_NETWORK_BANDWIDTH": "600",
+				"TITUS_IMAGE_NAME":            "titusops/image1",
+				"TITUS_IMAGE_TAG":             "latest",
+			},
+		},
+		{
+			name: "NoStackNoDetailNoSequence",
+			input: input{
+				annotations: map[string]string{
+					podCommon.AnnotationKeyAppName: "app1",
+				},
+				image:            "titusops/image1:latest",
+				cpu:              "7",
+				mem:              "700",
+				disk:             "7000",
+				networkBandwidth: "700",
+			},
+			want: map[string]string{
+				"NETFLIX_APP":                 "app1",
+				"NETFLIX_STACK":               "",
+				"NETFLIX_DETAIL":              "",
+				"NETFLIX_CLUSTER":             "app1",
+				"NETFLIX_AUTO_SCALE_GROUP":    "app1-v000",
+				"TITUS_NUM_CPU":               "7",
+				"TITUS_NUM_MEM":               "700",
+				"TITUS_NUM_DISK":              "7000",
+				"TITUS_NUM_NETWORK_BANDWIDTH": "700",
+				"TITUS_IMAGE_NAME":            "titusops/image1",
+				"TITUS_IMAGE_TAG":             "latest",
+			},
+		},
+		{
+			name: "NoNameNoStackNoDetailNoSequence",
+			input: input{
+				annotations: map[string]string{
+					podCommon.AnnotationKeyAppName: "image1",
+				},
+				image:            "titusops/image1:latest",
+				cpu:              "8",
+				mem:              "800",
+				disk:             "8000",
+				networkBandwidth: "800",
+			},
+			want: map[string]string{
+				"NETFLIX_APP":                 "image1",
+				"NETFLIX_STACK":               "",
+				"NETFLIX_DETAIL":              "",
+				"NETFLIX_CLUSTER":             "image1",
+				"NETFLIX_AUTO_SCALE_GROUP":    "image1-v000",
+				"TITUS_NUM_CPU":               "8",
+				"TITUS_NUM_MEM":               "800",
+				"TITUS_NUM_DISK":              "8000",
+				"TITUS_NUM_NETWORK_BANDWIDTH": "800",
+				"TITUS_IMAGE_NAME":            "titusops/image1",
+				"TITUS_IMAGE_TAG":             "latest",
+			},
+		},
+		{
+			name: "CanOverrideResources",
+			input: input{
+				env: map[string]string{
+					"TITUS_NUM_CPU": "42",
+				},
+				annotations: map[string]string{},
+				cpu:         "1",
+			},
+			want: map[string]string{
+				"TITUS_NUM_CPU": "42",
+			},
+		},
+		{
+			name: "CannotOverrideIAM",
+			input: input{
+				env: map[string]string{
+					"TITUS_IAM_ROLE": "arn:aws:iam::0:role/HackerRole",
+				},
+				annotations: map[string]string{
+					podCommon.AnnotationKeyIAMRole: "arn:aws:iam::0:role/RealRole",
+				},
+			},
+			want: map[string]string{
+				"TITUS_IAM_ROLE": "arn:aws:iam::0:role/RealRole",
+			},
+		},
+		{
+			// the control plane should set the EC2_OWNER_ID variable
+			name: "PreserveEC2OwnerID",
+			input: input{
+				env: map[string]string{
+					"EC2_OWNER_ID": "good",
+				},
+				annotations: map[string]string{
+					podCommon.AnnotationKeyNetworkAccountID: "default",
+				},
+			},
+			want: map[string]string{
+				"EC2_OWNER_ID": "good",
+			},
+		},
+		{
+			name: "FallbackToAccountIDParam",
+			input: input{
+				annotations: map[string]string{
+					podCommon.AnnotationKeyNetworkAccountID: "default",
+				},
+			},
+			want: map[string]string{
+				"EC2_OWNER_ID": "default",
+			},
+		},
+		{
+			name: "FallbackToConfig",
+			input: input{
+				env:         map[string]string{},
+				annotations: map[string]string{},
+			},
+			want: map[string]string{
+				"EC2_OWNER_ID": "config",
+			},
+		},
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.name, check(f.name, f.input, f.want))
+	}
+}
+
+func TestPodContainerServiceMeshEnabled(t *testing.T) {
+	imgName := "titusoss/test-svcmesh:latest"
+	config := config.Config{
+		ContainerServiceMeshEnabled: true,
+	}
+
+	pod, _, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	addPodAnnotations(pod, map[string]string{
+		podCommon.AnnotationKeyServicePrefix + "/servicemesh.v1.enabled": True,
+		podCommon.AnnotationKeyServicePrefix + "/servicemesh.v1.image":   imgName,
+	})
+
+	c, err := NewPodContainer(pod, config)
+	assert.NilError(t, err)
+	assert.Equal(t, c.ServiceMeshEnabled(), true)
+	scConfs, err := c.SidecarConfigs()
+	assert.NilError(t, err)
+	var svcMeshConf *ServiceOpts
+	for s := range scConfs {
+		if scConfs[s].ServiceName == SidecarServiceServiceMesh {
+			svcMeshConf = scConfs[s]
+			break
+		}
+	}
+	assert.Assert(t, svcMeshConf != nil)
+	assert.Equal(t, svcMeshConf.Image, imgName) // nolint:staticcheck
+}
+
+func TestPodContainerServiceMeshEnabledWithConfig(t *testing.T) {
+	// If service mesh is set to enabled, but neither the `ProxydServiceImage` config value
+	// or the passhtrough property are set, service mesh should end up disabled
+	config := config.Config{
+		ContainerServiceMeshEnabled: true,
+	}
+
+	pod, _, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	c, err := NewPodContainer(pod, config)
+	assert.NilError(t, err)
+	assert.Equal(t, c.ServiceMeshEnabled(), false)
+	scConfs, err := c.SidecarConfigs()
+	assert.NilError(t, err)
+	var svcMeshConf *ServiceOpts
+	for s := range scConfs {
+		if scConfs[s].ServiceName == SidecarServiceServiceMesh {
+			svcMeshConf = scConfs[s]
+			break
+		}
+	}
+	assert.Assert(t, svcMeshConf != nil)
+	assert.Equal(t, svcMeshConf.Image, "") // nolint:staticcheck
+}
+
+func TestPodContainerServiceMeshEnabledWithEmptyConfigValue(t *testing.T) {
+	// Setting proxyd image to the empty string should result servicemesh being disabled
+	config := config.Config{
+		ContainerServiceMeshEnabled: true,
+		ProxydServiceImage:          "",
+	}
+
+	pod, _, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	c, err := NewPodContainer(pod, config)
+	assert.NilError(t, err)
+	assert.Equal(t, c.ServiceMeshEnabled(), false)
+	scConfs, err := c.SidecarConfigs()
+	assert.NilError(t, err)
+	var svcMeshConf *ServiceOpts
+	for s := range scConfs {
+		if scConfs[s].ServiceName == SidecarServiceServiceMesh {
+			svcMeshConf = scConfs[s]
+			break
+		}
+	}
+	assert.Assert(t, svcMeshConf != nil)
+	assert.Equal(t, svcMeshConf.Image, "") // nolint:staticcheck
+}
+
+func TestPodContainerSubnetIDHasSpaces(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	addPodAnnotations(pod, map[string]string{
+		podCommon.AnnotationKeyNetworkSubnetIDs: "subnet-foo, subnet-bar ",
+	})
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+
+	expSubnets := []string{"subnet-foo", "subnet-bar"}
+	assert.DeepEqual(t, c.SubnetIDs(), &expSubnets)
+}
+
+func TestIsEFSID(t *testing.T) {
+	var actual bool
+	actual, _ = isEFSID("fs-123450")
+	assert.Equal(t, actual, true)
+
+	actual, _ = isEFSID("fs-123450.efs.us-west-1.amazonaws.com")
+	assert.Equal(t, actual, false)
+
+	actual, _ = isEFSID("nfs.example.com")
+	assert.Equal(t, actual, false)
+}
+
+func TestPodContainerCustomCmd(t *testing.T) {
+	t.Run("WithNilEntrypoint", testPodCustomCmdWithEntrypoint(nil))
+	t.Run("WithEmptyEntrypoint", testPodCustomCmdWithEntrypoint([]string{}))
+	t.Run("WithEntrypoint", testPodCustomCmdWithEntrypoint([]string{"/bin/sh", "-c"}))
+}
+
+func testPodCustomCmdWithEntrypoint(entrypoint []string) func(*testing.T) {
+	return func(t *testing.T) {
+		pod, conf, err := PodContainerTestArgs()
+		assert.NilError(t, err)
+
+		// k8s `Command` is the same as docker's Entrypoint
+		pod.Spec.Containers[0].Command = entrypoint
+		// k8s `Args` is the same as docker's Command
+		pod.Spec.Containers[0].Args = []string{"sleep", "1"}
+
+		c, err := NewPodContainer(pod, *conf)
+		assert.NilError(t, err)
+
+		entry, cmd := c.Process()
+		assert.Equal(t, len(entry), len(entrypoint))
+		assert.Equal(t, len(cmd), 2)
+		assert.Equal(t, cmd[0], "sleep")
+		assert.Equal(t, cmd[1], "1")
+	}
+}
+
+func TestPodContainerDefaultProcessIsEmpty(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+
+	entrypoint, cmd := c.Process()
+	assert.Equal(t, len(entrypoint), 0)
+	assert.Equal(t, len(cmd), 0)
+}
+
+func TestPodContainerDefaultHostnameStyle(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+
+	hostname, err := ComputeHostname(c)
+	assert.NilError(t, err)
+	assert.Equal(t, c.TaskID(), hostname)
+}
+
+func TestPodContainerEC2HostnameStyle(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	pod.Annotations[podCommon.AnnotationKeyPodHostnameStyle] = "ec2"
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+
+	c.SetVPCAllocation(&vpcTypes.HybridAllocation{
+		IPV4Address: &vpcapi.UsableAddress{
+			PrefixLength: 32,
+			Address: &vpcapi.Address{
+				Address: "1.2.3.4"},
+		},
+	})
+
+	hostname, err := ComputeHostname(c)
+	assert.NilError(t, err)
+	assert.Equal(t, "ip-1-2-3-4", hostname)
+}
+
+func TestPodContainerInvalidHostnameStyle(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	pod.Annotations[podCommon.AnnotationKeyPodHostnameStyle] = "foo"
+	_, err = NewPodContainer(pod, *conf)
+	assert.ErrorContains(t, err, "annotation is not a valid hostname style")
+}
+
+func TestPodContainerDefaultIPv6AddressAssignment(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	assert.Equal(t, c.AssignIPv6Address(), false)
+}
+
+func TestPodContainerIPv6AddressAssignment(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	pod.Annotations[podCommon.AnnotationKeyNetworkAssignIPv6Address] = True
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	assert.Equal(t, c.AssignIPv6Address(), true)
+}
+
+func TestPodContainerTtyEnabled(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	pod.Spec.Containers[0].TTY = true
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	assert.Equal(t, c.TTYEnabled(), true)
+
+	pod.Spec.Containers[0].TTY = false
+	c, err = NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	assert.Equal(t, c.TTYEnabled(), false)
+}
+
+func TestPodContainerOomScoreAdj(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	var oomScoreNil *int32
+	assert.DeepEqual(t, oomScoreNil, c.OomScoreAdj())
+
+	pod.Annotations[podCommon.AnnotationKeyPodOomScoreAdj] = "99"
+	c, err = NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	oomScore := int32(99)
+
+	assert.Equal(t, oomScore, *c.OomScoreAdj())
+}
+
+// TODO:
+// - log uploading durations

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -17,7 +17,7 @@ const (
 	SidecarServiceMetadataProxy = "metadata-proxy"
 )
 
-var sideCars = []*ServiceOpts{
+var sideCars = []ServiceOpts{
 	{
 		ServiceName: SidecarTitusContainer,
 		UnitName:    "titus-container",

--- a/executor/runtime/types/types_test.go
+++ b/executor/runtime/types/types_test.go
@@ -15,7 +15,7 @@ func TestFlatStringEntrypointIsParsed(t *testing.T) {
 	input := `/titusimage-1.2.0/bin/titusimage -id 0e2d2a2e-1f6f-42ac-80f5-a502646423a1 -email changed@netflix.com -audience "changed test abcdefg" -description "changed test abcdefg" -type WHAT -query "set hive.auto.convert.join=false; set hive.mapred.mode=unstrict; select distinct my_id from vault.ad_dfa_dcid_profile_last_seen_d m join (select account_id, sum(standard_sanitized_duration_sec) duration from dse.loc_acct_device_ttl_sum where show_title_id = 80028732 and country_iso_code in ('FR') and region_date >= 20151227 group by account_id having duration >= 360) x on m.account_id = x.account_id where my_id != '0' and last_seen_dateint >= 20150127" -reuse true`
 	expected := `["/titusimage-1.2.0/bin/titusimage", "-id", "0e2d2a2e-1f6f-42ac-80f5-a502646423a1", "-email", "changed@netflix.com", "-audience", "changed test abcdefg", "-description", "changed test abcdefg", "-type", "WHAT", "-query", "set hive.auto.convert.join=false; set hive.mapred.mode=unstrict; select distinct my_id from vault.ad_dfa_dcid_profile_last_seen_d m join (select account_id, sum(standard_sanitized_duration_sec) duration from dse.loc_acct_device_ttl_sum where show_title_id = 80028732 and country_iso_code in ('FR') and region_date >= 20151227 group by account_id having duration >= 360) x on m.account_id = x.account_id where my_id != '0' and last_seen_dateint >= 20150127", "-reuse", "true"]`
 
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 	titusInfo.EntrypointStr = &input
 	titusInfo.Process = &titus.ContainerInfo_Process{
@@ -44,7 +44,7 @@ func TestCustomCmd(t *testing.T) {
 
 func testCustomCmdWithEntrypoint(entrypoint []string) func(*testing.T) {
 	return func(t *testing.T) {
-		taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+		taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 		assert.NoError(t, err)
 		titusInfo.Process = &titus.ContainerInfo_Process{
 			Entrypoint: entrypoint,
@@ -64,7 +64,7 @@ func testCustomCmdWithEntrypoint(entrypoint []string) func(*testing.T) {
 
 func TestFlatStringEntryPointMustBeNilForCustomCmd(t *testing.T) {
 	empty := ""
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
 	titusInfo.EntrypointStr = &empty
@@ -81,7 +81,7 @@ func TestFlatStringEntryPointMustBeNilForCustomCmd(t *testing.T) {
 }
 
 func TestDefaultIsNil(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
 	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
@@ -93,7 +93,7 @@ func TestDefaultIsNil(t *testing.T) {
 }
 
 func TestDefaultHostnameStyle(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
 	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
@@ -105,7 +105,7 @@ func TestDefaultHostnameStyle(t *testing.T) {
 }
 
 func TestEc2HostnameStyle(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[hostnameStyleParam] = "ec2"
 
@@ -125,7 +125,7 @@ func TestEc2HostnameStyle(t *testing.T) {
 }
 
 func TestInvalidHostnameStyle(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[hostnameStyleParam] = "foo"
 
@@ -142,7 +142,7 @@ func TestInvalidHostnameStyle(t *testing.T) {
 }
 
 func TestDefaultIPv6AddressAssignment(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
 	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
@@ -151,7 +151,7 @@ func TestDefaultIPv6AddressAssignment(t *testing.T) {
 }
 
 func TestIPv6AddressAssignment(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[assignIPv6AddressParam] = "true"
 
@@ -161,7 +161,7 @@ func TestIPv6AddressAssignment(t *testing.T) {
 }
 
 func TestTtyEnabled(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[ttyEnabledParam] = "true"
 
@@ -171,7 +171,7 @@ func TestTtyEnabled(t *testing.T) {
 }
 
 func TestOomScoreAdj(t *testing.T) {
-	taskID, titusInfo, resources, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 	oomScore := int32(99)
 	titusInfo.OomScoreAdj = &oomScore

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Netflix/metrics-client-go v0.0.0-20171019173821-bb173f41fc07
 	github.com/Netflix/spectator-go v0.0.0-20190913215732-d4e0463555ef
 	github.com/Netflix/titus-api-definitions v0.0.1-rc9.0.20200520235959-0ab6f1129886
-	github.com/Netflix/titus-kube-common v0.10.1
+	github.com/Netflix/titus-kube-common v0.10.2-0.20210420003404-4e53c4032156
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
 	github.com/apparentlymart/go-cidr v1.0.0
@@ -22,6 +22,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/deckarep/golang-set v1.7.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/Netflix/titus-kube-common v0.9.0 h1:cICC1qS+PPoXT/Ih0e2fyDdANsbgwAIeg
 github.com/Netflix/titus-kube-common v0.9.0/go.mod h1:fU8ZwjsXgEaZNx1H4UjLD9S2h55EKwHQQeZwGyiwsdU=
 github.com/Netflix/titus-kube-common v0.10.1 h1:gX6vJyvGK6QDDxwqcIYGQw+vgn5uVLRsxOZ7Aww/ckk=
 github.com/Netflix/titus-kube-common v0.10.1/go.mod h1:OoWxqK3nzjhkRvtox9JJR7gXcXAehJ2tpEtBX2X2c2w=
+github.com/Netflix/titus-kube-common v0.10.2-0.20210420003404-4e53c4032156 h1:22GZFInn3rthZm6f+8aFyzwaKvkgFFY7gaOkBib+/jc=
+github.com/Netflix/titus-kube-common v0.10.2-0.20210420003404-4e53c4032156/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -674,6 +676,8 @@ github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v1.0.0-rc10 h1:AbmCEuSZXVflng0/cboQkpdEOeBsPMjz6tmq4Pv8MZw=

--- a/hack/agent/certs/setup-metatron-certs.sh
+++ b/hack/agent/certs/setup-metatron-certs.sh
@@ -12,7 +12,13 @@ function die() {
 }
 
 SRC_CERT_DIR=/metatron/certificates
+# Allow metatron certs to be mounted in to override the default location
+MNT_SRC_CERT_DIR=/mnt/metatron/certificates
 DEST_CERT_DIR=/run/metatron/certificates
+
+if [[ -e $MNT_SRC_CERT_DIR ]]; then
+    SRC_CERT_DIR=$MNT_SRC_CERT_DIR
+fi
 
 if [[ ! -d $SRC_CERT_DIR ]]; then
     die "Source certificate directory does not exist: $SRC_CERT_DIR"

--- a/hack/tests-with-dind.sh
+++ b/hack/tests-with-dind.sh
@@ -66,7 +66,7 @@ docker exec "$titus_agent_name" ${PWD}/hack/agent/certs/setup-metatron-certs.sh
 log "Running integration tests against the $titus_agent_name daemon"
 # --privileged is needed here since we are reading FDs from a unix socket
 docker exec --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
-  go test -timeout ${TEST_TIMEOUT:-15m} ${TEST_FLAGS:-} \
+  go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
     -covermode=count -coverprofile=coverage-standalone.out \
     -coverpkg=github.com/Netflix/... ./executor/standalone/... -standalone=true 2>&1 | tee test-standalone.log
 

--- a/logviewer/api/handlers.go
+++ b/logviewer/api/handlers.go
@@ -38,7 +38,7 @@ func logHandler(w http.ResponseWriter, r *http.Request, containerID, fileName st
 	containerLogsRoot := buildLogLocationBase(containerID)
 
 	filePath, err := securejoin.SecureJoin(containerLogsRoot, fileName)
-	log.Infof("Joined log file %s and %s", containerLogsRoot, filePath)
+	log.Infof("Joined log file %s and filename %s to %s (container ID: %s)", containerLogsRoot, fileName, filePath, containerID)
 	if err != nil {
 		log.WithError(err).Error("Unable to build secure path")
 		http.Error(w, "Cannot build log file path: "+err.Error(), 503)


### PR DESCRIPTION
This moves to using standard k8s pod spec fields and annotations to implement all of the features in ContainerInfo.  The majority of this code will only be run when the `pod.netflix.com/pod-schema-version` annotation is set to `1` or higher, so it can be enabled on a per-job basis by the Job Co-ordinator.

This moves the responsibility for a lot of things the executor used to do to the TJC, including:
* Mapping EFS FS IDs to a regional hostname
* Parsing entrypoint and command
* Setting the apparmor profile name for FUSE
* Images are assumed to be fully qualified with the registry to pull from

This also adds:
* better error messages for various failure modes (such as tini not starting correctly)
* updating the pod status when initial pod validation fails (before the container has been started): before this resulted in no message being returned, which was painful to debug
* copying of your local metatron creds when running integration tests directly on your Mac
* various other logging and error message fixes to make debugging test failures more straightforward

Other notes:
* This still uses the ContainerInfo annotation to return Metatron information in the IMDS for now - I'll remove this in a follow-on commit.
* I copied all unit tests that used ContainerInfo into new tests that use the pod fields instead. Once we're running with the pod spec everywhere, I'll go back and remove the ContainerInfo-based tests, along with the ContainerInfo-backed Container implementation. Until then, I'm leaving them in place as a safety net.

See the titus-kube-common PR at https://github.com/Netflix/titus-kube-common/pull/14/files for more details, and in particular the [example pod spec](https://github.com/Netflix/titus-kube-common/blob/pod-spec/docs/examples/complete-pod.yaml).