### PR TITLE
Enabled standalone tests runnable from mac (darwin)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ TEST_DIRS = $(shell go list -f 'TEST-{{.ImportPath}}' ./...)
 .PHONY: $(TEST_DIRS)
 $(TEST_DIRS): | $(clean)
 	$(eval import_path := $(subst TEST-,,$@))
-	CGO_ENABLED=0 go test -o test-darwin/$(import_path).test -c $(import_path)
+	CGO_ENABLED=0 go test -short -o test-darwin/$(import_path).test -c $(import_path)
 	$(RM) test-darwin/$(import_path).test
 
 .PHONY: build-tests-darwin
@@ -63,7 +63,7 @@ cross-linux:
 
 .PHONY: test-local
 test-local: | $(clean)
-	CGO_ENABLED=0 go test $(TEST_FLAGS) -covermode=count -coverprofile=coverage-local.out -coverpkg=github.com/Netflix/... ./... \
+	CGO_ENABLED=0 go test -short $(TEST_FLAGS) -covermode=count -coverprofile=coverage-local.out -coverpkg=github.com/Netflix/... ./... \
 	| tee /dev/stderr > test-local.log
 
 # run standalone tests against the docker container runtime

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1693,6 +1694,12 @@ func (r *DockerRuntime) setupPreStartTini(ctx context.Context, c runtimeTypes.Co
 }
 
 func (r *DockerRuntime) setupPostStartLogDirTini(ctx context.Context, l *net.UnixListener, c runtimeTypes.Container) (string, *ucred, *os.File, *net.UnixConn, error) {
+	// On darwin, we can't expect to be able to cross-mount unix socket directories for this to work,
+	// so we just return right away
+	if runtime.GOOS == "darwin" {
+		return "", nil, nil, nil, nil
+	}
+
 	genericConn, err := l.Accept()
 	if err != nil {
 		if ctx.Err() != nil {
@@ -2040,6 +2047,9 @@ func teardownCommand(netnsFile *os.File, allocation vpcTypes.HybridAllocation) e
 }
 
 func tellTiniToLaunch(conn *net.UnixConn) error {
+	if conn == nil {
+		return nil
+	}
 	// This should be non-blocking
 	_, err := conn.Write([]byte{'L'}) // L is for Launch
 	return err

--- a/executor/runtime/docker/docker_unsupported.go
+++ b/executor/runtime/docker/docker_unsupported.go
@@ -4,23 +4,18 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"net"
 
 	"github.com/Netflix/titus-executor/config"
 	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
 )
 
-var (
-	errUnsupported = errors.New("Unsupported on current platform")
-)
-
 func getPeerInfo(unixConn *net.UnixConn) (ucred, error) {
-	return ucred{0, 0, 0}, errUnsupported
+	return ucred{0, 0, 0}, nil
 }
 
 func setupScheduler(cred ucred) error {
-	return errUnsupported
+	return nil
 }
 
 func hasProjectQuotasEnabled(rootDir string) bool {
@@ -36,20 +31,20 @@ func (r *DockerRuntime) mountContainerProcPid1InTitusInits(parentCtx context.Con
 }
 
 func getOwnCgroup(subsystem string) (string, error) {
-	return "", errUnsupported
+	return "", nil
 }
 func cleanupCgroups(cgroupPath string) error {
-	return errUnsupported
+	return nil
 }
 
 func setCgroupOwnership(parentCtx context.Context, c runtimeTypes.Container, cred ucred) error {
-	return errUnsupported
+	return nil
 }
 
 func setupOOMAdj(c runtimeTypes.Container, cred ucred) error {
-	return errUnsupported
+	return nil
 }
 
 func stopSystemServices(ctx context.Context, c runtimeTypes.Container) error {
-	return errUnsupported
+	return nil
 }

--- a/hack/tests-with-dind.sh
+++ b/hack/tests-with-dind.sh
@@ -88,11 +88,11 @@ log "Running tests with CInfo"
 docker exec $TTYFLAG --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
   go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
     -covermode=count -coverprofile=coverage-standalone.out \
-    -coverpkg=github.com/Netflix/... ./executor/standalone/... -standalone=true 2>&1 | tee test-standalone.log
+    -coverpkg=github.com/Netflix/... ./executor/standalone/... -short=false -shouldUsePodspecInTest=false 2>&1 | tee test-standalone.log
 log "Running tests with Pod Spec v1"
 docker exec $TTYFLAG --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
   go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
     -covermode=count -coverprofile=coverage-standalone.out \
-    -coverpkg=github.com/Netflix/... ./executor/standalone/... -standalone=true -shouldUsePodspecInTest=true 2>&1 | tee test-standalone-podspec.log
+    -coverpkg=github.com/Netflix/... ./executor/standalone/... -short=false -shouldUsePodspecInTest=true 2>&1 | tee test-standalone-podspec.log
 
 log "Integration tests complete (rc: $?)"


### PR DESCRIPTION
This makes it so "unsupported" platforms (darwin) just are noops
instead of raising an unsupported error.

I think this is fine, I don't think anyone should expect a full
feature-set running Titus on darwin :)

But, this enables the majority of our standalone tests to actually
work on a mac. The few that don't I added a skipper and a comment
as to why they don't work, because they magically may start working
in the future.

It does mean that I had to make the standalone tests *opt out*
instead of opt in. This would only affect someone who is running
`go test` manually instead of `make test`, which is probably nobody.

But, we've finally made it. With this PR I can run standalone tests
in a few seconds with a click of a button from my IDE.

The full test suite takes 25 seconds on my laptop:

```
Running tool: /usr/local/opt/go/libexec/bin/go test -timeout 30s -coverprofile=/var/folders/qd/20hc8yr51nlg1x6n7ppjwzjh0000gn/T/vscode-goVhHHGp/go-code-cover github.com/Netflix/titus-executor/executor/standalone

ok  	github.com/Netflix/titus-executor/executor/standalone	25.023s	coverage: [no statements]
```
