### PR TITLE
Refactor: Promote user and platform containers as real attributes of the runtime struct

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -126,6 +126,14 @@ type SidecarContainerConfig struct {
 	Volumes     map[string]struct{}
 }
 
+// ExtraContainer stores data about the other containers running alongside the
+// main container in the C&W implementation of pods
+type ExtraContainer struct {
+	Name        string           // Name of the container from the pod spec
+	ID          string           // Docker container id
+	V1Container corev1.Container // The k8s definition of the container from the pod object
+}
+
 type NFSMount struct {
 	Server     string
 	ServerPath string
@@ -151,6 +159,8 @@ type Container interface {
 	EnvOverrides() map[string]string
 	ElasticIPPool() *string
 	ElasticIPs() *string
+	ExtraUserContainers() []*ExtraContainer
+	ExtraPlatformContainers() []*ExtraContainer
 	FuseEnabled() bool
 	GPUInfo() GPUContainer
 	HostnameStyle() *string


### PR DESCRIPTION

In some sense, this is much cleaner than constantly parsing the pod object
all the time.

It does solidify the difference between user/platform containers,
hopefully that is a good thing.

Someday, the bit `Container` object can be broken down in to the job stuff
and the `UserContainers` can have all user containers, not just the
extra ones!

The reason for this refactor is to make it easier to store more methods
and attributes into the ExtraContainer struct to make it easy to do
bookkeeping with them. You can see the first thing that becomes
easier is tracking the container id for each one. I no longer need
and extra map hanging around just for that, and I can iterate over
the real objects instead of their names. Good stuff.
