### PR TITLE
Added basic pod /logs for C&W

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -327,7 +327,7 @@ func (r *Runner) doShutdown(ctx context.Context, lastUpdate update) { // nolint:
 	if r.wasKilled() {
 		logger.G(ctx).Info("Killing and Shutting down main conatiner because of KillInitiated")
 	} else {
-		logger.G(ctx).Info("Shutting down main container because it finished")
+		logger.G(ctx).Info("Shutting down main container because it finished or died")
 	}
 	if err := r.runtime.Kill(ctx); err != nil {
 		// TODO(Andrew L): There may be leaked resources that are not being


### PR DESCRIPTION
This change uses /logs from the 'main' container and shares
it with other user containers.

The main benefit here is the /logs is consistent, and it
consumes the storage space from the main container. It is all
backwards compatible with all the other expectations around
how /logs behaves.

If we like this approach (bind mount from the main container),
it can be extended to other volumes, like /run.

Additionally, this PR includes injecting `tini` into the other
user containers. This is a bit hard, because docker won't do it
for us, even with `Init: true`.
https://github.com/moby/moby/blob/9f2b33f75cb094917c69e03ba101bc0bee8673fb/daemon/oci_linux.go#L737

This can be improved, but at least will now get files like:

    /logs/stdout
    /logs/stderr
    /logs/stdout-nginx
    /logs/stderr-nginx

Which is the killer feature of the /logs shared volume.

----

What do you all think of this approach? 