### PR TITLE
Use workload, not app, in v1 podspec annotations

### DIFF
--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -475,6 +475,11 @@ func (c *PodContainer) LogUploadThresholdTime() *time.Duration {
 }
 
 func (c *PodContainer) MetatronCreds() *titus.ContainerInfo_MetatronCreds {
+	if c.titusInfo != nil {
+		// ContainerInfo was passed in the attribute: return its copy of the creds
+		return c.titusInfo.MetatronCreds
+	}
+
 	if c.podConfig.WorkloadMetadata == nil || c.podConfig.WorkloadMetadataSig == nil {
 		return nil
 	}

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -176,8 +176,8 @@ func (c *PodContainer) AppArmorProfile() *string {
 }
 
 func (c *PodContainer) AppName() string {
-	if c.podConfig.AppName != nil {
-		return *c.podConfig.AppName
+	if c.podConfig.WorkloadName != nil {
+		return *c.podConfig.WorkloadName
 	}
 	return ""
 }
@@ -262,8 +262,8 @@ func (c *PodContainer) ContainerInfo() (*titus.ContainerInfo, error) {
 		},
 		JobGroupSequence: &seq,
 		MetatronCreds: &titus.ContainerInfo_MetatronCreds{
-			AppMetadata: c.podConfig.AppMetadata,
-			MetadataSig: c.podConfig.AppMetadataSig,
+			AppMetadata: c.podConfig.WorkloadMetadata,
+			MetadataSig: c.podConfig.WorkloadMetadataSig,
 		},
 		UserProvidedEnv:  userProvidedEnv,
 		TitusProvidedEnv: titusProvidedEnv,
@@ -389,22 +389,22 @@ func (c *PodContainer) IsSystemD() bool {
 }
 
 func (c *PodContainer) JobGroupDetail() string {
-	if c.podConfig.AppDetail != nil {
-		return *c.podConfig.AppDetail
+	if c.podConfig.WorkloadDetail != nil {
+		return *c.podConfig.WorkloadDetail
 	}
 	return ""
 }
 
 func (c *PodContainer) JobGroupStack() string {
-	if c.podConfig.AppStack != nil {
-		return *c.podConfig.AppStack
+	if c.podConfig.WorkloadStack != nil {
+		return *c.podConfig.WorkloadStack
 	}
 	return ""
 }
 
 func (c *PodContainer) JobGroupSequence() string {
-	if c.podConfig.AppSequence != nil {
-		return *c.podConfig.AppSequence
+	if c.podConfig.WorkloadSequence != nil {
+		return *c.podConfig.WorkloadSequence
 	}
 	return ""
 }
@@ -475,13 +475,13 @@ func (c *PodContainer) LogUploadThresholdTime() *time.Duration {
 }
 
 func (c *PodContainer) MetatronCreds() *titus.ContainerInfo_MetatronCreds {
-	if c.podConfig.AppMetadata == nil || c.podConfig.AppMetadataSig == nil {
+	if c.podConfig.WorkloadMetadata == nil || c.podConfig.WorkloadMetadataSig == nil {
 		return nil
 	}
 
 	return &titus.ContainerInfo_MetatronCreds{
-		AppMetadata: c.podConfig.AppMetadata,
-		MetadataSig: c.podConfig.AppMetadataSig,
+		AppMetadata: c.podConfig.WorkloadMetadata,
+		MetadataSig: c.podConfig.WorkloadMetadataSig,
 	}
 }
 
@@ -500,7 +500,7 @@ func (c *PodContainer) OomScoreAdj() *int32 {
 }
 
 func (c *PodContainer) OwnerEmail() *string {
-	return c.podConfig.AppOwnerEmail
+	return c.podConfig.WorkloadOwnerEmail
 }
 
 func (c *PodContainer) Process() ([]string, []string) {

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -152,11 +152,11 @@ func TestNewPodContainer(t *testing.T) {
 	}
 
 	addPodAnnotations(pod, map[string]string{
-		podCommon.AnnotationKeyAppName:                  testAppName,
-		podCommon.AnnotationKeyAppDetail:                testAppDetail,
-		podCommon.AnnotationKeyAppOwnerEmail:            testAppOwner,
-		podCommon.AnnotationKeyAppStack:                 testAppStack,
-		podCommon.AnnotationKeyAppSequence:              testAppSeq,
+		podCommon.AnnotationKeyWorkloadName:             testAppName,
+		podCommon.AnnotationKeyWorkloadDetail:           testAppDetail,
+		podCommon.AnnotationKeyWorkloadOwnerEmail:       testAppOwner,
+		podCommon.AnnotationKeyWorkloadStack:            testAppStack,
+		podCommon.AnnotationKeyWorkloadSequence:         testAppSeq,
 		podCommon.AnnotationKeyIAMRole:                  testIamRole,
 		podCommon.AnnotationKeyJobID:                    testJobID,
 		podCommon.AnnotationKeyJobType:                  "service",
@@ -600,13 +600,13 @@ func TestPodContainerClusterName(t *testing.T) {
 		assert.NilError(t, err)
 
 		if f.appName != "" {
-			pod.Annotations[podCommon.AnnotationKeyAppName] = f.appName
+			pod.Annotations[podCommon.AnnotationKeyWorkloadName] = f.appName
 		}
 		if f.jobGroupDetail != "" {
-			pod.Annotations[podCommon.AnnotationKeyAppDetail] = f.jobGroupDetail
+			pod.Annotations[podCommon.AnnotationKeyWorkloadDetail] = f.jobGroupDetail
 		}
 		if f.jobGroupStack != "" {
-			pod.Annotations[podCommon.AnnotationKeyAppStack] = f.jobGroupStack
+			pod.Annotations[podCommon.AnnotationKeyWorkloadStack] = f.jobGroupStack
 		}
 
 		c, err := NewPodContainer(pod, *conf)
@@ -714,10 +714,10 @@ func TestPodContainerEnvBasedOnTaskInfo(t *testing.T) {
 			name: "Full",
 			input: input{
 				annotations: map[string]string{
-					podCommon.AnnotationKeyAppName:     "app1",
-					podCommon.AnnotationKeyAppStack:    "stack1",
-					podCommon.AnnotationKeyAppDetail:   "detail1",
-					podCommon.AnnotationKeyAppSequence: "v001",
+					podCommon.AnnotationKeyWorkloadName:     "app1",
+					podCommon.AnnotationKeyWorkloadStack:    "stack1",
+					podCommon.AnnotationKeyWorkloadDetail:   "detail1",
+					podCommon.AnnotationKeyWorkloadSequence: "v001",
 				},
 				image:            "titusops/image1@" + testDigest,
 				cpu:              "1",
@@ -743,10 +743,10 @@ func TestPodContainerEnvBasedOnTaskInfo(t *testing.T) {
 			name: "NoName",
 			input: input{
 				annotations: map[string]string{
-					podCommon.AnnotationKeyAppName:     "image1",
-					podCommon.AnnotationKeyAppStack:    "stack1",
-					podCommon.AnnotationKeyAppDetail:   "detail1",
-					podCommon.AnnotationKeyAppSequence: "v001",
+					podCommon.AnnotationKeyWorkloadName:     "image1",
+					podCommon.AnnotationKeyWorkloadStack:    "stack1",
+					podCommon.AnnotationKeyWorkloadDetail:   "detail1",
+					podCommon.AnnotationKeyWorkloadSequence: "v001",
 				},
 				image:            "titusops/image1:latest",
 				cpu:              "2",
@@ -772,9 +772,9 @@ func TestPodContainerEnvBasedOnTaskInfo(t *testing.T) {
 			name: "NoStack",
 			input: input{
 				annotations: map[string]string{
-					podCommon.AnnotationKeyAppName:     "app1",
-					podCommon.AnnotationKeyAppDetail:   "detail1",
-					podCommon.AnnotationKeyAppSequence: "v001",
+					podCommon.AnnotationKeyWorkloadName:     "app1",
+					podCommon.AnnotationKeyWorkloadDetail:   "detail1",
+					podCommon.AnnotationKeyWorkloadSequence: "v001",
 				},
 				image:            "titusops/image1:latest",
 				cpu:              "3",
@@ -800,9 +800,9 @@ func TestPodContainerEnvBasedOnTaskInfo(t *testing.T) {
 			name: "NoDetail",
 			input: input{
 				annotations: map[string]string{
-					podCommon.AnnotationKeyAppName:     "app1",
-					podCommon.AnnotationKeyAppStack:    "stack1",
-					podCommon.AnnotationKeyAppSequence: "v001",
+					podCommon.AnnotationKeyWorkloadName:     "app1",
+					podCommon.AnnotationKeyWorkloadStack:    "stack1",
+					podCommon.AnnotationKeyWorkloadSequence: "v001",
 				},
 				image:            "titusops/image1:latest",
 				cpu:              "4",
@@ -828,9 +828,9 @@ func TestPodContainerEnvBasedOnTaskInfo(t *testing.T) {
 			name: "NoSequence",
 			input: input{
 				annotations: map[string]string{
-					podCommon.AnnotationKeyAppName:   "app1",
-					podCommon.AnnotationKeyAppStack:  "stack1",
-					podCommon.AnnotationKeyAppDetail: "detail1",
+					podCommon.AnnotationKeyWorkloadName:   "app1",
+					podCommon.AnnotationKeyWorkloadStack:  "stack1",
+					podCommon.AnnotationKeyWorkloadDetail: "detail1",
 				},
 				image:            "titusops/image1:latest",
 				cpu:              "5",
@@ -856,8 +856,8 @@ func TestPodContainerEnvBasedOnTaskInfo(t *testing.T) {
 			name: "NoStackNoDetail",
 			input: input{
 				annotations: map[string]string{
-					podCommon.AnnotationKeyAppName:     "app1",
-					podCommon.AnnotationKeyAppSequence: "v001",
+					podCommon.AnnotationKeyWorkloadName:     "app1",
+					podCommon.AnnotationKeyWorkloadSequence: "v001",
 				},
 				image:            "titusops/image1:latest",
 				cpu:              "6",
@@ -883,7 +883,7 @@ func TestPodContainerEnvBasedOnTaskInfo(t *testing.T) {
 			name: "NoStackNoDetailNoSequence",
 			input: input{
 				annotations: map[string]string{
-					podCommon.AnnotationKeyAppName: "app1",
+					podCommon.AnnotationKeyWorkloadName: "app1",
 				},
 				image:            "titusops/image1:latest",
 				cpu:              "7",
@@ -909,7 +909,7 @@ func TestPodContainerEnvBasedOnTaskInfo(t *testing.T) {
 			name: "NoNameNoStackNoDetailNoSequence",
 			input: input{
 				annotations: map[string]string{
-					podCommon.AnnotationKeyAppName: "image1",
+					podCommon.AnnotationKeyWorkloadName: "image1",
 				},
 				image:            "titusops/image1:latest",
 				cpu:              "8",
@@ -1402,16 +1402,16 @@ func TestContainerInfoGenerationAllFields(t *testing.T) {
 
 	addPodAnnotations(pod, map[string]string{
 		podCommon.AnnotationKeyPodTitusUserEnvVarsStartIndex: "2",
-		podCommon.AnnotationKeyAppName:                       testAppName,
-		podCommon.AnnotationKeyAppDetail:                     testAppDetail,
-		podCommon.AnnotationKeyAppOwnerEmail:                 testAppOwner,
-		podCommon.AnnotationKeyAppStack:                      testAppStack,
-		podCommon.AnnotationKeyAppSequence:                   testAppSeq,
+		podCommon.AnnotationKeyWorkloadName:                  testAppName,
+		podCommon.AnnotationKeyWorkloadDetail:                testAppDetail,
+		podCommon.AnnotationKeyWorkloadOwnerEmail:            testAppOwner,
+		podCommon.AnnotationKeyWorkloadStack:                 testAppStack,
+		podCommon.AnnotationKeyWorkloadSequence:              testAppSeq,
 		podCommon.AnnotationKeyIAMRole:                       testIamRole,
 		podCommon.AnnotationKeyJobAcceptedTimestampMs:        "44",
 		podCommon.AnnotationKeyJobID:                         testJobID,
-		podCommon.AnnotationKeySecurityAppMetadata:           "app-meta",
-		podCommon.AnnotationKeySecurityAppMetadataSig:        "meta-sig",
+		podCommon.AnnotationKeySecurityWorkloadMetadata:      "app-meta",
+		podCommon.AnnotationKeySecurityWorkloadMetadataSig:   "meta-sig",
 		podCommon.AnnotationKeyNetworkSecurityGroups:         "sg-1,sg-2",
 		// enable shell splitting to confirm that ContainerInfo returns the non-split version
 		podCommon.AnnotationKeyPodTitusEntrypointShellSplitting: "true",

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -390,7 +390,7 @@ func createPodTask(jobInput *JobInput, jobID string, task *runner.Task, env map[
 				podCommon.AnnotationKeyEgressBandwidth:  bandwidth.String(),
 				podCommon.AnnotationKeyIngressBandwidth: bandwidth.String(),
 				podCommon.AnnotationKeyLogKeepLocalFile: True,
-				podCommon.AnnotationKeyAppName:          defaultAppName,
+				podCommon.AnnotationKeyWorkloadName:     defaultAppName,
 				podCommon.AnnotationKeyJobID:            jobID,
 			},
 			Labels: map[string]string{},
@@ -488,8 +488,8 @@ func createPodTask(jobInput *JobInput, jobID string, task *runner.Task, env map[
 	}
 
 	if jobInput.MetatronEnabled {
-		pod.Annotations[podCommon.AnnotationKeySecurityAppMetadata] = "fake-metatron-app"
-		pod.Annotations[podCommon.AnnotationKeySecurityAppMetadataSig] = "fake-metatron-sig"
+		pod.Annotations[podCommon.AnnotationKeySecurityWorkloadMetadata] = "fake-metatron-app"
+		pod.Annotations[podCommon.AnnotationKeySecurityWorkloadMetadataSig] = "fake-metatron-sig"
 	}
 
 	task.Pod = pod

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -88,7 +88,7 @@ var (
 	}
 	userSet = testImage{
 		name: "titusoss/user-set",
-		tag:  "20190209-1549676483",
+		tag:  "20210524-1621898423",
 	}
 	systemdImage = testImage{
 		name: "titusoss/ubuntu-systemd-bionic",
@@ -1065,9 +1065,18 @@ func TestMetatron(t *testing.T) {
 		Version:         userSet.tag,
 		MetatronEnabled: true,
 		// The metatron test image writes out the task identity retrieved from the metadata service to `/task-identity`
-		EntrypointOld: fmt.Sprintf("/bin/bash -c \"cat /task-identity; grep %s /task-identity && grep jobAcceptedTimestampMs /task-identity | grep -E '[\\d+]'\"", t.Name()),
-		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		EntrypointOld: strings.Join([]string{
+			"/bin/bash -c \"",
+			"echo '-- task identity: begin --' ;",
+			"curl -isSH Accept:application/json http://169.254.169.254/nflx/v1/task-identity ;",
+			"echo '-- task identity: end --' ;",
+			"cat /task-identity ;",
+			"grep " + t.Name() + " /task-identity &&",
+			"grep jobAcceptedTimestampMs /task-identity | grep -E '[\\d+]'",
+			"\"",
+		}, " "),
+		JobID:      generateJobID(t.Name()),
+		UsePodSpec: shouldUsePodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Netflix/metrics-client-go v0.0.0-20171019173821-bb173f41fc07
 	github.com/Netflix/spectator-go v0.0.0-20190913215732-d4e0463555ef
 	github.com/Netflix/titus-api-definitions v0.0.1-rc9.0.20210426164010-ef784d356ff6
-	github.com/Netflix/titus-kube-common v0.14.0
+	github.com/Netflix/titus-kube-common v0.15.0
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
 	github.com/apex/log v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/Netflix/titus-kube-common v0.13.0 h1:4qU7z5NiMp1MmVZROm60iaT5S0GNC+Me
 github.com/Netflix/titus-kube-common v0.13.0/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
 github.com/Netflix/titus-kube-common v0.14.0 h1:fAYK/hrZMw1At2lW3C28kV41jEt1RU5dETint8RYTns=
 github.com/Netflix/titus-kube-common v0.14.0/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
+github.com/Netflix/titus-kube-common v0.15.0 h1:jcHHq91GM2iAGZdFBzQ7lIIVwawaFLhWWSGnogKQmzc=
+github.com/Netflix/titus-kube-common v0.15.0/go.mod h1:3l3FDJluNNzBlYmCDmFBN+8ClVqVE/kqtBlngQ4BIag=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
This is the executor side of https://github.com/Netflix/titus-kube-common/pull/18 - making the v1 pod spec annotations use "workload" instead of "app".