### PR TITLE
Setup docker auth for dind standalone tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	// Docker returns the Docker-specific configuration settings
 	DockerHost     string
 	DockerRegistry string
+	DockerUsername string
+	DockerPassword string
 	// What region we're running in
 	AwsRegion string
 
@@ -150,6 +152,18 @@ func NewConfig() (*Config, []cli.Flag) {
 			Value:       "docker.io",
 			Destination: &cfg.DockerRegistry,
 			EnvVar:      "DOCKER_REGISTRY",
+		},
+		cli.StringFlag{
+			Name:        "titus.executor.dockerUser",
+			EnvVar:      "DOCKER_USER",
+			Destination: &cfg.DockerUsername,
+			Usage:       "Docker registry (hub) login username",
+		},
+		cli.StringFlag{
+			Name:        "titus.executor.dockerPass",
+			EnvVar:      "DOCKER_PASS",
+			Destination: &cfg.DockerPassword,
+			Usage:       "Docker registry (hub) login password",
 		},
 		cli.StringFlag{
 			Name:        "aws-region",

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -566,7 +566,7 @@ func (r *DockerRuntime) DockerPull(ctx context.Context, c runtimeTypes.Container
 	r.metrics.Counter("titus.executor.dockerImagePulls", 1, nil)
 	logger.Infof("DockerPull: pulling image")
 	pullStartTime := time.Now()
-	if err := pullWithRetries(ctx, r.metrics, r.client, c.QualifiedImageName(), doDockerPull); err != nil {
+	if err := pullWithRetries(ctx, r.cfg, r.metrics, r.client, c.QualifiedImageName(), doDockerPull); err != nil {
 		return nil, err
 	}
 	r.metrics.Timer("titus.executor.imagePullTime", time.Since(pullStartTime), c.ImageTagForMetrics())
@@ -840,7 +840,7 @@ func (r *DockerRuntime) createVolumeContainer(ctx context.Context, containerName
 
 	if tmpImageInfo == nil || imageSpecifiedByTag {
 		logger.G(ctx).WithField("byTag", imageSpecifiedByTag).Info("createVolumeContainer: pulling image")
-		err = pullWithRetries(ctx, r.metrics, r.client, image, doDockerPull)
+		err = pullWithRetries(ctx, r.cfg, r.metrics, r.client, image, doDockerPull)
 		if err != nil {
 			return err
 		}
@@ -1417,7 +1417,7 @@ func (r *DockerRuntime) pullAllUserContainers(ctx context.Context, pod *v1.Pod) 
 		image := images[idx]
 		group.Go(func(ctx context.Context) error {
 			l.Debugf("pulling other user container %s", image)
-			return pullWithRetries(ctx, r.metrics, r.client, image, doDockerPull)
+			return pullWithRetries(ctx, r.cfg, r.metrics, r.client, image, doDockerPull)
 		})
 	}
 	return group.Wait()

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -327,9 +327,13 @@ func setupOOMAdj(c runtimeTypes.Container, cred ucred) error {
 	oomScoreAdjPath := filepath.Join("/proc", pid, "oom_score_adj")
 	file, err := os.OpenFile(oomScoreAdjPath, os.O_RDWR, 0000)
 	if err != nil {
+		err = fmt.Errorf("Failed to open oom_score_adj: %w", err)
 		return err
 	}
 	defer shouldClose(file)
 	_, err = file.WriteString(fmt.Sprintf("%d\n", oomScore))
+	if err != nil {
+		err = fmt.Errorf("Failed to set oom_score_adj: %w", err)
+	}
 	return err
 }

--- a/executor/runtime/docker/docker_test.go
+++ b/executor/runtime/docker/docker_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Netflix/metrics-client-go/metrics"
+	"github.com/Netflix/titus-executor/config"
 	"github.com/Netflix/titus-executor/properties"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -25,11 +26,12 @@ func TestDockerPullRetries(t *testing.T) {
 	begin := time.Now()
 	myErr := errors.New("Fake error")
 	retries := 0
-	fakePuller := func(context.Context, metrics.Reporter, *docker.Client, string) error {
+	fakePuller := func(context.Context, config.Config, metrics.Reporter, *docker.Client, string) error {
 		retries = retries + 1
 		return myErr
 	}
-	err := pullWithRetries(context.Background(), metrics.Discard, nil, "", fakePuller)
+	cfg := config.Config{}
+	err := pullWithRetries(context.Background(), cfg, metrics.Discard, nil, "", fakePuller)
 	if retries != 5 {
 		t.Fatal("Not enough retries: ", retries)
 	}
@@ -49,15 +51,16 @@ func TestDockerCancel(t *testing.T) {
 	t.Parallel()
 	begin := time.Now()
 	ctx, cancel := context.WithCancel(context.Background())
+	cfg := config.Config{}
 
-	fakePuller := func(context.Context, metrics.Reporter, *docker.Client, string) error {
+	fakePuller := func(context.Context, config.Config, metrics.Reporter, *docker.Client, string) error {
 		return errors.New("Fake Error")
 	}
 
 	c := make(chan error)
 	go func() {
 		defer close(c)
-		c <- pullWithRetries(ctx, metrics.Discard, nil, "", fakePuller)
+		c <- pullWithRetries(ctx, cfg, metrics.Discard, nil, "", fakePuller)
 	}()
 	time.AfterFunc(time.Second*15, cancel)
 	if err := <-c; err == nil {

--- a/hack/tests-with-dind.sh
+++ b/hack/tests-with-dind.sh
@@ -62,6 +62,7 @@ docker run --privileged --security-opt seccomp=unconfined \
   -v ${PWD}:${PWD} \
   ${metatron_cert_mnt} \
   -w ${PWD} \
+  -e BUMP_TINI_SCHED_PRIORITY=false \
   -e DEBUG=${debug} \
   -e SHORT_CIRCUIT_QUITELITE=true \
   -e GOPATH=${GOPATH} \

--- a/hack/tests-with-dind.sh
+++ b/hack/tests-with-dind.sh
@@ -62,6 +62,8 @@ docker run --privileged --security-opt seccomp=unconfined \
   -v ${PWD}:${PWD} \
   ${metatron_cert_mnt} \
   -w ${PWD} \
+  -e DOCKER_USER \
+  -e DOCKER_PASS \
   -e BUMP_TINI_SCHED_PRIORITY=false \
   -e DEBUG=${debug} \
   -e SHORT_CIRCUIT_QUITELITE=true \


### PR DESCRIPTION
This enables basic docker registry authentication.

At first my goal is to make the tests less flakey.
Maybe someday we will use auth on our real registries too.

This also includes changes to make the dind tests run on mac.