### PR TITLE
Refactor logic around log / filesystem watcher shutdown

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -326,6 +326,7 @@ func (r *Runner) doShutdown(ctx context.Context, lastUpdate update) { // nolint:
 
 	ctx, span := trace.StartSpan(ctx, "doShutdown")
 	defer span.End()
+	span.AddAttributes(trace.BoolAttribute("wasKiled", r.wasKilled()))
 
 	logger.G(ctx).WithField("lastUpdate", lastUpdate).WithField("wasKilled", r.wasKilled()).Debug("Handling shutdown")
 	var errs *multierror.Error
@@ -351,7 +352,7 @@ func (r *Runner) doShutdown(ctx context.Context, lastUpdate update) { // nolint:
 	}
 
 	if r.watcher != nil {
-		if err := r.watcher.Stop(); err != nil {
+		if err := r.watcher.Stop(ctx); err != nil {
 			logger.G(ctx).Error("Error while shutting down watcher for: ", err)
 			errs = multierror.Append(errs, err)
 		}

--- a/filesystems/watcher_test.go
+++ b/filesystems/watcher_test.go
@@ -100,11 +100,11 @@ func TestWatcher(t *testing.T) {
 
 	verifyTestWatcher(destLoc, t)
 
-	assert.NoError(t, w.Stop())
+	assert.NoError(t, w.Stop(context.TODO()))
 	if err != nil {
 		t.Fatal("Could not stop watcher: ", err)
 	}
-	assert.NoError(t, w.Stop(), "Stopping the watcher a second time did something odd")
+	assert.NoError(t, w.Stop(context.TODO()), "Stopping the watcher a second time did something odd")
 }
 
 func verifyTestWatcher(destLoc string, t *testing.T) {
@@ -193,7 +193,7 @@ func TestDoubleUpload(t *testing.T) { // nolint: gocyclo
 		t.Fatal(err)
 	}
 
-	err = w.Stop()
+	err = w.Stop(context.TODO())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,7 +377,7 @@ func testLogRotateMain(tmpLogDir, destLogDir string, t *testing.T) {
 	w, buf := setupLogRotate(tmpLogDir, destLogDir, t)
 	checkOngoingLogRotate(tmpLogDir, destLogDir, buf, t)
 
-	err := w.Stop()
+	err := w.Stop(context.TODO())
 	if err != nil {
 		t.Fatal("Could not stop watcher: ", err)
 	}


### PR DESCRIPTION
1. This changes where the final upload occurs, from a call stack
   perspective. This is so the Zipkin traces look "right".
2. This removes the duplicated upload logic from the final
   upload function, again, so we can get a per-file breakdown
   of uploads.

