### PR TITLE
Added new system-service: container-tools

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,8 @@ type Config struct {
 	ContainerAtlasd    bool
 	AtlasdServiceImage string
 
+	ContainerToolsImage string
+
 	// CopiedFromHost indicates which environment variables to lift from the current config
 	copiedFromHostEnv cli.StringSlice
 	hardCodedEnv      cli.StringSlice
@@ -250,6 +252,11 @@ func NewConfig() (*Config, []cli.Flag) {
 			Name:        "container-atlasd-image",
 			EnvVar:      "ATLASD_SERVICE_IMAGE",
 			Destination: &cfg.AtlasdServiceImage,
+		},
+		cli.StringFlag{
+			Name:        "container-tools-image",
+			EnvVar:      "CONTAINER_TOOLS_IMAGE",
+			Destination: &cfg.ContainerToolsImage,
 		},
 		cli.StringSliceFlag{
 			Name:  "copied-from-host-env",

--- a/executor/runtime/docker/container_tools.go
+++ b/executor/runtime/docker/container_tools.go
@@ -1,5 +1,0 @@
-package docker
-
-func getContainerToolsBindMounts() []string {
-	return []string{"/apps/titus-container-tools/:/titus/container-tools/:ro"}
-}

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1028,7 +1028,6 @@ func (r *DockerRuntime) Prepare(parentCtx context.Context) error { // nolint: go
 	}
 
 	bindMounts = append(bindMounts, getLXCFsBindMounts()...)
-	bindMounts = append(bindMounts, getContainerToolsBindMounts()...)
 
 	dockerCfg, hostCfg, err = r.dockerConfig(r.c, bindMounts, size, volumeContainers)
 	if err != nil {
@@ -1685,11 +1684,11 @@ func (r *DockerRuntime) setupPostStartLogDirTini(ctx context.Context, l *net.Uni
 	genericConn, err := l.Accept()
 	if err != nil {
 		if ctx.Err() != nil {
-			log.WithField("ctxError", ctx.Err()).Error("Never received connection from container: ", err)
-			return "", nil, nil, nil, errors.New("Never received connection from container")
+			log.WithField("ctxError", ctx.Err()).Error("Never received connection from container from tini: ", err)
+			return "", nil, nil, nil, errors.New("Never received connection from container from tini")
 		}
 		log.WithError(err).Error("Error accepting tini connection from container")
-		return "", nil, nil, nil, fmt.Errorf("error accepting connection from container: %w", err)
+		return "", nil, nil, nil, fmt.Errorf("error accepting tini connection from container: %w", err)
 	}
 
 	switch typedConn := genericConn.(type) {

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -144,6 +144,9 @@ func setupSystemServices(parentCtx context.Context, c runtimeTypes.Container, cf
 		if svc.EnabledCheck != nil && !svc.EnabledCheck(&cfg, c) {
 			continue
 		}
+		if svc.UnitName == "" {
+			continue
+		}
 
 		// Different runtimes have different root paths that need to be passed to runc with `--root`.
 		// In particular, we use the `oci-add-hooks` runtime for GPU containers.

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -955,6 +955,7 @@ func (c *TitusInfoContainer) SidecarConfigs() ([]*ServiceOpts, error) {
 		SidecarServiceSshd:        c.config.SSHDServiceImage,
 		SidecarServiceSpectatord:  c.config.SpectatordServiceImage,
 		SidecarServiceAtlasd:      c.config.AtlasdServiceImage,
+		SidecarContainerTools:     c.config.ContainerToolsImage,
 	}
 
 	for _, scOrig := range sideCars {

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -507,6 +507,7 @@ func (c *PodContainer) SidecarConfigs() ([]*ServiceOpts, error) {
 		SidecarServiceSshd:        c.config.SSHDServiceImage,
 		SidecarServiceSpectatord:  c.config.SpectatordServiceImage,
 		SidecarServiceAtlasd:      c.config.AtlasdServiceImage,
+		SidecarContainerTools:     c.config.ContainerToolsImage,
 	}
 
 	sideCarPtrs := []*ServiceOpts{}

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -417,6 +417,7 @@ func TestNewPodContainer(t *testing.T) {
 			SidecarServiceAbMetrix,
 			SidecarSeccompAgent,
 			SidecarTitusStorage,
+			SidecarContainerTools,
 		})
 	assert.Equal(t, svcMeshImage, expSvcMeshImage)
 

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -15,6 +15,7 @@ const (
 	SidecarTitusStorage         = "titus-storage"
 	SidecarSeccompAgent         = "seccomp-agent"
 	SidecarServiceMetadataProxy = "metadata-proxy"
+	SidecarContainerTools       = "container-tools"
 )
 
 var sideCars = []ServiceOpts{
@@ -111,6 +112,15 @@ var sideCars = []ServiceOpts{
 		Required:     true,
 		EnabledCheck: shouldStartTitusStorage,
 	},
+	{
+		ServiceName:  SidecarContainerTools,
+		UnitName:     "",
+		Required:     false,
+		EnabledCheck: shouldStartContainerTools,
+		Volumes: map[string]struct{}{
+			"/titus/container-tools": {},
+		},
+	},
 }
 
 func shouldStartMetatronSync(cfg *config.Config, c Container) bool {
@@ -181,6 +191,10 @@ func shouldStartLogViewer(cfg *config.Config, c Container) bool {
 
 func shouldStartTitusStorage(cfg *config.Config, c Container) bool {
 	return c.EBSInfo().VolumeID != ""
+}
+
+func shouldStartContainerTools(cfg *config.Config, c Container) bool {
+	return cfg.ContainerToolsImage != ""
 }
 
 // GetSidecarConfig is a helper to get a particular sidecar config out by name

--- a/hack/run-pod-locally.sh
+++ b/hack/run-pod-locally.sh
@@ -39,6 +39,7 @@ docker run -ti --privileged --security-opt seccomp=unconfined -v /sys/fs/cgroup:
   -e METATRON_SERVICE_IMAGE="/ps/titus-metatron-identity" \
   -e PROXYD_SERVICE_IMAGE="/ipc/proxyd-rootless-candidate@sha256:9d5e5292015856b60cfcca51024cdceba1b07f9fe952b96ccac4b741aab43708" \
   -e ABMETRIX_SERVICE_IMAGE="/baseos/nflx-abmetrix-titus@sha256:0b01b2d74b9b62c7ad85007da0491d40c1f80e5812676667bedcade2448f24e3" \
+  -e CONTAINER_TOOLS_IMAGE="/tn/titus-container-tools-image@sha256:f993a8de3173fd13006623f541fbfb25ce8f205f595842caeffcaa8573b52d35" \
   -e TITUS_EXECUTOR_TINI_PATH="${PWD}/build/bin/linux-amd64/tini-static" \
   --rm --name "$docker_container_name" \
   -d \


### PR DESCRIPTION
This is phase 2 of my container tools work, in an effort
to make containers easier to debug on titus.

This moves the `/titus/container-tools/` folder away from
a host bind-mount into a real sidecar container.

This container/image has statically linked tools to make
it easier for our users to debug their containers without
having to mutate their own, or bring heavyweight tools
with them.

This new image is lightweight (static binaries from scratch),
so I don't anticipate a lot of extra load from docker.
Additionally there is no systemd unit to start, so no additional
load from systemd.