### PR TITLE
Make prefix length of IPv6 addresses the same

### DIFF
--- a/vpc/service/assign_addresses_v3.go
+++ b/vpc/service/assign_addresses_v3.go
@@ -1145,7 +1145,7 @@ func assignArbitraryIPv6AddressV3(ctx context.Context, tx *sql.Tx, branchENI *ec
 		Address: &vpcapi.Address{
 			Address: aws.StringValue(output.AssignedIpv6Addresses[0]),
 		},
-		PrefixLength: uint32(64),
+		PrefixLength: uint32(128),
 	}, nil
 }
 


### PR DESCRIPTION
Right now, there's a bug where if we assign an address using
new IPv6 addresses on an interface, we install a /64, versus
a /128.
