### PR TITLE
Bind mount docker creds in dind to avoid rate limiting

### DIFF
--- a/hack/tests-with-dind.sh
+++ b/hack/tests-with-dind.sh
@@ -55,10 +55,19 @@ if [[ $(uname) == "Darwin" ]]; then
 fi
 
 log "Running a docker daemon named $titus_agent_name"
-docker run --privileged --security-opt seccomp=unconfined -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-  -v ${GOPATH}:${GOPATH} -w ${PWD} -v ${PWD}:${PWD} ${metatron_cert_mnt} \
-  --rm --name "$titus_agent_name" -e DEBUG=${debug} \
-  -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} --label "$run_id" -d titusoss/titus-agent
+docker run --privileged --security-opt seccomp=unconfined \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+  -v ${GOPATH}:${GOPATH} \
+  -v ~/.docker/config.json:/root/.docker/config.json \
+  -v ${PWD}:${PWD} \
+  ${metatron_cert_mnt} \
+  -w ${PWD} \
+  -e DEBUG=${debug} \
+  -e SHORT_CIRCUIT_QUITELITE=true \
+  -e GOPATH=${GOPATH} \
+  --label "$run_id" \
+  --rm --name "$titus_agent_name" \
+  -d titusoss/titus-agent
 
 log "Copying test metatron certs to their correct location"
 docker exec "$titus_agent_name" ${PWD}/hack/agent/certs/setup-metatron-certs.sh


### PR DESCRIPTION
Now that the docker hub does strict rate limiting
without login, I would like to make it so our tests
use the auto-login that buildkite provides.

We use dind, so to do this, I bind mount the credentials into
the dind daemon.
