### PR TITLE
Fix the titus-sshd aa profile to allow for scratch containers

### DIFF
--- a/root/etc/apparmor.d/docker_fuse
+++ b/root/etc/apparmor.d/docker_fuse
@@ -43,9 +43,29 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
-/titus/sshd/usr/sbin/run-titus-sshd Cx,
+  # Special sub-profile just for the init script for sshd
+  /titus/sshd/run-titus-sshd Cx,
+  profile run-sshd /titus/sshd/run-titus-sshd {
+    # We trust everything under /titus
+    # No writes though...
+    /titus/** rmlk,
+    /titus/sshd/usr/sbin/sshd ix,
 
-  profile sshd /titus/sshd/usr/sbin/run-titus-sshd {
+    # You're allowed to do anything with yourself
+    @{PROC}/@{pid}/** rwmlk,
+    @{PROC}/self/** rwmlk,
+
+    /dev/{null,ptmx,tty,urandom,log} rwmlk,
+    /dev/pts/* rwmlk,
+
+    /etc/{gai.conf,group,nsswitch.conf,shadow} rmkl,
+    # The ssh startup script does edit these files if they need modification for sshd to start
+    /etc/{passwd,profile} rwmlk,
+  }
+
+  # Once we are running, this is the profile that the sshd binary itself gets
+  /titus/sshd/usr/sbin/sshd Cx,
+  profile sshd /titus/sshd/usr/sbin/sshd {
     signal (send,receive) peer=@{profile_name},
 
     network,

--- a/root/etc/apparmor.d/docker_fuse
+++ b/root/etc/apparmor.d/docker_fuse
@@ -43,29 +43,35 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
+  /titus/sshd/usr/sbin/sshd Cx -> &docker_titus//exec-sshd,
+  /titus/sshd/run-titus-sshd Cx -> &docker_titus//sshd,
+
   # Special sub-profile just for the init script for sshd
-  /titus/sshd/run-titus-sshd Cx,
-  profile run-sshd /titus/sshd/run-titus-sshd {
-    # We trust everything under /titus
-    # No writes though...
-    /titus/** rmlk,
-    /titus/sshd/usr/sbin/sshd ix,
+  profile sshd /titus/sshd/run-titus-sshd {
 
-    # You're allowed to do anything with yourself
-    @{PROC}/@{pid}/** rwmlk,
-    @{PROC}/self/** rwmlk,
+    # The only two files the startup script needs to read
+    /titus/sshd/bin/busybox ixr,
+    /titus/sshd/run-titus-sshd r,
 
-    /dev/{null,ptmx,tty,urandom,log} rwmlk,
-    /dev/pts/* rwmlk,
+    # This script should only exec one thing, which should go back to the parent
+    # profile, which as its own transitions defined
+    /titus/sshd/usr/sbin/sshd Px -> docker_titus,
 
-    /etc/{gai.conf,group,nsswitch.conf,shadow} rmkl,
+    # Signals are required so that systemd can shut it down if needed
+    signal (receive) peer="unconfined",
+    signal (send,receive) peer=@{profile_name},
+
     # The ssh startup script does edit these files if they need modification for sshd to start
     /etc/{passwd,profile} rwmlk,
+    /var/ rw,
+    /var/log/ rw,
+    /var/log/lastlog rw,
   }
 
   # Once we are running, this is the profile that the sshd binary itself gets
-  /titus/sshd/usr/sbin/sshd Cx,
-  profile sshd /titus/sshd/usr/sbin/sshd {
+  profile exec-sshd /titus/sshd/usr/sbin/sshd {
+    # Signals are required so that systemd can shut it down if needed
+    signal (receive) peer="unconfined",
     signal (send,receive) peer=@{profile_name},
 
     network,
@@ -74,7 +80,6 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
     # We trust everything under /titus
     # No writes though...
     /titus/** rmlk,
-    /titus/sshd/usr/sbin/sshd ix,
 
     # I don't think that memory mapping, or locking can lead to any attacks
     /** mk,
@@ -91,9 +96,7 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
     /dev/{null,ptmx,tty,urandom,log} rwmlk,
     /dev/pts/* rwmlk,
 
-    /etc/{gai.conf,group,nsswitch.conf,shadow} rmkl,
-    # The ssh startup script does edit these files if they need modification for sshd to start
-    /etc/{passwd,profile} rwmlk,
+    /etc/{gai.conf,group,nsswitch.conf,passwd,shadow} rmkl,
   }
 }
 

--- a/root/etc/apparmor.d/docker_fuse
+++ b/root/etc/apparmor.d/docker_fuse
@@ -71,7 +71,9 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
     /dev/{null,ptmx,tty,urandom,log} rwmlk,
     /dev/pts/* rwmlk,
 
-    /etc/{gai.conf,group,nsswitch.conf,passwd,shadow} rmkl,
+    /etc/{gai.conf,group,nsswitch.conf,shadow} rmkl,
+    # The ssh startup script does edit these files if they need modification for sshd to start
+    /etc/{passwd,profile} rwmlk,
   }
 }
 

--- a/root/etc/apparmor.d/docker_titus
+++ b/root/etc/apparmor.d/docker_titus
@@ -31,9 +31,29 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
+  # Special sub-profile just for the init script for sshd
   /titus/sshd/run-titus-sshd Cx,
+  profile run-sshd /titus/sshd/run-titus-sshd {
+    # We trust everything under /titus
+    # No writes though...
+    /titus/** rmlk,
+    /titus/sshd/usr/sbin/sshd ix,
 
-  profile sshd /titus/sshd/run-titus-sshd {
+    # You're allowed to do anything with yourself
+    @{PROC}/@{pid}/** rwmlk,
+    @{PROC}/self/** rwmlk,
+
+    /dev/{null,ptmx,tty,urandom,log} rwmlk,
+    /dev/pts/* rwmlk,
+
+    /etc/{gai.conf,group,nsswitch.conf,shadow} rmkl,
+    # The ssh startup script does edit these files if they need modification for sshd to start
+    /etc/{passwd,profile} rwmlk,
+  }
+
+  # Once we are running, this is the profile that the sshd binary itself gets
+  /titus/sshd/usr/sbin/sshd Cx,
+  profile sshd /titus/sshd/usr/sbin/sshd {
     # Allow signals from unconfined, usually systemd
     signal (receive) peer="unconfined",
     signal (send,receive) peer=@{profile_name},
@@ -61,9 +81,7 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
     /dev/{null,ptmx,tty,urandom,log} rwmlk,
     /dev/pts/* rwmlk,
 
-    /etc/{gai.conf,group,nsswitch.conf,shadow} rmkl,
-    # The ssh startup script does edit these files if they need modification for sshd to start
-    /etc/{passwd,profile} rwmlk,
+    /etc/{gai.conf,group,nsswitch.conf,passwd,shadow} rmkl,
   }
 
 }

--- a/root/etc/apparmor.d/docker_titus
+++ b/root/etc/apparmor.d/docker_titus
@@ -31,29 +31,33 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
 
   deny /titus/** wl,
 
+  /titus/sshd/usr/sbin/sshd Cx -> &docker_titus//exec-sshd,
+  /titus/sshd/run-titus-sshd Cx -> &docker_titus//sshd,
+
   # Special sub-profile just for the init script for sshd
-  /titus/sshd/run-titus-sshd Cx,
-  profile run-sshd /titus/sshd/run-titus-sshd {
-    # We trust everything under /titus
-    # No writes though...
-    /titus/** rmlk,
-    /titus/sshd/usr/sbin/sshd ix,
+  profile sshd /titus/sshd/run-titus-sshd {
 
-    # You're allowed to do anything with yourself
-    @{PROC}/@{pid}/** rwmlk,
-    @{PROC}/self/** rwmlk,
+    # The only two files the startup script needs to read
+    /titus/sshd/bin/busybox ixr,
+    /titus/sshd/run-titus-sshd r,
 
-    /dev/{null,ptmx,tty,urandom,log} rwmlk,
-    /dev/pts/* rwmlk,
+    # This script should only exec one thing, which should go back to the parent
+    # profile, which as its own transitions defined
+    /titus/sshd/usr/sbin/sshd Px -> docker_titus,
 
-    /etc/{gai.conf,group,nsswitch.conf,shadow} rmkl,
+    # Signals are required so that systemd can shut it down if needed
+    signal (receive) peer="unconfined",
+    signal (send,receive) peer=@{profile_name},
+
     # The ssh startup script does edit these files if they need modification for sshd to start
     /etc/{passwd,profile} rwmlk,
+    /var/ rw,
+    /var/log/ rw,
+    /var/log/lastlog rw,
   }
 
   # Once we are running, this is the profile that the sshd binary itself gets
-  /titus/sshd/usr/sbin/sshd Cx,
-  profile sshd /titus/sshd/usr/sbin/sshd {
+  profile exec-sshd /titus/sshd/usr/sbin/sshd {
     # Allow signals from unconfined, usually systemd
     signal (receive) peer="unconfined",
     signal (send,receive) peer=@{profile_name},
@@ -64,7 +68,6 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
     # We trust everything under /titus
     # No writes though...
     /titus/** rmlk,
-    /titus/sshd/usr/sbin/sshd ix,
 
     # I don't think that memory mapping, or locking can lead to any attacks
     /** mk,
@@ -83,5 +86,4 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
 
     /etc/{gai.conf,group,nsswitch.conf,passwd,shadow} rmkl,
   }
-
 }

--- a/root/etc/apparmor.d/docker_titus
+++ b/root/etc/apparmor.d/docker_titus
@@ -61,6 +61,9 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
     /dev/{null,ptmx,tty,urandom,log} rwmlk,
     /dev/pts/* rwmlk,
 
-    /etc/{gai.conf,group,nsswitch.conf,passwd,shadow} rmkl,
+    /etc/{gai.conf,group,nsswitch.conf,shadow} rmkl,
+    # The ssh startup script does edit these files if they need modification for sshd to start
+    /etc/{passwd,profile} rwmlk,
   }
+
 }


### PR DESCRIPTION
For scratch containers, the run-titus-sshd touches

* /etc/passwd
* /etc/profile

(and a few other files, but those are the sensitive ones)
For sshd to startup properly.

The AA profile was blocking those, and whatever testing I was
doing before where it works must have had AA off or in complain mode.
