### PR TITLE
Minor changes to make logs easier to understand in standlone tests

### DIFF
--- a/hack/agent/10-disable-atlas-agent.conf
+++ b/hack/agent/10-disable-atlas-agent.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStart=
-ExecStart=/bin/true

--- a/hack/agent/Dockerfile
+++ b/hack/agent/Dockerfile
@@ -49,7 +49,6 @@ COPY hack/agent/fake-gpu-runtime /usr/local/bin/fake-gpu-runtime
 RUN chmod 755 /usr/local/bin/fake-gpu-runtime
 COPY hack/agent/daemon.json /etc/docker/daemon.json
 COPY hack/agent/titus-shared.env /etc/titus-shared.env
-COPY hack/agent/10-disable-atlas-agent.conf /etc/systemd/system/atlas-titus-agent@.service.d/10-disable-atlas-agent.conf
 
 # Directories that the executor needs access to, which will be available with --volumes-from
 VOLUME /run

--- a/inject/titus-nsenter.c
+++ b/inject/titus-nsenter.c
@@ -173,8 +173,10 @@ int get_apparmor_profile(int titus_pid_1_fd, char apparmor_profile[8192],
 	memset(lsm_buf, 0, sizeof(lsm_buf));
 	fd = open("/sys/kernel/security/lsm", O_RDONLY | O_CLOEXEC);
 	if (fd == -1) {
-		perror("Could not open LSM config file");
-		return 1;
+		// Sometimes LSM is not available, especially if running *in* a docker container
+		fprintf(stderr,
+			"Could not open LSM config file, not setting up Apparmor");
+		return 0;
 	}
 
 	if (read(fd, lsm_buf, sizeof(lsm_buf) - 1) == -1) {

--- a/metadataserver/server.go
+++ b/metadataserver/server.go
@@ -52,6 +52,9 @@ const notFoundBody = `<?xml version="1.0" encoding="iso-8859-1"?>
  </body>
 </html>`
 
+// A sentinel role used under test
+const FakeARNRole = "arn:aws:iam::0:role/RealRole"
+
 var whitelist = set.NewSetFromSlice([]interface{}{
 	"/latest/meta-data",
 	"/latest/meta-data/network/interfaces/macs/null/vpc-id",
@@ -212,7 +215,9 @@ func NewMetaDataServer(ctx context.Context, config types.MetadataServerConfigura
 	ms.tokenKey = []byte(config.TokenKey)
 
 	// Create the IAM proxy - we'll attach routes to it for the different versions when we install handlers below
-	ms.iamProxy = newIamProxy(ctx, config, conn)
+	if config.IAMARN != FakeARNRole {
+		ms.iamProxy = newIamProxy(ctx, config, conn)
+	}
 
 	/* IMDS routes */
 	ms.internalMux.Use(ms.serverHeader)

--- a/root/lib/systemd/system/titus-container@.target
+++ b/root/lib/systemd/system/titus-container@.target
@@ -1,2 +1,2 @@
 [Unit]
-Description=Faux target unit for container ID %i
+Description=Titus System Services Started for container ID %i

--- a/root/lib/systemd/system/titus-sidecar-atlas-titus-agent@.service
+++ b/root/lib/systemd/system/titus-sidecar-atlas-titus-agent@.service
@@ -2,6 +2,7 @@
 Description=Metrics Pod for %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 ConditionPathExists=!/etc/disable-atlas-titus-agent
+ConditionFileIsExecutable=/usr/local/bin/atlas-titus-agent
 
 StartLimitIntervalSec=30
 StartLimitBurst=5

--- a/root/lib/systemd/system/titus-sidecar-sshd@.service
+++ b/root/lib/systemd/system/titus-sidecar-sshd@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=SSHD for container %s
+Description=SSHD for container %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
 
 StartLimitIntervalSec=30


### PR DESCRIPTION
Lots of stuff doesn't work in standalone, and isn't supposed to.
These are a few changes that I think are safe to make the
tests less noisy, hopefully making it easier to spot and understand
the "real" error and not the "normal" errors that fly by all the time.
