### PR TITLE
Added new TITUS_HOST_EC2_INSTANCE_ID var

### DIFF
--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -1144,6 +1144,12 @@ func populateContainerEnv(c Container, config config.Config, userEnv map[string]
 		env[key] = value
 	}
 
+	// This variable comes early from the host, and later is overwritten
+	// by other env variables injected from the control plane.
+	// We save it here because it is useful to "leak" the true
+	// instance ID we are running on for other infrastructure tools
+	env["TITUS_HOST_EC2_INSTANCE_ID"] = env["EC2_INSTANCE_ID"]
+
 	resources := c.Resources()
 	// Resource environment variables
 	env["TITUS_NUM_MEM"] = itoa(resources.Mem)

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -318,6 +318,7 @@ func TestNewPodContainer(t *testing.T) {
 		"NETFLIX_DETAIL":                    "appDetail",
 		"NETFLIX_STACK":                     "appStack",
 		"TITUS_BATCH":                       "idle",
+		"TITUS_HOST_EC2_INSTANCE_ID":        "",
 		"TITUS_CONTAINER_ID":                taskID,
 		"TITUS_IAM_ROLE":                    testIamRole,
 		"TITUS_IMAGE_DIGEST":                imgDigest,


### PR DESCRIPTION
Months ago we decieded to set EC2_INSTANCE_ID==taskid in containers
for backwards compatibility with EC2 migrators.

Making EC2_INSTANCE_ID==titus_host_instance_id seemed just plain wrong,
and screwed up lots of logging and metrics.

But, we still want to leak the "real" ec2 instance id for advanced
debugging and telemetry.

This new TITUS_HOST_EC2_INSTANCE_ID variable does that.
