### PR TITLE
Up the EBS attach/detach timeout from 20 to 60 seconds

### DIFF
--- a/cmd/titus-storage/ebs.go
+++ b/cmd/titus-storage/ebs.go
@@ -130,8 +130,8 @@ func ebsStop(ctx context.Context, ec2Client *ec2.EC2, c MountConfig, ec2Instance
 	// *Sometimes* ebsStop gets called *defore* a container dies, but *after* a *different* container
 	// comes up, see it is attached, and mounts. In this case we need to still panic here, but it is "ok"
 	// In that situation we should not continue to detach a volume out from underneath it
-	l.Printf("Waiting up to %d seconds for %s to be not in use...", 30, actualDeviceName)
-	err = waitForDeviceToBeNotInUse(actualDeviceName, 30)
+	l.Printf("Waiting up to %d seconds for %s to be not in use...", 60, actualDeviceName)
+	err = waitForDeviceToBeNotInUse(actualDeviceName, 60)
 	if err != nil {
 		return fmt.Errorf("Not detaching volume: %s", err)
 	}
@@ -249,7 +249,7 @@ func waitForDeviceToDisappear(ctx context.Context, driveName string, maxAttempts
 func waitForDriveToExistWithTimeout(driveName string, maxAttempts int) error {
 	var attempts int
 	for !doesDriveExist(driveName) {
-		time.Sleep(2 * time.Second)
+		time.Sleep(6 * time.Second)
 		attempts++
 		if attempts >= maxAttempts {
 			return fmt.Errorf("drive %s still does't exist after waiting %d seconds", driveName, attempts*2)
@@ -319,7 +319,7 @@ func attachEBS(ctx context.Context, ebsVolumeID string, ec2Client *ec2.EC2, inst
 		return "", err
 	}
 	l.Printf("volAttachments status after AttachVolume: %+v", volAttachments)
-	l.Printf("Now waiting for device to exist as ec2Device name %s", ec2DeviceName)
+	l.Printf("Now waiting up to 60 seconds for device to exist as ec2Device name %s", ec2DeviceName)
 	err = waitForDriveToExistWithTimeout(ec2DeviceName, 10)
 	if err != nil {
 		return "", err

--- a/cmd/titus-storage/mount.go
+++ b/cmd/titus-storage/mount.go
@@ -56,6 +56,8 @@ func mountBlockDeviceInContainer(ctx context.Context, mc MountCommand) error {
 	return cmd.Run()
 }
 
+// waitForDeviceToBeNotInUse polls once a second to see if a unix device
+// file to see if it is "in use" aka mounted.
 func waitForDeviceToBeNotInUse(device string, timeout int) error {
 	for attempts := 0; attempts < timeout; attempts++ {
 		inUse, err := deviceIsInUse(device)


### PR DESCRIPTION
I think we just need to give it more time to reduce
flakiness in our tests and the user experience.