### PR TITLE
Refactor standalone tests to be able to be run one at a time

### DIFF
--- a/hack/tests-with-dind.sh
+++ b/hack/tests-with-dind.sh
@@ -84,10 +84,12 @@ docker exec "$titus_agent_name" ${PWD}/hack/agent/certs/setup-metatron-certs.sh
 
 log "Running integration tests against the $titus_agent_name daemon"
 # --privileged is needed here since we are reading FDs from a unix socket
-#docker exec $TTYFLAG --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
-#  go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
-#    -covermode=count -coverprofile=coverage-standalone.out \
-#    -coverpkg=github.com/Netflix/... ./executor/standalone/... -standalone=true 2>&1 | tee test-standalone.log
+log "Running tests with CInfo"
+docker exec $TTYFLAG --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
+  go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
+    -covermode=count -coverprofile=coverage-standalone.out \
+    -coverpkg=github.com/Netflix/... ./executor/standalone/... -standalone=true 2>&1 | tee test-standalone.log
+log "Running tests with Pod Spec v1"
 docker exec $TTYFLAG --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
   go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
     -covermode=count -coverprofile=coverage-standalone.out \

--- a/hack/tests-with-dind.sh
+++ b/hack/tests-with-dind.sh
@@ -2,6 +2,14 @@
 
 set -eu -o pipefail
 
+set -vx
+TTYFLAG=""
+if [ -t 1 ] ;then
+  # Setting the tty flag when available streams the test output in real time
+  TTYFLAG="-ti"
+fi
+
+
 ## Runs integration tests against a docker daemon dedicated to them:
 #  - the docker daemon runs as docker-in-docker (dind) in background
 #  - systemd, dbus and all other titus-executor dependencies are available where the docker daemon runs
@@ -55,7 +63,7 @@ if [[ $(uname) == "Darwin" ]]; then
 fi
 
 log "Running a docker daemon named $titus_agent_name"
-docker run --privileged --security-opt seccomp=unconfined \
+docker run $TTYFLAG --privileged --security-opt seccomp=unconfined \
   -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
   -v ${GOPATH}:${GOPATH} \
   -v ${PWD}:${PWD} \
@@ -76,9 +84,13 @@ docker exec "$titus_agent_name" ${PWD}/hack/agent/certs/setup-metatron-certs.sh
 
 log "Running integration tests against the $titus_agent_name daemon"
 # --privileged is needed here since we are reading FDs from a unix socket
-docker exec --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
+#docker exec $TTYFLAG --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
+#  go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
+#    -covermode=count -coverprofile=coverage-standalone.out \
+#    -coverpkg=github.com/Netflix/... ./executor/standalone/... -standalone=true 2>&1 | tee test-standalone.log
+docker exec $TTYFLAG --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
   go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
     -covermode=count -coverprofile=coverage-standalone.out \
-    -coverpkg=github.com/Netflix/... ./executor/standalone/... -standalone=true 2>&1 | tee test-standalone.log
+    -coverpkg=github.com/Netflix/... ./executor/standalone/... -standalone=true -shouldUsePodspecInTest=true 2>&1 | tee test-standalone-podspec.log
 
 log "Integration tests complete (rc: $?)"


### PR DESCRIPTION
This does a few things:

1. Runs standalone tests *twice* in the script instead of twice
   in the golang runner. I don't like this too much, but this
   split is temporary anyway and will go away once we are using
   v1 schema.
2. Removes the injected jobID var in each test. This was also
   kinda a function of the WithPod or WithCinfo. Again, this was
   temp code anyway, so I'm not too mornful about dropping it.
3. Put the parallizing code *in* each test. This kinda sucks, but
   it is only one line for each test, instead of having to maintain
   the big master list of tests at the top.
4. Makes all tests "public", so they can be run individually.
   This is the big deal, it means I can click on one in my IDE
   and run it. An iteration cycle of seconds instead of many minutes.

This is still not quite enough to make it all work on MacOSX, but
it is a prereq.