### PR TITLE
Misc logging and status updates

### DIFF
--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -142,7 +142,7 @@ func setupSystemServices(parentCtx context.Context, c runtimeTypes.Container, cf
 	// TODO: Can we somehow make sure titus-container always starts first?
 	for _, svc := range sidecars {
 		if svc.EnabledCheck != nil && !svc.EnabledCheck(&cfg, c) {
-			logrus.Warnf("Skipping sidecar %s, not enabled", svc.UnitName)
+			logrus.Debugf("skipping sidecar %s, not enabled", svc.UnitName)
 			continue
 		}
 


### PR DESCRIPTION
When trying to debug why a container didn't start
correctly, I took it as an opportunity to do a
refresh of all the (semi) cryptic `creating` and
`got msg` log messages.

My main philosophy here is to remove the "cool story"
logs, and hopefully make it easier for users and operators
to know the "why" for what is happening.

----

Also, now that we are entering the pod world,
I think it will become more important that our logs say "which"
container is having things done to it.