### PR TITLE
Fix the titus-sshd docker build for 2021

### DIFF
--- a/hack/images/titus-sshd/Dockerfile
+++ b/hack/images/titus-sshd/Dockerfile
@@ -11,10 +11,9 @@ RUN emerge --sync
 RUN echo 'MAKEOPTS="-j32"' >> /etc/portage/make.conf
 RUN echo 'USE="-pam -gdbm -berkdb -bindist"' >> /etc/portage/make.conf
 # This is because Docker builds don't have CAP_SYS_PTRACE and cannot unshare
-RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
-#TEMP
-ENV FEATURES="nostrip"
-RUN emerge -C openssh
+# Note: For some reason we cannot strip our binaries. Not sure why...
+RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox nostrip"' >> /etc/portage/make.conf
+RUN emerge --unmerge openssh
 # We want to re-emerge openssl with the new USE flags, because the old USE flags can confuse portage
 RUN emerge --oneshot openssl
 # you need nss on the host to build nss in the prefix

--- a/hack/images/titus-sshd/Dockerfile
+++ b/hack/images/titus-sshd/Dockerfile
@@ -1,3 +1,10 @@
+# Welcome to the titus-sshd Dockerfile!
+#
+# This image uses gentoo to get fine-grained control over the
+# sshd binary and to relocate it to /titus/sshd, *even though*
+# it is still dynamically linked!
+#
+# First we setup a gentoo environment that can run *in* docker:
 FROM gentoo/stage3-amd64 as builder
 RUN emerge-webrsync
 RUN emerge --sync
@@ -5,53 +12,64 @@ RUN echo 'MAKEOPTS="-j32"' >> /etc/portage/make.conf
 RUN echo 'USE="-pam -gdbm -berkdb -bindist"' >> /etc/portage/make.conf
 # This is because Docker builds don't have CAP_SYS_PTRACE and cannot unshare
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
-
 #TEMP
 ENV FEATURES="nostrip"
-
 RUN emerge -C openssh
 # We want to re-emerge openssl with the new USE flags, because the old USE flags can confuse portage
-RUN emerge -v --oneshot openssl
+RUN emerge --oneshot openssl
 # you need nss on the host to build nss in the prefix
 RUN PYTHON_TARGETS="python3_7" emerge patchelf repoman nss
-# sys-kernel/linux-headers is a build-time dependency of glibc
+
+
+# Next Stage: We build up dependencies and binary gentoo packages for the things
+# we want to eventually be in /titus/sshd
+# We use the special `emerge --prefix=/titus/sshd` so that all the things
+# we build will have paths (just like one might do /usr/local/) in /titus/sshd
+#
+# These symlinks are required, as many configure scripts require
+# them to even get off the ground and compile
 RUN mkdir -p /titus/sshd/bin /titus/sshd/usr/bin
 RUN ln -s /bin/bash /titus/sshd/bin/
 RUN ln -s /usr/bin/perl /titus/sshd/usr/bin/
-RUN emerge --prefix=/titus/sshd --oneshot sys-kernel/linux-headers
 RUN ln -s /usr/bin/python3.7 /titus/sshd/usr/bin/
 RUN ln -s /bin/sh /titus/sshd/bin/
 RUN ln -s /bin/fgrep /titus/sshd/bin/
+RUN ln -s /usr/bin/env /titus/sshd/usr/bin/
+# sys-kernel/linux-headers is a build-time dependency of glibc
+RUN emerge --prefix=/titus/sshd --oneshot sys-kernel/linux-headers
 RUN emerge --prefix=/titus/sshd --buildpkg glibc
