### PR TITLE
Added the first multi-container workload standalone test

### DIFF
--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -142,7 +142,7 @@ func setupSystemServices(parentCtx context.Context, c runtimeTypes.Container, cf
 	// TODO: Can we somehow make sure titus-container always starts first?
 	for _, svc := range sidecars {
 		if svc.EnabledCheck != nil && !svc.EnabledCheck(&cfg, c) {
-			logrus.Debugf("skipping sidecar %s, not enabled", svc.UnitName)
+			logrus.Debugf("skipping sidecar %s, not enabled", svc.ServiceName)
 			continue
 		}
 		if svc.UnitName == "" {


### PR DESCRIPTION
This adds a few more docker-for-mac workarounds, and then our
first multi-container workload test. This test should continue
to work regardless of the backend, but currently works
using the C&W implementation.