### PR TITLE
Added titus-sshd to the CircleCI build steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ workflows:
       - ci-builder
       - test-images
       - titus-logviewer
+      - titus-sshd
       - build:
           requires:
             - builder


### PR DESCRIPTION
This makes it so we continuously build + push
the titus-sshd image, along with the other images
(builder, titus-logviewer, etc).

We haven't pushed a new image in 2 years it looks like:
https://hub.docker.com/r/titusoss/titus-sshd