### PR TITLE
Use podEnv whenever there is at least 1 container

### DIFF
--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -615,9 +615,9 @@ func (c *TitusInfoContainer) Env() map[string]string {
 		if c.pod == nil {
 			return containerInfoEnv
 		}
-		// This is a "dumb" check -- that just makes sure 1 container exists so we don't null pointer exception
+		// This is a "dumb" check -- that just makes sure at least 1 container exists so we don't null pointer exception
 		// We probably don't want to blindly source env
-		if len(c.pod.Spec.Containers) != 1 {
+		if len(c.pod.Spec.Containers) == 0 {
 			return containerInfoEnv
 		}
 		if len(c.pod.Spec.Containers[0].Env) == 0 {


### PR DESCRIPTION
Now that we can have multiple containers in the pod,
we should always return the podEnv in that case.

I dare say we should never return containerInfoEnv?

----

The cinfo env was subtly different and wrong (didn't have `NETFLIX_ACCOUNT_ID`).