### PR TITLE
Do shell splitting on container's Command when an annotation is set

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -328,8 +328,8 @@ func maybeAddOptimisticDad(sysctl map[string]string) {
 }
 
 func (r *DockerRuntime) dockerConfig(c runtimeTypes.Container, binds []string, imageSize int64, volumeContainers []string) (*container.Config, *container.HostConfig, error) { // nolint: gocyclo
-	// Extract the entrypoint from the proto. If the proto is empty, pass
-	// an empty entrypoint and let Docker extract it from the image.
+	// Extract the entrypoint and command from the pod. If either is empty,
+	// pass them along and let Docker extract them from the image instead.
 	entrypoint, cmd := c.Process()
 
 	// hostname style: ip-{ip-addr} or {task ID}

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -755,6 +755,10 @@ func (c *PodContainer) extractServiceMesh() error {
 	return nil
 }
 
+// Optionally do shell splitting on the container's Command if the appropriate annotation is set. We do this
+// because lots of jobs still depend on this behaviour. Unfortunately, this parsing can't be done in
+// the TJC and passed down to the executor, because Titus clients sign jobs with the original unparsed Command
+// and Args. If the executor reports something different than what was in the signature, this breaks Metatron.
 func (c *PodContainer) parsePodCommandAndArgs() error {
 	uc := podCommon.GetUserContainer(c.pod)
 	c.entrypoint = uc.Command

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Netflix/metrics-client-go v0.0.0-20171019173821-bb173f41fc07
 	github.com/Netflix/spectator-go v0.0.0-20190913215732-d4e0463555ef
 	github.com/Netflix/titus-api-definitions v0.0.1-rc9.0.20210426164010-ef784d356ff6
-	github.com/Netflix/titus-kube-common v0.10.2-0.20210420003404-4e53c4032156
+	github.com/Netflix/titus-kube-common v0.13.0
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
 	github.com/apex/log v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/Netflix/titus-kube-common v0.10.1 h1:gX6vJyvGK6QDDxwqcIYGQw+vgn5uVLRs
 github.com/Netflix/titus-kube-common v0.10.1/go.mod h1:OoWxqK3nzjhkRvtox9JJR7gXcXAehJ2tpEtBX2X2c2w=
 github.com/Netflix/titus-kube-common v0.10.2-0.20210420003404-4e53c4032156 h1:22GZFInn3rthZm6f+8aFyzwaKvkgFFY7gaOkBib+/jc=
 github.com/Netflix/titus-kube-common v0.10.2-0.20210420003404-4e53c4032156/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
+github.com/Netflix/titus-kube-common v0.13.0 h1:4qU7z5NiMp1MmVZROm60iaT5S0GNC+MekI3tMTTKxrE=
+github.com/Netflix/titus-kube-common v0.13.0/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
The previous pod spec implementation assumed that we could get the TJC to do the docker shell splitting and then pass down the result in the container's Command and Args. Unfortunately, since the jobs are signed with the original Command and Args, this breaks Metatron. The executor will now parse Command when an annotation is set.

See https://github.com/Netflix/titus-kube-common/pull/15 for the kube-common changes