-# Some of the packages which get build here turn into deps that are part of openssh
-#RUN USE="-ssl" emerge --prefix=/titus/sshd --oneshot --buildpkg python:3.6 bash
-RUN ln -s /usr/bin/python3.6 /titus/sshd/usr/bin/
+# For openssh itself, in titus we can't assume that the gentoo convention of having an 'sshd' user is valid
+# Instead we depend on the 'nobody' user, and in titus if we don't even have *that*
+# we can create the nobody user ourselves at startup time
 RUN sed -i s/with-privsep-user=sshd/with-privsep-user=nobody/ /var/db/repos/gentoo/net-misc/openssh/*.ebuild # |grep =ssh
 RUN cd /var/db/repos/gentoo/net-misc/openssh/ && repoman manifest
-RUN ln -s /usr/bin/env /titus/sshd/usr/bin/
-# TODO TEMP
-RUN emerge gdb  strace
-#RUN echo 'FEATURES="-sandbox -usersandbox nostrip"' >> /etc/portage/make.conf
-#RUN sed -i 's/pipe/pipe -gdb/g' /etc/portage/make.conf
-RUN emerge --prefix=/titus/sshd --buildpkg openssh
-RUN emerge --prefix=/titus/sshd --buildpkg nss
-RUN emerge --prefix=/titus/sshd --buildpkg busybox
-# Now we want to discard our temp build dir
+RUN emerge --prefix=/titus/sshd --buildpkg openssh nss busybox
+
+# Now we want to discard our temp build dir and re-build
+# This time we can do `--usepkgonly` to save time and use the packages we built above
+# This gives us a very clean /titus/sshd with only what we need
 RUN rm -r /titus/sshd
-RUN emerge --prefix=/titus/sshd --nodeps -K glibc
-RUN emerge --prefix=/titus/sshd -K glibc openssh nss busybox
-RUN ln -s /etc/hosts /titus/sshd/etc/
-# Here, the LD_LIBRARY_PATH under /titus/sshd is are the primary ones we look at, and if those don't work,
-# we fall back to the ubuntu ones
+RUN emerge --prefix=/titus/sshd --nodeps --usepkgonly glibc
+RUN emerge --prefix=/titus/sshd --usepkgonly glibc openssh nss busybox
+
+# Here we *relocate* the /titus/sshd binaries using the patchelf command.
+# This forces the linker to use *our* /titus/sshd/lib64/ld-linux-x86-64.so.2 as
+# Here, the LD_LIBRARY_PATH under /titus/sshd is are the primary ones we look at
 RUN for i in $(scanelf --recursive --mount --symlink --etype ET_DYN --perms 0700 --nobanner --format '%F' /titus/sshd/bin /titus/sshd/sbin /titus/sshd/usr/bin/ /titus/sshd/usr/sbin/  /titus/sshd/usr/lib64/misc/); do \
       xargs -n1 patchelf --set-interpreter /titus/sshd/lib64/ld-linux-x86-64.so.2 --set-rpath /titus/sshd/lib64:/titus/sshd/usr/lib64:/usr/local/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu ${i}; \
     done
-# We might want to get rid of this later:
+
 RUN /titus/sshd/usr/bin/ssh-keygen -A
 RUN ln -s /etc/resolv.conf /titus/sshd/etc/
 RUN ln -s /etc/passwd /titus/sshd/etc/
+RUN ln -s /etc/hosts /titus/sshd/etc/
 RUN ln -s /titus/sshd/bin/busybox /titus/sshd/bin/sh
+ADD run-titus-sshd /titus/sshd/run-titus-sshd
+# The /titus/sshd volume is considered immutable, but sshd_config is generated
+# dynamically from the titus-agent, so we symlink it in from /titus/etc
 RUN rm /titus/sshd/etc/ssh/sshd_config && ln -s /titus/etc/ssh/sshd_config /titus/sshd/etc/ssh/sshd_config
+
+# Finally, as a multi-stage build, we want an image that *only* has /titus/sshd and none
+# of the stuff we started with:
 FROM scratch
 COPY --from=builder /titus/sshd /titus/sshd
-ADD run-titus-sshd /titus/sshd/run-titus-sshd

--- a/hack/images/titus-sshd/Dockerfile
+++ b/hack/images/titus-sshd/Dockerfile
@@ -3,35 +3,48 @@ RUN emerge-webrsync
 RUN emerge --sync
 RUN echo 'MAKEOPTS="-j32"' >> /etc/portage/make.conf
 RUN echo 'USE="-pam -gdbm -berkdb -bindist"' >> /etc/portage/make.conf
-# This is because Docker builds don't have CAP_SYS_PTRACE
-RUN echo 'FEATURES="-sandbox -usersandbox"' >> /etc/portage/make.conf
-RUN echo "=sys-auth/libnss-compat-1.2 ~amd64" >> /etc/portage/package.accept_keywords
+# This is because Docker builds don't have CAP_SYS_PTRACE and cannot unshare
+RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
+
+#TEMP
+ENV FEATURES="nostrip"
+
 RUN emerge -C openssh
 # We want to re-emerge openssl with the new USE flags, because the old USE flags can confuse portage
 RUN emerge -v --oneshot openssl
 # you need nss on the host to build nss in the prefix
-RUN emerge patchelf repoman nss
+RUN PYTHON_TARGETS="python3_7" emerge patchelf repoman nss
 # sys-kernel/linux-headers is a build-time dependency of glibc
 RUN mkdir -p /titus/sshd/bin /titus/sshd/usr/bin
 RUN ln -s /bin/bash /titus/sshd/bin/
 RUN ln -s /usr/bin/perl /titus/sshd/usr/bin/
 RUN emerge --prefix=/titus/sshd --oneshot sys-kernel/linux-headers
+RUN ln -s /usr/bin/python3.7 /titus/sshd/usr/bin/
+RUN ln -s /bin/sh /titus/sshd/bin/
+RUN ln -s /bin/fgrep /titus/sshd/bin/
 RUN emerge --prefix=/titus/sshd --buildpkg glibc
 # Some of the packages which get build here turn into deps that are part of openssh
 #RUN USE="-ssl" emerge --prefix=/titus/sshd --oneshot --buildpkg python:3.6 bash
 RUN ln -s /usr/bin/python3.6 /titus/sshd/usr/bin/
-RUN sed -i s/with-privsep-user=sshd/with-privsep-user=nobody/ /usr/portage/net-misc/openssh/*.ebuild # |grep =ssh
-RUN cd /usr/portage/net-misc/openssh && repoman manifest
-RUN emerge --prefix=/titus/sshd --buildpkg openssh nss libnss-compat busybox
+RUN sed -i s/with-privsep-user=sshd/with-privsep-user=nobody/ /var/db/repos/gentoo/net-misc/openssh/*.ebuild # |grep =ssh
+RUN cd /var/db/repos/gentoo/net-misc/openssh/ && repoman manifest
+RUN ln -s /usr/bin/env /titus/sshd/usr/bin/
+# TODO TEMP
+RUN emerge gdb  strace
+#RUN echo 'FEATURES="-sandbox -usersandbox nostrip"' >> /etc/portage/make.conf
+#RUN sed -i 's/pipe/pipe -gdb/g' /etc/portage/make.conf
+RUN emerge --prefix=/titus/sshd --buildpkg openssh
+RUN emerge --prefix=/titus/sshd --buildpkg nss
+RUN emerge --prefix=/titus/sshd --buildpkg busybox
 # Now we want to discard our temp build dir
 RUN rm -r /titus/sshd
 RUN emerge --prefix=/titus/sshd --nodeps -K glibc
-RUN emerge --prefix=/titus/sshd -K glibc openssh nss libnss-compat busybox
+RUN emerge --prefix=/titus/sshd -K glibc openssh nss busybox
 RUN ln -s /etc/hosts /titus/sshd/etc/
 # Here, the LD_LIBRARY_PATH under /titus/sshd is are the primary ones we look at, and if those don't work,
 # we fall back to the ubuntu ones
 RUN for i in $(scanelf --recursive --mount --symlink --etype ET_DYN --perms 0700 --nobanner --format '%F' /titus/sshd/bin /titus/sshd/sbin /titus/sshd/usr/bin/ /titus/sshd/usr/sbin/  /titus/sshd/usr/lib64/misc/); do \
-      xargs patchelf --set-interpreter /titus/sshd/lib64/ld-linux-x86-64.so.2 --set-rpath /titus/sshd/lib64:/titus/sshd/usr/lib64:/usr/local/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu ${i}; \
+      xargs -n1 patchelf --set-interpreter /titus/sshd/lib64/ld-linux-x86-64.so.2 --set-rpath /titus/sshd/lib64:/titus/sshd/usr/lib64:/usr/local/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu ${i}; \
     done
 # We might want to get rid of this later:
 RUN /titus/sshd/usr/bin/ssh-keygen -A

--- a/hack/images/titus-sshd/Makefile
+++ b/hack/images/titus-sshd/Makefile
@@ -4,7 +4,7 @@ build:
 dev:
 	docker run -it $(shell docker build -q .) /titus/sshd/bin/busybox sh
 
-itest:
+itest: build
 	# Uses the -T (test) option of sshd to ensure everything is compiled correctly
 	# And the config file, keys, etc are all good to go
 	docker run -it -v sshd_config.itest:/titus/etc/ssh/sshd_config:ro $(shell docker build -q .) \

--- a/hack/images/titus-sshd/Makefile
+++ b/hack/images/titus-sshd/Makefile
@@ -1,0 +1,15 @@
+build:
+	docker build .
+
+dev:
+	docker run -it $(shell docker build -q .) /titus/sshd/bin/busybox sh
+
+itest:
+	# Uses the -T (test) option of sshd to ensure everything is compiled correctly
+	# And the config file, keys, etc are all good to go
+	docker run -it -v sshd_config.itest:/titus/etc/ssh/sshd_config:ro $(shell docker build -q .) \
+	  /titus/sshd/run-titus-sshd -T && echo "PASS: titus-sshd environment validated"
+
+push:
+	docker build -t titusoss/titus-sshd .
+	docker push titusoss/titus-sshd

--- a/hack/images/titus-sshd/README.md
+++ b/hack/images/titus-sshd/README.md
@@ -1,0 +1,19 @@
+# `titus-sshd`
+
+This docker image is used as a Titus system service to provide sshd capabilities for a container.
+
+It is intended to run as a volume-mounted image, and then run in the container via `titus-nsenter`.
+
+## Build Instructions
+
+This image uses a complex build process to ensure that the `sshd` command can be relocated to `/titus/sshd/`.
+
+See the `Dockerfile` for inline explainations.
+
+## Push Instructions
+
+This build is tool long to be done in a CI/CD fashion.
+
+Build this image locally and run `make push` to upload a new image.
+
+For Titus engineers, run the Jenkins job to mirror this image locally to the Titus Registries, then update Titus executors to point to the new image carefully.

--- a/hack/images/titus-sshd/sshd_config.itest
+++ b/hack/images/titus-sshd/sshd_config.itest
@@ -1,0 +1,77 @@
+# See the sshd_config(5) manpage for details
+
+# What ports, IPs and protocols we listen for
+Port 7522
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /titus/sshd/etc/ssh/ssh_host_rsa_key
+HostCertificate /run/metatron/certificates/ssh_host_rsa_key-cert.pub
+HostKey /titus/sshd/etc/ssh/ssh_host_ecdsa_key
+HostCertificate /run/metatron/certificates/ssh_host_ecdsa_key-cert.pub
+HostKey /titus/sshd/etc/ssh/ssh_host_ed25519_key
+HostCertificate /run/metatron/certificates/ssh_host_ed25519_key-cert.pub
+
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin without-password
+StrictModes yes
+
+PubkeyAuthentication yes
+AuthorizedKeysFile	/titus/ssh_keys/%u
+
+TrustedUserCAKeys /titus/etc/ssh/trusted_user_ca_keys.pub
+AuthorizedPrincipalsFile /titus/etc/ssh/authorized_principals_%u
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+PasswordAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding no
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog no
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /titus/sshd/usr/lib64/misc/sftp-server
+
+PidFile /dev/null


### PR DESCRIPTION
I think the gentoo approach is OK. It does give us
the benefit of being able to precisely control how
sshd is built, *and* keep all the features of a modern
ssh daemon (port forwarding, ssh CA auth, etc).

The downside of course is... gentoo and build times.

But this does work, and maybe it is just worth it to
fight the build once every couple of years.

----

Holy shit it works.

I still have a lot of extra junk in the dockerfile that is "temporary", so I'm going to remove that one piece at a time, `make itest` each time to ensure it *still* works.