### PR TITLE
Added Pod status container statuses for multiple containers

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -129,9 +129,9 @@ type SidecarContainerConfig struct {
 // ExtraContainer stores data about the other containers running alongside the
 // main container in the C&W implementation of pods
 type ExtraContainer struct {
-	Name        string           // Name of the container from the pod spec
-	ID          string           // Docker container id
-	V1Container corev1.Container // The k8s definition of the container from the pod object
+	Name        string                 // Name of the container from the pod spec
+	V1Container corev1.Container       // The k8s definition of the container from the pod object
+	Status      corev1.ContainerStatus // Status of the container, shows up in podstatus
 }
 
 type NFSMount struct {

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -1356,7 +1356,7 @@ func TestMultiContainerDoesPlatformFirst(t *testing.T) {
 func TestBasicMultiContainerFailingHealthcheck(t *testing.T) {
 	wrapTestStandalone(t)
 	skipIfNotPod(t)
-	testEntrypointOld := `/bin/sleep 21`
+	testEntrypointOld := `/bin/sleep 10`
 	badHealthcheckCommand := corev1.ExecAction{
 		Command: []string{"/bin/false"},
 	}


### PR DESCRIPTION
Ever inching towards the multi-container world.

This plubming makes it so we can track the status
of the other non-main containers.

I'm not sending additional pod updates, however.
I'm concerned about overwhelming the API server.

But, when it is updated, I should be able to see the podstatus
via kubectl and actually see how my sidecars are doing.

Next steps after this are:
1. Add docker event watchers to actually update the status after `start`.
   Optionally killing and restarting containers

2. Update the Titus API so that we can actually get the containerstatus's
   all the way back to the user (so one doesn't have to use kubectl)
