### PR TITLE
Added basic ordering (class type) in multi-container workloads

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1642,6 +1642,9 @@ func v1ConatinerEnvToList(v1Env []v1.EnvVar) []string {
 
 func getUserContainerNames(pod *v1.Pod) []string {
 	userContainerNames := []string{}
+	if pod == nil || pod.Spec.Containers == nil {
+		return userContainerNames
+	}
 	for _, c := range pod.Spec.Containers {
 		// Currently anything *not* a sidecar needs to fall
 		// into the "user" bucket. No container can be left behind
@@ -1654,6 +1657,9 @@ func getUserContainerNames(pod *v1.Pod) []string {
 
 func getPlaformContainerNames(pod *v1.Pod) []string {
 	platformContainerNames := []string{}
+	if pod == nil || pod.Spec.Containers == nil {
+		return platformContainerNames
+	}
 	for _, c := range pod.Spec.Containers {
 		if isPlatformSidecarContainer(c.Name, pod) {
 			platformContainerNames = append(platformContainerNames, c.Name)

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1380,7 +1380,7 @@ func (r *DockerRuntime) startUserContainers(ctx context.Context, pod *v1.Pod, ma
 
 	// Starting, however, has its own logic
 	l.Infof("Starting %d user containers", len(cidMapping))
-	err := r.startAllUserContainers(ctx, cidMapping, r.c.TaskID(), tiniConn)
+	err := r.startAllUserContainers(ctx, pod, cidMapping, r.c.TaskID(), tiniConn)
 	if err != nil {
 		return fmt.Errorf("Failed to start a user container: %s", err)
 	}
@@ -1455,26 +1455,75 @@ func (r *DockerRuntime) createAllUserContainers(ctx context.Context, pod *v1.Pod
 
 // startAllUserContainers actually launches all containers,
 // and requires all containers to be created and ready
-func (r *DockerRuntime) startAllUserContainers(ctx context.Context, cidMapping map[string]string, mainContainerID string, tiniConn *net.UnixConn) error {
-	// Currently the order here is hard-coded to be whatever order it is in the podspec
-	// with no health or startup probes. Someday we'll add more logic here.
+// The current implementation of multi-container workloads does
+// ordering in 2 phases:
+// Phase 1: Launch all platform containers (service mesh, gandalf, etc)
+// Phase 2: Launch all user-defined conatiners (main, nginx, etc)
+func (r *DockerRuntime) startAllUserContainers(ctx context.Context, pod *v1.Pod, cidMapping map[string]string, mainContainerID string, tiniConn *net.UnixConn) error {
 	l := log.WithField("taskID", r.c.TaskID())
-	for name, cid := range cidMapping {
-		l.Debugf("Starting up user container %s, container id %s", name, cid)
-		err := r.client.ContainerStart(ctx, cid, types.ContainerStartOptions{})
-		if err != nil {
-			return fmt.Errorf("Failed to start %s container: %w", name, err)
-		}
+
+	platformContainerNames := getPlaformContainerNames(pod)
+	l.Debugf("Starting %d platform sidecars: %s", len(platformContainerNames), platformContainerNames)
+	err := r.startPlatformDefinedContainers(ctx, platformContainerNames, cidMapping)
+	if err != nil {
+		return err
 	}
 
-	// And then lastly we tell tini to launch the main container
-	l.Debug("Telling tini to launch the main container")
-	err := tellTiniToLaunch(tiniConn)
-	if err != nil {
-		shouldClose(tiniConn)
-		err = fmt.Errorf("error telling tini to launch: %w", err)
-	}
+	userContainerNames := getUserContainerNames(pod)
+	l.Debugf("Starting %d user containers: %s", len(userContainerNames), userContainerNames)
+	err = r.startUserDefinedContainers(ctx, userContainerNames, cidMapping, tiniConn)
+
 	return err
+}
+
+func (r *DockerRuntime) startPlatformDefinedContainers(ctx context.Context, names []string, cidMapping map[string]string) error {
+	l := log.WithField("taskID", r.c.TaskID())
+	group := groupWithContext(ctx)
+	for _, name := range names {
+		group.Go(func(ctx context.Context) error {
+			cid := cidMapping[name]
+			l.Debugf("Starting up platform-defined container %s, container id %s", name, cid)
+			err := r.client.ContainerStart(ctx, cid, types.ContainerStartOptions{})
+			if err != nil {
+				return fmt.Errorf("Failed to start %s platform container: %w", name, err)
+			}
+			return nil
+		})
+	}
+	return group.Wait()
+}
+
+func (r *DockerRuntime) startUserDefinedContainers(ctx context.Context, names []string, cidMapping map[string]string, tiniConn *net.UnixConn) error {
+	l := log.WithField("taskID", r.c.TaskID())
+	group := groupWithContext(ctx)
+	for _, name := range names {
+		if name == r.c.TaskID() {
+			// Special case, the main container here is already running, it just needs
+			// to be told to run its own process via tini, we'll handle that in a different case
+			continue
+		}
+		group.Go(func(ctx context.Context) error {
+			cid := cidMapping[name]
+			l.Debugf("Starting up user-defined container %s, container id %s", name, cid)
+			err := r.client.ContainerStart(ctx, cid, types.ContainerStartOptions{})
+			if err != nil {
+				return fmt.Errorf("Failed to start %s user container: %w", name, err)
+			}
+			return nil
+		})
+	}
+
+	group.Go(func(ctx context.Context) error {
+		// And then lastly we tell tini to launch the main container
+		l.Debug("Telling tini to launch the main container")
+		err := tellTiniToLaunch(tiniConn)
+		if err != nil {
+			shouldClose(tiniConn)
+			return fmt.Errorf("error launching tini: %w", err)
+		}
+		return nil
+	})
+	return group.Wait()
 }
 
 func (r *DockerRuntime) createOtherUserContainer(ctx context.Context, v1Container v1.Container, mainContainerID string, mainContainerRoot string) (string, error) {
@@ -1536,7 +1585,7 @@ func (r *DockerRuntime) k8sContainerToDockerConfigs(v1Container v1.Container, ma
 	b := true
 	// What docker calls "command", is what k8s calls "Args"
 	dockerCmd := v1Container.Args
-	// What docker calls "entrypoint", k8s calls "command", but in addition, we prepend tinit
+	// What docker calls "entrypoint", k8s calls "command", but in addition, we prepend tini
 	// The reason we do this is because, even with init=true, docker will only inject tini
 	// on containers running in a private pid namespace.
 	// On titus, we want tini on *every* container, because it gives us features like stdout/err
@@ -1587,6 +1636,35 @@ func v1ConatinerEnvToList(v1Env []v1.EnvVar) []string {
 		envList = append(envList, e.Name+"="+e.Value)
 	}
 	return envList
+}
+
+func getUserContainerNames(pod *v1.Pod) []string {
+	userContainerNames := []string{}
+	for _, c := range pod.Spec.Containers {
+		// Currently anything *not* a sidecar needs to fall
+		// into the "user" bucket. No container can be left behind
+		if !isPlatformSidecarContainer(c.Name, pod) {
+			userContainerNames = append(userContainerNames, c.Name)
+		}
+	}
+	return userContainerNames
+}
+
+func getPlaformContainerNames(pod *v1.Pod) []string {
+	platformContainerNames := []string{}
+	for _, c := range pod.Spec.Containers {
+		if isPlatformSidecarContainer(c.Name, pod) {
+			platformContainerNames = append(platformContainerNames, c.Name)
+		}
+	}
+	return platformContainerNames
+}
+
+func isPlatformSidecarContainer(name string, pod *v1.Pod) bool {
+	// TODO: put this in podcommon
+	containerTypeAnnotation := fmt.Sprintf("type.pod.netflix.com/%s", name)
+	value := pod.Annotations[containerTypeAnnotation]
+	return value == "sidecar"
 }
 
 // return true to exit

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1480,12 +1480,13 @@ func (r *DockerRuntime) startPlatformDefinedContainers(ctx context.Context, name
 	l := log.WithField("taskID", r.c.TaskID())
 	group := groupWithContext(ctx)
 	for _, name := range names {
+		cName := name
 		group.Go(func(ctx context.Context) error {
-			cid := cidMapping[name]
-			l.Debugf("Starting up platform-defined container %s, container id %s", name, cid)
+			cid := cidMapping[cName]
+			l.Debugf("Starting up platform-defined container %s, container id %s", cName, cid)
 			err := r.client.ContainerStart(ctx, cid, types.ContainerStartOptions{})
 			if err != nil {
-				return fmt.Errorf("Failed to start %s platform container: %w", name, err)
+				return fmt.Errorf("Failed to start %s platform container: %w", cName, err)
 			}
 			return nil
 		})
@@ -1497,17 +1498,18 @@ func (r *DockerRuntime) startUserDefinedContainers(ctx context.Context, names []
 	l := log.WithField("taskID", r.c.TaskID())
 	group := groupWithContext(ctx)
 	for _, name := range names {
-		if name == r.c.TaskID() {
+		cName := name
+		if cName == r.c.TaskID() {
 			// Special case, the main container here is already running, it just needs
 			// to be told to run its own process via tini, we'll handle that in a different case
 			continue
 		}
 		group.Go(func(ctx context.Context) error {
-			cid := cidMapping[name]
-			l.Debugf("Starting up user-defined container %s, container id %s", name, cid)
+			cid := cidMapping[cName]
+			l.Debugf("Starting up user-defined container %s, container id %s", cName, cid)
 			err := r.client.ContainerStart(ctx, cid, types.ContainerStartOptions{})
 			if err != nil {
-				return fmt.Errorf("Failed to start %s user container: %w", name, err)
+				return fmt.Errorf("Failed to start %s user container: %w", cName, err)
 			}
 			return nil
 		})

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -30,6 +30,7 @@ import (
 	vpcapi "github.com/Netflix/titus-executor/vpc/api"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	vpcTypes "github.com/Netflix/titus-executor/vpc/types"
+	podCommon "github.com/Netflix/titus-kube-common/pod"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -1648,7 +1649,7 @@ func getUserContainerNames(pod *v1.Pod) []string {
 	for _, c := range pod.Spec.Containers {
 		// Currently anything *not* a sidecar needs to fall
 		// into the "user" bucket. No container can be left behind
-		if !isPlatformSidecarContainer(c.Name, pod) {
+		if !podCommon.IsPlatformSidecarContainer(c.Name, pod) {
 			userContainerNames = append(userContainerNames, c.Name)
 		}
 	}
@@ -1661,18 +1662,11 @@ func getPlaformContainerNames(pod *v1.Pod) []string {
 		return platformContainerNames
 	}
 	for _, c := range pod.Spec.Containers {
-		if isPlatformSidecarContainer(c.Name, pod) {
+		if podCommon.IsPlatformSidecarContainer(c.Name, pod) {
 			platformContainerNames = append(platformContainerNames, c.Name)
 		}
 	}
 	return platformContainerNames
-}
-
-func isPlatformSidecarContainer(name string, pod *v1.Pod) bool {
-	// TODO: put this in podcommon
-	containerTypeAnnotation := fmt.Sprintf("type.pod.netflix.com/%s", name)
-	value := pod.Annotations[containerTypeAnnotation]
-	return value == "sidecar"
 }
 
 // return true to exit

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -96,7 +96,8 @@ type JobInput struct {
 
 	GPUManager runtimeTypes.GPUManager
 	// Raw k8s containers, expected to come from the control plane
-	ExtraContainers []corev1.Container
+	ExtraContainers  []corev1.Container
+	ExtraAnnotations map[string]string
 }
 
 // JobRunResponse returned from RunJob
@@ -420,6 +421,9 @@ func createPodTask(jobInput *JobInput, jobID string, task *runner.Task, env map[
 		},
 	}
 	pod.Spec.Containers = append(pod.Spec.Containers, jobInput.ExtraContainers...)
+	for k, v := range jobInput.ExtraAnnotations {
+		pod.Annotations[k] = v
+	}
 
 	mainContainer := &pod.Spec.Containers[0]
 	pod.Annotations[podCommon.AnnotationKeyPodTitusUserEnvVarsStartIndex] = strconv.Itoa(len(mainContainer.Env))

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -1304,3 +1304,53 @@ func TestBasicMultiContainer(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestMultiContainerDoesPlatformFirst(t *testing.T) {
+	wrapTestStandalone(t)
+	skipIfNotPod(t)
+
+	// And for the main container, we use pgrep to ensure that our *user* sentinel container
+	// is in fact running along side us.
+	// It will only work if the user sentinel sidecar is seen running by the time we start.
+	testEntrypointOld := "pgrep -fx '/bin/sleep 430'"
+	if runtime.GOOS == "darwin" { //nolint:goconst
+		// To make this test compatible with darwin, which can't use tini callbacks
+		// for strict ordering. So we add a short sleep in front.
+		testEntrypointOld = `/bin/sh -c "sleep 5; ` + testEntrypointOld + `"`
+	} else {
+		testEntrypointOld = `/bin/sh -c "` + testEntrypointOld + `"`
+	}
+
+	ji := &JobInput{
+		ImageName:  busybox.name,
+		Version:    busybox.tag,
+		UsePodSpec: shouldUsePodspecInTest,
+		// This sentinel container is a second process we can look out
+		// for, in order to detect if multi-container workloads are setup
+		ExtraContainers: []corev1.Container{
+			// This first one is a platform sidecar with a special sleep, this
+			// *should* run first if the code is correct.
+			{
+				Name:    "platform-sentinel",
+				Image:   busybox.name + `:` + busybox.tag,
+				Command: []string{"/bin/sh", "-c"},
+				Args:    []string{"/bin/sleep 420"},
+			},
+			// Second is a user sidecar, it *should* run second. If it sees the platform-sentinel
+			// running, only then will it keep running with its own sleep
+			{
+				Name:    "user-sentinel",
+				Image:   busybox.name + `:` + busybox.tag,
+				Command: []string{"/bin/sh", "-c"},
+				Args:    []string{"pgrep -fx '/bin/sleep 420' && /bin/sleep 430"},
+			},
+		},
+		ExtraAnnotations: map[string]string{
+			"type.pod.netflix.com/platform-sentinel": "sidecar",
+		},
+		EntrypointOld: testEntrypointOld,
+	}
+	if !RunJobExpectingSuccess(t, ji) {
+		t.Fail()
+	}
+}

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -1313,13 +1313,10 @@ func TestMultiContainerDoesPlatformFirst(t *testing.T) {
 	// is in fact running along side us.
 	// It will only work if the user sentinel sidecar is seen running by the time we start.
 	testEntrypointOld := "pgrep -fx '/bin/sleep 430'"
-	if runtime.GOOS == "darwin" { //nolint:goconst
-		// To make this test compatible with darwin, which can't use tini callbacks
-		// for strict ordering. So we add a short sleep in front.
-		testEntrypointOld = `/bin/sh -c "sleep 5; ` + testEntrypointOld + `"`
-	} else {
-		testEntrypointOld = `/bin/sh -c "` + testEntrypointOld + `"`
-	}
+	// The main container and the user-sentinel are both 'user' containers,
+	// So we want the main container to waid just a little bit for the user-sentinel
+	// to come up, report back if the platform-sentinel is running or not, and then continue
+	testEntrypointOld = `/bin/sh -c "sleep 3;` + testEntrypointOld + `"`
 
 	ji := &JobInput{
 		ImageName:  busybox.name,

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -1276,13 +1276,9 @@ func TestBasicMultiContainer(t *testing.T) {
 	// And for the main container, we use pgrep to ensure that our sentinel container
 	// is in fact running along side us.
 	testEntrypointOld := "pgrep -fx '/bin/sleep 420'"
-	if runtime.GOOS == "darwin" { //nolint:goconst
-		// To make this test compatible with darwin, which can't use tini callbacks
-		// for strict ordering. So we add a short sleep in front.
-		testEntrypointOld = `/bin/sh -c "/bin/sleep 3; ` + testEntrypointOld + `"`
-	} else {
-		testEntrypointOld = `/bin/sh -c "` + testEntrypointOld + `"`
-	}
+	// The main container and the user-sentinel are both 'user' containers,
+	// So we want the main container to waid just a little bit for the user-sentinel
+	testEntrypointOld = `/bin/sh -c "sleep 3;` + testEntrypointOld + `"`
 
 	ji := &JobInput{
 		ImageName:  busybox.name,

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Netflix/titus-executor/executor/runner"
 	"github.com/Netflix/titus-executor/executor/runtime/docker"
 	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
+	podCommon "github.com/Netflix/titus-kube-common/pod"
 	dockerTypes "github.com/docker/docker/api/types"
 	protobuf "github.com/golang/protobuf/proto" // nolint: staticcheck
 	"github.com/google/uuid"
@@ -1339,7 +1340,7 @@ func TestMultiContainerDoesPlatformFirst(t *testing.T) {
 			},
 		},
 		ExtraAnnotations: map[string]string{
-			"type.pod.netflix.com/platform-sentinel": "sidecar",
+			podCommon.AnnotationKeyPrefixContainerTypePlatformSidecar + `platform-sentinel`: podCommon.AnnotationValueContainerTypePlatformSidecar,
 		},
 		EntrypointOld: testEntrypointOld,
 	}

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -516,7 +516,7 @@ func TestImagePullError(t *testing.T) {
 	wrapTestStandalone(t)
 	ji := &JobInput{
 		ImageName:     busybox.name,
-		Version:       "latest1",
+		Version:       "purposelyDoesntExist",
 		EntrypointOld: "/usr/bin/true",
 		JobID:         generateJobID(t.Name()),
 		UsePodSpec:    shouldUsePodspecInTest,

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Netflix/metrics-client-go v0.0.0-20171019173821-bb173f41fc07
 	github.com/Netflix/spectator-go v0.0.0-20190913215732-d4e0463555ef
 	github.com/Netflix/titus-api-definitions v0.0.1-rc9.0.20210426164010-ef784d356ff6
-	github.com/Netflix/titus-kube-common v0.15.0
+	github.com/Netflix/titus-kube-common v0.16.0
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
 	github.com/apex/log v1.9.0
@@ -77,8 +77,8 @@ require (
 	gopkg.in/ini.v1 v1.52.0 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gotest.tools v2.2.0+incompatible
-	k8s.io/api v0.18.4
-	k8s.io/apimachinery v0.18.4
+	k8s.io/api v0.19.10
+	k8s.io/apimachinery v0.19.10
 	k8s.io/client-go v10.0.0+incompatible
 	k8s.io/kubernetes v1.18.4
 	k8s.io/utils v0.0.0-20201104234853-8146046b121e

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/Netflix/titus-kube-common v0.14.0 h1:fAYK/hrZMw1At2lW3C28kV41jEt1RU5d
 github.com/Netflix/titus-kube-common v0.14.0/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
 github.com/Netflix/titus-kube-common v0.15.0 h1:jcHHq91GM2iAGZdFBzQ7lIIVwawaFLhWWSGnogKQmzc=
 github.com/Netflix/titus-kube-common v0.15.0/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
+github.com/Netflix/titus-kube-common v0.16.0 h1:rGKFhOQOfajbmdWchaXWrUykiNCSbSHzdvtkQg3y7OE=
+github.com/Netflix/titus-kube-common v0.16.0/go.mod h1:KshIwzd3u5+0WYPVTgNCRG8GQoO3TaW3fVOTgK54ktw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -692,6 +694,7 @@ github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
@@ -700,6 +703,7 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
@@ -900,6 +904,7 @@ github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiff
 github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
 github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 github.com/tj/go-buffer v1.1.0/go.mod h1:iyiJpfFcR2B9sXu7KvjbT9fpM4mOelRSDTbntVj52Uc=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
@@ -1397,6 +1402,7 @@ k8s.io/utils v0.0.0-20180801164400-045dc31ee5c4/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTUt3aVoBpi2DqRsU=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+k8s.io/utils v0.0.0-20200912215256-4140de9c8800/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20201104234853-8146046b121e h1:dUhh0zO/94tOe9DB05HFGE69ofectI1PBCmIxO612MI=
 k8s.io/utils v0.0.0-20201104234853-8146046b121e/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=

--- a/hack/agent/daemon.json
+++ b/hack/agent/daemon.json
@@ -1,5 +1,5 @@
 {
-    "storage-driver": "vfs",
+    "storage-driver": "overlay2",
     "debug": true,
     "log-driver": "journald",
     "init-path": "/apps/titus-executor/bin/tini-static",


### PR DESCRIPTION
This is the first part of class-based sidecar ordering in
Titus. It does not do "dependsOn" yet, only does two-layer
ordering between platform-defined and user-defined containers.
    
Currently just starts all platform-containers in parallel,
and then user-defined ones in parallel. dependsOn will be complex
and added in the next pass of code.
    
For this one, I wanted to check to make sure I was going in the
right direction.
