### PR TITLE
If pod has user env var index annotation set, don't require ContainerInfo

### DIFF
--- a/cmd/titus-metadata-service/main.go
+++ b/cmd/titus-metadata-service/main.go
@@ -363,10 +363,13 @@ func main() {
 			return cli.NewExitError(err.Error(), 1)
 		}
 		log.Info("Done serving?")
-		time.Sleep(1 * time.Second)
 		return nil
 	}
+
 	if err := app.Run(os.Args); err != nil {
+		time.Sleep(1 * time.Second)
 		log.WithError(err).Fatal()
 	}
+	// Sleep for 1 second (both here and above) to give logs a chance to flush
+	time.Sleep(1 * time.Second)
 }

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -256,6 +256,8 @@ func (c *PodContainer) ContainerInfo() (*titus.ContainerInfo, error) {
 		JobGroupDetail: &detail,
 		IamProfile:     c.IamRole(),
 		NetworkConfigInfo: &titus.ContainerInfo_NetworkConfigInfo{
+			// This isn't used, but is marked as required in the protobuf
+			EniLablel:      ptr.StringPtr("0"),
 			SecurityGroups: sgIDs,
 		},
 		JobGroupSequence: &seq,
@@ -473,7 +475,14 @@ func (c *PodContainer) LogUploadThresholdTime() *time.Duration {
 }
 
 func (c *PodContainer) MetatronCreds() *titus.ContainerInfo_MetatronCreds {
-	return c.titusInfo.GetMetatronCreds()
+	if c.podConfig.AppMetadata == nil || c.podConfig.AppMetadataSig == nil {
+		return nil
+	}
+
+	return &titus.ContainerInfo_MetatronCreds{
+		AppMetadata: c.podConfig.AppMetadata,
+		MetadataSig: c.podConfig.AppMetadataSig,
+	}
 }
 
 func (c *PodContainer) NFSMounts() []NFSMount {

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -114,12 +114,18 @@ func NewPodContainer(pod *corev1.Pod, cfg config.Config) (*PodContainer, error) 
 		userEnv:           userEnv,
 	}
 
-	if pConf.UserEnvVarsStartIndex == nil {
+	// If the containerInfo annotation was set, use it
+	if pConf.ContainerInfo != nil {
 		cInfo, err := extractContainerInfo(pConf)
 		if err != nil {
 			return nil, err
 		}
 		c.titusInfo = cInfo
+	} else {
+		// No containerInfo: we need to know which env vars are user vs Titus so Metatron works
+		if pConf.UserEnvVarsStartIndex == nil {
+			return nil, fmt.Errorf("user environment variable index annotation is required: %s", podCommon.AnnotationKeyPodTitusUserEnvVarsStartIndex)
+		}
 	}
 
 	err = c.parsePodVolumes()

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -475,7 +475,7 @@ func TestNewPodContainerErrors(t *testing.T) {
 
 	pod.Spec.Containers[0].Resources = goodPod.Spec.Containers[0].Resources
 	_, err = NewPodContainer(pod, *conf)
-	assert.ErrorContains(t, err, "unable to find containerInfo annotation")
+	assert.ErrorContains(t, err, "user environment variable index annotation is required")
 
 	pod.Annotations = map[string]string{
 		podCommon.AnnotationKeyPodTitusContainerInfo: "0",
@@ -1471,6 +1471,7 @@ func TestContainerInfoGenerationNoUserEnvVars(t *testing.T) {
 		},
 	}
 
+	// If there are no user env vars, the TJC will set the index to where they would have started
 	addPodAnnotations(pod, map[string]string{
 		podCommon.AnnotationKeyPodTitusUserEnvVarsStartIndex: "2",
 	})

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -1357,6 +1357,7 @@ func TestContainerInfoGenerationBasic(t *testing.T) {
 		JobGroupDetail:   ptr.StringPtr(""),
 		MetatronCreds:    &titus.ContainerInfo_MetatronCreds{},
 		NetworkConfigInfo: &titus.ContainerInfo_NetworkConfigInfo{
+			EniLablel:      ptr.StringPtr("0"),
 			SecurityGroups: []string{},
 		},
 		Process: &titus.ContainerInfo_Process{},
@@ -1370,6 +1371,9 @@ func TestContainerInfoGenerationBasic(t *testing.T) {
 		},
 		Version: ptr.StringPtr(testImageTag),
 	})
+
+	var metatronCredsNil *titus.ContainerInfo_MetatronCreds
+	assert.DeepEqual(t, c.MetatronCreds(), metatronCredsNil)
 }
 
 func TestContainerInfoGenerationAllFields(t *testing.T) {
@@ -1423,6 +1427,10 @@ func TestContainerInfoGenerationAllFields(t *testing.T) {
 
 	cInfo, err := c.ContainerInfo()
 	assert.NilError(t, err)
+	expMetatronCreds := &titus.ContainerInfo_MetatronCreds{
+		AppMetadata: ptr.StringPtr("app-meta"),
+		MetadataSig: ptr.StringPtr("meta-sig"),
+	}
 	assert.DeepEqual(t, cInfo, &titus.ContainerInfo{
 		AppName:                ptr.StringPtr(testAppName),
 		IamProfile:             ptr.StringPtr(testIamRole),
@@ -1432,11 +1440,9 @@ func TestContainerInfoGenerationAllFields(t *testing.T) {
 		JobGroupStack:          ptr.StringPtr(testAppStack),
 		JobGroupDetail:         ptr.StringPtr(testAppDetail),
 		JobId:                  ptr.StringPtr(testJobID),
-		MetatronCreds: &titus.ContainerInfo_MetatronCreds{
-			AppMetadata: ptr.StringPtr("app-meta"),
-			MetadataSig: ptr.StringPtr("meta-sig"),
-		},
+		MetatronCreds:          expMetatronCreds,
 		NetworkConfigInfo: &titus.ContainerInfo_NetworkConfigInfo{
+			EniLablel:      ptr.StringPtr("0"),
 			SecurityGroups: []string{"sg-1", "sg-2"},
 		},
 		Process: &titus.ContainerInfo_Process{
@@ -1453,6 +1459,8 @@ func TestContainerInfoGenerationAllFields(t *testing.T) {
 		},
 		Version: ptr.StringPtr(testImageTag),
 	})
+
+	assert.DeepEqual(t, c.MetatronCreds(), expMetatronCreds)
 }
 
 func TestContainerInfoGenerationNoUserEnvVars(t *testing.T) {

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -45,7 +45,9 @@ const (
 	False            = "false"
 	ec2HostnameStyle = "ec2"
 	testIamRole      = "arn:aws:iam::0:role/DefaultContainerRole"
+	testImageName    = "titusoss/alpine"
 	testImageWithTag = "titusoss/alpine:latest"
+	testImageTag     = "latest"
 )
 
 // ErrMissingIAMRole indicates that the Titus job was submitted without an IAM role

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Netflix/metrics-client-go v0.0.0-20171019173821-bb173f41fc07
 	github.com/Netflix/spectator-go v0.0.0-20190913215732-d4e0463555ef
 	github.com/Netflix/titus-api-definitions v0.0.1-rc9.0.20210426164010-ef784d356ff6
-	github.com/Netflix/titus-kube-common v0.13.0
+	github.com/Netflix/titus-kube-common v0.14.0
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
 	github.com/apex/log v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/Netflix/titus-kube-common v0.10.2-0.20210420003404-4e53c4032156 h1:22
 github.com/Netflix/titus-kube-common v0.10.2-0.20210420003404-4e53c4032156/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
 github.com/Netflix/titus-kube-common v0.13.0 h1:4qU7z5NiMp1MmVZROm60iaT5S0GNC+MekI3tMTTKxrE=
 github.com/Netflix/titus-kube-common v0.13.0/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
+github.com/Netflix/titus-kube-common v0.14.0 h1:fAYK/hrZMw1At2lW3C28kV41jEt1RU5dETint8RYTns=
+github.com/Netflix/titus-kube-common v0.14.0/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/hack/test-images/user-set/Dockerfile
+++ b/hack/test-images/user-set/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y curl
 # Make sure that we can use `runc` to enter containers that have USER set to non-root
 RUN addgroup app && adduser --ingroup app app
 USER app


### PR DESCRIPTION
This removes the last hard dependency on the ContainerInfo annotation: for generating the Metatron task-identity endpoint.  If the TJC sets the annotation indicating what index the user env vars start at, the executor has enough info to reconstruct ContainerInfo on its own, so let's do that instead.

kube-common PR: https://github.com/Netflix/titus-kube-common/pull/17