### PR TITLE
Re-enable sshd on scratch containers using a startup script

### DIFF
--- a/root/etc/apparmor.d/docker_fuse
+++ b/root/etc/apparmor.d/docker_fuse
@@ -43,9 +43,9 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
-/titus/sshd/usr/sbin/sshd Cx,
+/titus/sshd/usr/sbin/run-titus-sshd Cx,
 
-  profile sshd /titus/sshd/usr/sbin/sshd {
+  profile sshd /titus/sshd/usr/sbin/run-titus-sshd {
     signal (send,receive) peer=@{profile_name},
 
     network,

--- a/root/etc/apparmor.d/docker_titus
+++ b/root/etc/apparmor.d/docker_titus
@@ -31,9 +31,9 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
-  /titus/sshd/usr/sbin/sshd Cx,
+  /titus/sshd/usr/sbin/run-titus-sshd Cx,
 
-  profile sshd /titus/sshd/usr/sbin/sshd {
+  profile sshd /titus/sshd/usr/sbin/run-titus-sshd {
     # Allow signals from unconfined, usually systemd
     signal (receive) peer="unconfined",
     signal (send,receive) peer=@{profile_name},

--- a/root/lib/systemd/system/titus-sidecar-sshd@.service
+++ b/root/lib/systemd/system/titus-sidecar-sshd@.service
@@ -14,7 +14,7 @@ Environment=TITUS_PID_1_DIR=/var/lib/titus-inits/%i
 # get TSA help too. This environment variable ensures that will happen.
 Environment=TITUS_NSENTER_USE_TSA=true
 EnvironmentFile=/var/lib/titus-environments/%i.env
-ExecStart=/apps/titus-executor/bin/titus-nsenter /titus/sshd/usr/sbin/sshd -D -e
+ExecStart=/apps/titus-executor/bin/titus-nsenter /titus/sshd/usr/sbin/run-titus-sshd -D -e
 LimitNOFILE=65535
 ## TODO: Wire up more "lockdown" so this unit can't wreck havoc if it gets compromised
 PrivateTmp=yes


### PR DESCRIPTION
This re-enables the run-titus-sshd script which makes it
so we can ssh to scratch containers.

This was previously reverted because we were blocked on
updating the sshd image. Now that it is updated and deployed,
we can safely do this bump and enable sshd on scratch containers.

(or an container that doesn't have the things sshd needs, like
the nobody user, etc)
