### PR TITLE
Made `/titus/run/pod.json` the "Downward API"

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -164,6 +165,7 @@ func NewDockerRuntime(ctx context.Context, m metrics.Reporter, dockerCfg Config,
 	// We bind-mount tini in as /sbin/docker-init to ensure we can always
 	// depend on it being there, regardless of the host docker configuration.
 	defaultBindMounts := []string{dockerCfg.tiniPath + ":/sbin/docker-init:ro"}
+	defaultBindMounts = append(defaultBindMounts, filepath.Join(cfg.RuntimeDir, "pod.json")+":/titus/run/pod.json:ro")
 
 	pidCgroupPath, err := getOwnCgroup("pids")
 	if err != nil {
@@ -1447,6 +1449,7 @@ func (r *DockerRuntime) Start(parentCtx context.Context, pod *v1.Pod) (string, *
 			IsRoutableIP: true,
 			IPAddress:    ipv4addr.Address.Address,
 			EniIPAddress: ipv4addr.Address.Address,
+			NetworkMode:  r.c.EffectiveNetworkMode(),
 			ResourceID:   fmt.Sprintf("resource-eni-%d", allocation.DeviceIndex()-1),
 			EniID:        eni.NetworkInterfaceId,
 		},
@@ -1713,6 +1716,12 @@ func (r *DockerRuntime) k8sContainerToDockerConfigs(v1Container v1.Container, ma
 			Source:   r.dockerCfg.tiniPath,
 			ReadOnly: true,
 			Target:   "/sbin/docker-init",
+		},
+		{
+			Type:     "bind",
+			Source:   path.Join(r.cfg.RuntimeDir, "pod.json"),
+			ReadOnly: true,
+			Target:   "/titus/run/pod.json",
 		},
 	}
 	if mainContainerRoot != "" {

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -473,6 +473,7 @@ type NetworkConfigurationDetails struct {
 	ElasticIPAddress string
 	EniIPAddress     string
 	EniIPv6Address   string
+	NetworkMode      string
 	EniID            string
 	ResourceID       string
 }
@@ -490,7 +491,7 @@ func (n *NetworkConfigurationDetails) ToMap() map[string]string {
 	if n.ElasticIPAddress != "" {
 		m["ElasticIPAddress"] = n.ElasticIPAddress
 	}
-
+	m["NetworkMode"] = n.NetworkMode
 	return m
 }
 

--- a/executor/standalone/gpu_test.go
+++ b/executor/standalone/gpu_test.go
@@ -7,7 +7,10 @@ import (
 	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
 )
 
-const gpuTestRuntime = "fake-gpu-runtime"
+const (
+	gpuTestRuntime = "fake-gpu-runtime"
+	devNull        = "/dev/null"
+)
 
 var (
 	_ runtimeTypes.GPUManager = (*gpuManager)(nil)
@@ -42,7 +45,7 @@ func (g *gpuContainer) Env() map[string]string {
 func (g *gpuContainer) Devices() []string {
 	ret := make([]string, g.devices)
 	for i := 0; i < g.devices; i++ {
-		ret[i] = "/dev/null"
+		ret[i] = devNull
 	}
 	return ret
 }

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -235,8 +235,7 @@ func (jobRunResponse *JobRunResponse) logContainerStdErrOut() {
 
 }
 
-// GenerateConfigs generates test configs
-func GenerateConfigs(jobInput *JobInput) (*config.Config, *docker.Config) {
+func GenerateTestConfigs(jobInput *JobInput) (*config.Config, *docker.Config) {
 	configArgs := []string{"--copy-uploader", logUploadDir}
 
 	logViewerEnabled := false
@@ -264,7 +263,6 @@ func GenerateConfigs(jobInput *JobInput) (*config.Config, *docker.Config) {
 	if err != nil {
 		panic(err)
 	}
-
 	cfg.ContainerLogViewer = logViewerEnabled
 	cfg.LogViewerServiceImage = logViewerTestImage
 	cfg.MetatronEnabled = metatronEnabled
@@ -279,7 +277,7 @@ func GenerateConfigs(jobInput *JobInput) (*config.Config, *docker.Config) {
 		cfg.DockerRegistry = "docker-hub.netflix.net"
 		// during full docker-in-docker tests, the titus agent touches the default file
 		// for darwin, we can just use /dev/null and it is fine, but it must be *some* file
-		cfg.ContainerSSHDCAFile = "/dev/null"
+		cfg.ContainerSSHDCAFile = devNull
 	}
 
 	// This ensures that under test we are using the tini that is part of our build,
@@ -508,9 +506,9 @@ func createPodTask(jobInput *JobInput, jobID string, task *runner.Task, env map[
 	return nil
 }
 
-// StartJob starts a job and returns once the job is started
-func StartJob(t *testing.T, ctx context.Context, jobInput *JobInput) (*JobRunResponse, error) { // nolint: gocyclo,golint
-	cfg, dockerCfg := GenerateConfigs(jobInput)
+// StartTestTask starts a job and returns once the job is started
+func StartTestTask(t *testing.T, ctx context.Context, jobInput *JobInput) (*JobRunResponse, error) { // nolint: gocyclo,golint
+	cfg, dockerCfg := GenerateTestConfigs(jobInput)
 
 	log.SetLevel(log.DebugLevel)
 	// Create an executor
@@ -634,7 +632,7 @@ func RunJobExpectingSuccess(t *testing.T, jobInput *JobInput) bool {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	jobResult, err := StartJob(t, ctx, jobInput)
+	jobResult, err := StartTestTask(t, ctx, jobInput)
 	assert.NilError(t, err)
 
 	defer jobResult.StopExecutor()
@@ -646,7 +644,7 @@ func RunJobExpectingFailure(t *testing.T, jobInput *JobInput) bool {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	jobResult, err := StartJob(t, ctx, jobInput)
+	jobResult, err := StartTestTask(t, ctx, jobInput)
 	assert.NilError(t, err)
 
 	defer jobResult.StopExecutor()
@@ -658,7 +656,7 @@ func RunJob(t *testing.T, jobInput *JobInput) (string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	jobResult, err := StartJob(t, ctx, jobInput)
+	jobResult, err := StartTestTask(t, ctx, jobInput)
 	assert.NilError(t, err)
 
 	return jobResult.WaitForCompletion()
@@ -669,7 +667,7 @@ func StartJobExpectingFailure(t *testing.T, jobInput *JobInput) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	jobResult, err := StartJob(t, ctx, jobInput)
+	jobResult, err := StartTestTask(t, ctx, jobInput)
 
 	if jobResult != nil {
 		defer jobResult.StopExecutor()

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -126,7 +126,7 @@ func generateJobID(testName string) string {
 }
 
 func dockerImageRemove(t *testing.T, imgName string) {
-	cfg, dockerCfg := GenerateConfigs(nil)
+	cfg, dockerCfg := GenerateTestConfigs(nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -146,7 +146,7 @@ func dockerImageRemove(t *testing.T, imgName string) {
 }
 
 func dockerPull(t *testing.T, imgName string, imgDigest string) (*dockerTypes.ImageInspect, error) {
-	cfg, dockerCfg := GenerateConfigs(nil)
+	cfg, dockerCfg := GenerateTestConfigs(nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -238,7 +238,7 @@ func TestInvalidFlatStringAsCmd(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
-	jobResponse, err := StartJob(t, ctx, ji)
+	jobResponse, err := StartTestTask(t, ctx, ji)
 	require.NoError(t, err)
 	if err := jobResponse.WaitForFailureWithStatus(ctx, 127); err != nil {
 		t.Fatal(err)
@@ -275,7 +275,7 @@ func TestEntrypointAndCmdFromImage(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
-	jobResponse, err := StartJob(t, ctx, ji)
+	jobResponse, err := StartTestTask(t, ctx, ji)
 	require.NoError(t, err)
 	if err := jobResponse.WaitForFailureWithStatus(ctx, 123); err != nil {
 		t.Fatal(err)
@@ -295,7 +295,7 @@ func TestOverrideCmdFromImage(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
-	jobResponse, err := StartJob(t, ctx, ji)
+	jobResponse, err := StartTestTask(t, ctx, ji)
 	require.NoError(t, err)
 	if err := jobResponse.WaitForFailureWithStatus(ctx, 5); err != nil {
 		t.Fatal(err)
@@ -317,7 +317,7 @@ func TestResetEntrypointFromImage(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
-	jobResponse, err := StartJob(t, ctx, ji)
+	jobResponse, err := StartTestTask(t, ctx, ji)
 	require.NoError(t, err)
 	if err := jobResponse.WaitForFailureWithStatus(ctx, 6); err != nil {
 		t.Fatal(err)
@@ -538,7 +538,7 @@ func TestCancelPullBigImage(t *testing.T) { // nolint: gocyclo
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	jobResponse, err := StartJob(t, ctx, &JobInput{
+	jobResponse, err := StartTestTask(t, ctx, &JobInput{
 		JobID:      generateJobID(t.Name()),
 		ImageName:  bigImage.name,
 		Version:    bigImage.tag,
@@ -641,7 +641,7 @@ func TestShutdown(t *testing.T) {
 		UsePodSpec:    UseV1PodspecInTest,
 	}
 
-	jobRunner, err := StartJob(t, ctx, ji)
+	jobRunner, err := StartTestTask(t, ctx, ji)
 	require.NoError(t, err)
 	defer jobRunner.StopExecutor()
 
@@ -752,7 +752,7 @@ func testTerminateTimeoutWrapped(t *testing.T, jobID string, killWaitSeconds uin
 		UsePodSpec:      UseV1PodspecInTest,
 	}
 	// Start the executor
-	jobResponse, err := StartJob(t, ctx, ji)
+	jobResponse, err := StartTestTask(t, ctx, ji)
 	require.NoError(t, err)
 	defer jobResponse.StopExecutorAsync()
 
@@ -840,7 +840,7 @@ func TestOOMKill(t *testing.T) {
 	}
 
 	// Start the executor
-	jobResponse, err := StartJob(t, ctx, ji)
+	jobResponse, err := StartTestTask(t, ctx, ji)
 	require.NoError(t, err)
 	defer jobResponse.StopExecutorAsync()
 
@@ -1116,7 +1116,7 @@ func TestMetatronFailure(t *testing.T) {
 		UsePodSpec: UseV1PodspecInTest,
 	}
 
-	jobResponse, err := StartJob(t, ctx, ji)
+	jobResponse, err := StartTestTask(t, ctx, ji)
 	require.NoError(t, err)
 	defer jobResponse.StopExecutor()
 
@@ -1259,7 +1259,7 @@ func TestGPUManager1GPU(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
 
-	jobResult, err := StartJob(t, ctx, ji)
+	jobResult, err := StartTestTask(t, ctx, ji)
 	assert.Nil(t, err)
 
 	require.True(t, jobResult.WaitForSuccess())


### PR DESCRIPTION
We need to be very sure this is the API we want to support,
it is hard to take back once we do it.

I do like the idea of files though.

This change adds `/titus/run/pod.json`, as a bind mount
to the container. It does get updated as VK changes it,
which is useful for processes inside that need to ask
"are we healthy?".

----

While this "works", the file cannot be read because outside the container it is 600 because we use `tempFile`:

```
// The file's permissions will be 0600 by default. You can change these by
// explicitly calling Chmod on the returned PendingFile.
```

If shipit, I'll make a PR to VK to do 644.