### PR TITLE
Added NETFLIX_IPV6 vars

### DIFF
--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -1181,6 +1181,8 @@ func populateContainerEnv(c Container, config config.Config, userEnv map[string]
 
 		if vpcAllocation.IPV6Address != nil {
 			env[metadataserverTypes.EC2IPv6sEnvVarName] = vpcAllocation.IPV6Address.Address.Address
+			env[metadataserverTypes.NetflixIPv6EnvVarName] = vpcAllocation.IPV6Address.Address.Address
+			env[metadataserverTypes.NetflixIPv6sEnvVarName] = vpcAllocation.IPV6Address.Address.Address
 		}
 
 		if vpcAllocation.ElasticAddress != nil {

--- a/metadataserver/types/types.go
+++ b/metadataserver/types/types.go
@@ -17,6 +17,8 @@ const (
 	EC2PublicIPv4sEnvVarName  = "EC2_PUBLIC_IPV4S"
 	EC2IPv6sEnvVarName        = "EC2_IPV6S"
 	NetflixAccountIDVarName   = "NETFLIX_ACCOUNT_ID"
+	NetflixIPv6EnvVarName     = "NETFLIX_IPV6"
+	NetflixIPv6sEnvVarName    = "NETFLIX_IPV6S"
 )
 
 // MetadataServerConfiguration is a configuration for metadata service + IAM Proxy


### PR DESCRIPTION
A Netflix we (apparently) do not use the EC2_IPV6 variables.
This is because we don't trust them, because they don't come
from v6 assigner, which come post-launch. Instead they use
the Netflix-specific NETFLIX_IPV6* vars.

In order for application to smoothly transition to Titus, this
PR adds the same variables as well.
