### PR TITLE
Reverted changes to the titus-ssh system service

### DIFF
--- a/root/etc/apparmor.d/docker_fuse
+++ b/root/etc/apparmor.d/docker_fuse
@@ -43,9 +43,9 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
-/titus/sshd/usr/sbin/run-titus-sshd Cx,
+/titus/sshd/usr/sbin/sshd Cx,
 
-  profile sshd /titus/sshd/usr/sbin/run-titus-sshd {
+  profile sshd /titus/sshd/usr/sbin/sshd {
     signal (send,receive) peer=@{profile_name},
 
     network,

--- a/root/etc/apparmor.d/docker_titus
+++ b/root/etc/apparmor.d/docker_titus
@@ -31,9 +31,9 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
-  /titus/sshd/usr/sbin/run-titus-sshd Cx,
+  /titus/sshd/usr/sbin/sshd Cx,
 
-  profile sshd /titus/sshd/usr/sbin/run-titus-sshd {
+  profile sshd /titus/sshd/usr/sbin/sshd {
     # Allow signals from unconfined, usually systemd
     signal (receive) peer="unconfined",
     signal (send,receive) peer=@{profile_name},

--- a/root/lib/systemd/system/titus-sidecar-sshd@.service
+++ b/root/lib/systemd/system/titus-sidecar-sshd@.service
@@ -14,7 +14,7 @@ Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
 # get TSA help too. This environment variable ensures that will happen.
 Environment=TITUS_NSENTER_USE_TSA=true
 EnvironmentFile=/var/lib/titus-environments/%i.env
-ExecStart=/apps/titus-executor/bin/titus-nsenter /titus/sshd/usr/sbin/run-titus-sshd -D -e
+ExecStart=/apps/titus-executor/bin/titus-nsenter /titus/sshd/usr/sbin/sshd -D -e
 LimitNOFILE=65535
 ## TODO: Wire up more "lockdown" so this unit can't wreck havoc if it gets compromised
 PrivateTmp=yes


### PR DESCRIPTION
The titus-ssh image build is currently broken, which means
we are not ready for these particular changes.

I would like to:

1. Fix the build
2. Push a new image everywhere
3. Revert this revert start using the new entrypoint (which is alpine/scratch-friendly)
