### PR TITLE
Allow users to specific version of titus system sidecars

### DIFF
--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -991,6 +991,10 @@ func (c *TitusInfoContainer) SidecarConfigs() ([]*ServiceOpts, error) {
 		SidecarContainerTools:     c.config.ContainerToolsImage,
 	}
 
+	if c.pod != nil {
+		updateImageMapWithAttributeOverrides(sideCars, imageMap, c.pod.Annotations)
+	}
+
 	for _, scOrig := range sideCars {
 		// Make a copy to avoid mutating the original
 		sc := scOrig


### PR DESCRIPTION
This allows users or titus developers to specify the version
of a system sidecar (or set to be empty!).

This is useful for platform partners who want to unset sidecars,
allowing them to opt out if they want.

It also allows for sidecar developers to better iterate on them,
because they can override which version they want to use, so they
can canary a sidecar before anyone else sees it.

If shipit, I'll setup our functional tests to be able to set these
overrides, so that we can run our tests against sidecars that
are not even really deployed yet.

This override kinda already existed for servicemesh, but this generalizes
it to any sidecar.
