### PR TITLE
Only exercise seccomp fd code when there is a socket to use in the first place

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -223,6 +223,7 @@ func (r *Runner) runMainContainerAndStartSidecars(ctx context.Context, startTime
 		return
 	}
 	startedMsg := fmt.Sprintf("started %d container(s): %s, now monitoring for container status", len(containerNames), containerNames)
+	logger.G(ctx).Info(startedMsg)
 	updateChan <- update{status: titusdriver.Starting, msg: startedMsg, details: details}
 
 	err = r.maybeSetupExternalLogger(ctx, logDir)

--- a/tini/src/tini.c
+++ b/tini/src/tini.c
@@ -859,16 +859,18 @@ void maybe_unix_cb()
 
 	sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (sockfd == -1) {
-		PRINT_FATAL("Unable to open unix socket: '%s'",
-			    strerror(errno));
+		PRINT_FATAL(
+			"Unable to open titus-executor unix socket %s: '%s'",
+			socket_path, strerror(errno));
 		goto error;
 	}
 
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
 	if (connect(sockfd, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
-		PRINT_FATAL("Unable to connect unix socket: '%s'",
-			    strerror(errno));
+		PRINT_FATAL(
+			"Unable to connect titus-executor unix socket %s: '%s'",
+			socket_path, strerror(errno));
 		goto error;
 	}
 
@@ -973,7 +975,7 @@ int main(int argc, char *argv[])
 	/* Setup a seccomp notification fd and pass it off, if available */
 	maybe_setup_seccomp_notifer();
 
-	/* Go on */
+	/* Go on, even if we couldn't tell titus-executor we started */
 	int spawn_ret = spawn(&child_sigconf, *child_args_ptr, &child_pid);
 	if (spawn_ret) {
 		return spawn_ret;


### PR DESCRIPTION
With `TITUS_SECCOMP_NOTIFY_SOCK_PATH` unset (majority of the time), we were still exercising the fd/clone/etc needlessly, and only after we fork would we return with the error that TITUS_SECCOMP_NOTIFY_SOCK_PATH is unset!

This is a bit worrying, but hopefully should be harmless, but that code is going to test now.

With this PR, we bail silently if `TITUS_SECCOMP_NOTIFY_SOCK_PATH` is unset in the first place.