### PR TITLE
RFC: Use static busybox and static openssh binaries for titus-sshd

### DIFF
--- a/executor/runtime/docker/docker_ssh.go
+++ b/executor/runtime/docker/docker_ssh.go
@@ -23,13 +23,6 @@ Protocol 2
 # HostKeys for protocol version 2
 HostKey /titus/sshd/etc/ssh/ssh_host_rsa_key
 HostCertificate /run/metatron/certificates/ssh_host_rsa_key-cert.pub
-HostKey /titus/sshd/etc/ssh/ssh_host_ecdsa_key
-HostCertificate /run/metatron/certificates/ssh_host_ecdsa_key-cert.pub
-HostKey /titus/sshd/etc/ssh/ssh_host_ed25519_key
-HostCertificate /run/metatron/certificates/ssh_host_ed25519_key-cert.pub
-
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
 
 # Logging
 SyslogFacility AUTH

--- a/hack/images/titus-sshd/Dockerfile
+++ b/hack/images/titus-sshd/Dockerfile
@@ -1,44 +1,27 @@
-FROM gentoo/stage3-amd64 as builder
-RUN emerge-webrsync
-RUN emerge --sync
-RUN echo 'MAKEOPTS="-j32"' >> /etc/portage/make.conf
-RUN echo 'USE="-pam -gdbm -berkdb -bindist"' >> /etc/portage/make.conf
-# This is because Docker builds don't have CAP_SYS_PTRACE
-RUN echo 'FEATURES="-sandbox -usersandbox"' >> /etc/portage/make.conf
-RUN echo "=sys-auth/libnss-compat-1.2 ~amd64" >> /etc/portage/package.accept_keywords
-RUN emerge -C openssh
-# We want to re-emerge openssl with the new USE flags, because the old USE flags can confuse portage
-RUN emerge -v --oneshot openssl
-# you need nss on the host to build nss in the prefix
-RUN emerge patchelf repoman nss
-# sys-kernel/linux-headers is a build-time dependency of glibc
-RUN mkdir -p /titus/sshd/bin /titus/sshd/usr/bin
-RUN ln -s /bin/bash /titus/sshd/bin/
-RUN ln -s /usr/bin/perl /titus/sshd/usr/bin/
-RUN emerge --prefix=/titus/sshd --oneshot sys-kernel/linux-headers
-RUN emerge --prefix=/titus/sshd --buildpkg glibc
-# Some of the packages which get build here turn into deps that are part of openssh
-#RUN USE="-ssl" emerge --prefix=/titus/sshd --oneshot --buildpkg python:3.6 bash
-RUN ln -s /usr/bin/python3.6 /titus/sshd/usr/bin/
-RUN sed -i s/with-privsep-user=sshd/with-privsep-user=nobody/ /usr/portage/net-misc/openssh/*.ebuild # |grep =ssh
-RUN cd /usr/portage/net-misc/openssh && repoman manifest
-RUN emerge --prefix=/titus/sshd --buildpkg openssh nss libnss-compat busybox
-# Now we want to discard our temp build dir
-RUN rm -r /titus/sshd
-RUN emerge --prefix=/titus/sshd --nodeps -K glibc
-RUN emerge --prefix=/titus/sshd -K glibc openssh nss libnss-compat busybox
-RUN ln -s /etc/hosts /titus/sshd/etc/
-# Here, the LD_LIBRARY_PATH under /titus/sshd is are the primary ones we look at, and if those don't work,
-# we fall back to the ubuntu ones
-RUN for i in $(scanelf --recursive --mount --symlink --etype ET_DYN --perms 0700 --nobanner --format '%F' /titus/sshd/bin /titus/sshd/sbin /titus/sshd/usr/bin/ /titus/sshd/usr/sbin/  /titus/sshd/usr/lib64/misc/); do \
-      xargs patchelf --set-interpreter /titus/sshd/lib64/ld-linux-x86-64.so.2 --set-rpath /titus/sshd/lib64:/titus/sshd/usr/lib64:/usr/local/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu ${i}; \
-    done
-# We might want to get rid of this later:
+FROM busybox as builder
+
+RUN mkdir /downloads
+WORKDIR /downloads
+
+RUN wget https://github.com/minos-org/minos-static/raw/master/static-get
+RUN chmod +x static-get
+
+RUN mkdir -p /titus/sshd
+RUN ./static-get --extract openssh-6.1p1-3
+RUN cp -a openssh-6.1p1-3/* /titus/sshd/
+
+RUN mkdir -p /titus/sshd/etc/ssh
+RUN mkdir /etc/ssh/
 RUN /titus/sshd/usr/bin/ssh-keygen -A
+RUN cp -a /etc/ssh/* /titus/sshd/etc/ssh/
 RUN ln -s /etc/resolv.conf /titus/sshd/etc/
 RUN ln -s /etc/passwd /titus/sshd/etc/
-RUN ln -s /titus/sshd/bin/busybox /titus/sshd/bin/sh
-RUN rm /titus/sshd/etc/ssh/sshd_config && ln -s /titus/etc/ssh/sshd_config /titus/sshd/etc/ssh/sshd_config
+RUN ln -sf /titus/etc/ssh/sshd_config /titus/sshd/etc/ssh/sshd_config
+ADD run-titus-sshd /titus/sshd/run-titus-sshd
+
+RUN mkdir -p /titus/sshd/bin/
+RUN cp /bin/busybox /titus/sshd/bin/
+RUN cd /titus/sshd/bin/ && /titus/sshd/bin/busybox --install -s .
+
 FROM scratch
 COPY --from=builder /titus/sshd /titus/sshd
-ADD run-titus-sshd /titus/sshd/run-titus-sshd

--- a/hack/images/titus-sshd/run-titus-sshd
+++ b/hack/images/titus-sshd/run-titus-sshd
@@ -30,6 +30,7 @@ setup_files() {
   # must exist for ssh to work
   [ -f /etc/passwd ] || ($touch /etc/passwd && log "setting up /etc/passwd for ssh to work")
   [ -d /var/log ] || ($mkdir -p /var/log && log "creating /var/log for ssh to work")
+  [ -d /var/empty ] || ($mkdir -p /var/empty && log "creating /var/empty for ssh to work")
   [ -f /var/log/lastlog ] || ($touch /var/log/lastlog && log "creating /var/log/lastlog for ssh to work")
   [ -f /etc/profile ] || (write_etc_profile && log "creating /etc/profile for environment variables to work")
 }
@@ -42,14 +43,14 @@ setup_users() {
     log "Adding the 'nfsuper' user into /etc/passwd"
     echo 'nfsuper:x:0:0:root:/root:/titus/sshd/bin/sh' >> /etc/passwd
   fi
-  # Nobody is an ssh requirement for privilege separation
-  if ! $grep -q nobody /etc/passwd; then
-    log "Adding the 'nobody' user into /etc/passwd"
-    echo 'nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin' >> /etc/passwd
+  # sshd is an ssh requirement for privilege separation
+  if ! $grep -q sshd: /etc/passwd; then
+    log "Adding the 'sshd' user into /etc/passwd"
+    echo 'sshd:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin' >> /etc/passwd
   fi
 }
 
 setup_files
 setup_users
 
-exec /titus/sshd/usr/sbin/sshd "$@"
+exec /titus/sshd/usr/sbin/sshd -f /titus/etc/ssh/sshd_config "$@"


### PR DESCRIPTION
This is a radical departure from the way we build titus-sshd
today, but is faster and hopefully more sustainable?

It uses the sshd binary from the minos distro, which has a
library of static binaries:

https://github.com/minos-org/morpheus-ports/tree/master/openssh

The downside is that this is a step backwards in versions
6.1 compared to what we currently run, 7.7. And the build is
more opaque.

On the upside, the image is much smaller, because things are
statically linked instead of just relocated.