### PR TITLE
Fix Availability Zone Reconcilation Loop

### DIFF
--- a/vpc/service/service.go
+++ b/vpc/service/service.go
@@ -434,7 +434,7 @@ func (vpcService *vpcService) getTaskLoops() []taskLoop {
 		},
 		{
 			taskName:   "availability_zone",
-			itemLister: vpcService.getRegionAccounts,
+			itemLister: vpcService.getAllRegionAccounts,
 			workFunc:   vpcService.reconcileAvailabilityZonesRegionAccount,
 		},
 		{


### PR DESCRIPTION
This fixes the availability zone reconcilation loop to iterate through
all accounts (both Trunk ENIs and Branch ENIs). We specific detachment
function requires some information it derives from the trunk ENI account,
because the disassociation operation happens in that account.
