### PR TITLE
Refactor: Always assume we have a pod object to work with

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -178,9 +178,6 @@ func (r *Runner) prepareContainer(ctx context.Context) update {
 }
 
 func getContainerNames(pod *v1.Pod) []string {
-	if pod == nil || pod.Spec.Containers == nil {
-		return []string{"main"}
-	}
 	names := []string{}
 	for _, c := range pod.Spec.Containers {
 		names = append(names, c.Name)

--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -164,6 +164,7 @@ func TestSendTerminalStatusUntilCleanup(t *testing.T) {
 		Gpu:       0,
 		Disk:      1,
 		Network:   1,
+		Pod:       runtimeTypes.GenerateV0TestPod(taskID, nil, nil),
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
 		r.c = c
@@ -244,6 +245,7 @@ func TestCancelDuringPrepare(t *testing.T) { // nolint: gocyclo
 		Gpu:       0,
 		Disk:      1,
 		Network:   1,
+		Pod:       runtimeTypes.GenerateV0TestPod(taskID, nil, nil),
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
 		r.c = c
@@ -336,6 +338,7 @@ func TestSendRedundantStatusMessage(t *testing.T) { // nolint: gocyclo
 		Gpu:       0,
 		Disk:      1,
 		Network:   1,
+		Pod:       runtimeTypes.GenerateV0TestPod(taskID, nil, nil),
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
 		r.c = c

--- a/executor/runtime/docker/capabilities_test.go
+++ b/executor/runtime/docker/capabilities_test.go
@@ -14,9 +14,9 @@ const (
 )
 
 func TestDefaultProfileContainerInfo(t *testing.T) {
-	taskID, titusInfo, resources, _, conf, err := runtimeTypes.ContainerTestArgs()
+	taskID, titusInfo, resources, pod, conf, err := runtimeTypes.ContainerTestArgs()
 	assert.NoError(t, err)
-	c, err := runtimeTypes.NewContainer(taskID, titusInfo, *resources, *conf)
+	c, err := runtimeTypes.NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	hostConfig := container.HostConfig{}
 
@@ -47,7 +47,8 @@ func TestFuseProfileContainerInfo(t *testing.T) {
 	taskID, titusInfo, resources, _, conf, err := runtimeTypes.ContainerTestArgs()
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[runtimeTypes.FuseEnabledParam] = True
-	c, err := runtimeTypes.NewContainer(taskID, titusInfo, *resources, *conf)
+	pod := runtimeTypes.GenerateV0TestPod(taskID, resources, conf)
+	c, err := runtimeTypes.NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	hostConfig := container.HostConfig{}
 

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -183,22 +183,15 @@ type TitusInfoContainer struct {
 	config config.Config
 }
 
-// NewContainer allocates and initializes a new container struct object
-func NewContainer(taskID string, titusInfo *titus.ContainerInfo, resources Resources, cfg config.Config) (Container, error) {
-	return NewContainerWithPod(taskID, titusInfo, resources, cfg, nil)
-}
-
 // NewContainerWithPod allocates and initializes a new container struct object. Pod can be optionally passed. If nil, ignored
 func NewContainerWithPod(taskID string, titusInfo *titus.ContainerInfo, resources Resources, cfg config.Config, pod *corev1.Pod) (Container, error) {
-	if pod != nil {
-		schemaVer, err := podCommon.PodSchemaVersion(pod)
-		if err != nil {
-			return nil, err
-		}
+	schemaVer, err := podCommon.PodSchemaVersion(pod)
+	if err != nil {
+		return nil, err
+	}
 
-		if schemaVer > 0 {
-			return NewPodContainer(pod, cfg)
-		}
+	if schemaVer > 0 {
+		return NewPodContainer(pod, cfg)
 	}
 
 	return NewTitusInfoContainer(taskID, titusInfo, resources, cfg, pod)
@@ -216,22 +209,16 @@ func NewTitusInfoContainer(taskID string, titusInfo *titus.ContainerInfo, resour
 		config:       cfg,
 	}
 
-	if pod != nil {
-		c.pod = pod.DeepCopy()
-	}
+	c.pod = pod.DeepCopy()
 
-	if c.pod != nil {
-		c.extraUserContainers, c.extraPlatformContainers = NewExtraContainersFromPod(*c.pod)
-	}
+	c.extraUserContainers, c.extraPlatformContainers = NewExtraContainersFromPod(*c.pod)
 
 	c.podConfig = &podCommon.Config{}
-	if c.pod != nil {
-		pConf, err := podCommon.PodToConfig(pod)
-		if err != nil {
-			return nil, err
-		}
-		c.podConfig = pConf
+	pConf, err := podCommon.PodToConfig(pod)
+	if err != nil {
+		return nil, err
 	}
+	c.podConfig = pConf
 
 	if eniLabel := networkCfgParams.GetEniLabel(); eniLabel != "" {
 		titusENIIndex, err := strconv.Atoi(networkCfgParams.GetEniLabel())

--- a/executor/runtime/types/container_test.go
+++ b/executor/runtime/types/container_test.go
@@ -17,14 +17,14 @@ import (
 )
 
 func TestImageNameWithTag(t *testing.T) {
-	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, pod, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
 	expected := "docker.io/titusoss/alpine:latest"
 	titusInfo.ImageName = protobuf.String("titusoss/alpine")
 	titusInfo.Version = protobuf.String("latest")
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	if got := c.QualifiedImageName(); got != expected {
 		t.Fatalf("Expected %s, got %s", expected, got)
@@ -32,20 +32,20 @@ func TestImageNameWithTag(t *testing.T) {
 }
 
 func TestImageTagLatestByDefault(t *testing.T) {
-	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, pod, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
 	expected := "docker.io/titusoss/alpine:latest"
 	titusInfo.ImageName = protobuf.String("titusoss/alpine")
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	if got := c.QualifiedImageName(); got != expected {
 		t.Fatalf("Expected %s, got %s", expected, got)
 	}
 }
 
-func TestImageByDigest(t *testing.T) {
+func TestImageByDigestWithCinfo(t *testing.T) {
 	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
@@ -54,14 +54,15 @@ func TestImageByDigest(t *testing.T) {
 	titusInfo.ImageName = protobuf.String("titusoss/alpine")
 	titusInfo.ImageDigest = protobuf.String("sha256:58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4")
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	pod := GenerateV0TestPod(taskID, resources, conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	if got := c.QualifiedImageName(); got != expected {
 		t.Fatalf("Expected %s, got %s", expected, got)
 	}
 }
 
-func TestImageByDigestIgnoresTag(t *testing.T) {
+func TestImageByDigestIgnoresTagWithCinfo(t *testing.T) {
 	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
@@ -71,7 +72,8 @@ func TestImageByDigestIgnoresTag(t *testing.T) {
 	titusInfo.Version = protobuf.String("latest")
 	titusInfo.ImageDigest = protobuf.String("sha256:58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4")
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	pod := GenerateV0TestPod(taskID, resources, conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	if got := c.QualifiedImageName(); got != expected {
 		t.Fatalf("Expected %s, got %s", expected, got)
@@ -139,7 +141,8 @@ func TestNewContainer(t *testing.T) {
 
 	config := config.Config{}
 
-	container, err := NewContainer(taskID, containerInfo, resources, config)
+	pod := GenerateV0TestPod(taskID, &resources, &config)
+	container, err := NewContainerWithPod(taskID, containerInfo, resources, config, pod)
 	require.Nil(t, err)
 
 	assert2.DeepEqual(t, container.Labels(), map[string]string{
@@ -212,7 +215,8 @@ func TestMetatronEnabled(t *testing.T) {
 		MetatronEnabled: true,
 	}
 
-	container, err := NewContainer(taskID, containerInfo, resources, config)
+	pod := GenerateV0TestPod(taskID, &resources, &config)
+	container, err := NewContainerWithPod(taskID, containerInfo, resources, config, pod)
 	require.Nil(t, err)
 	assert.Equal(t, container.Env()["TITUS_METATRON_ENABLED"], "true")
 }
@@ -262,7 +266,8 @@ func TestClusterName(t *testing.T) {
 			titusInfo.JobGroupStack = &f.jobGroupStack
 		}
 
-		c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+		pod := GenerateV0TestPod(taskID, resources, conf)
+		c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 		assert.NoError(t, err)
 
 		got := c.CombinedAppStackDetails()
@@ -325,7 +330,8 @@ func TestEnvBasedOnTaskInfo(t *testing.T) {
 			if input.info.IamProfile == nil {
 				input.info.IamProfile = protobuf.String("arn:aws:iam::0:role/DefaultContainerRole")
 			}
-			container, err := NewContainer(name, input.info, resources, *cfg)
+			pod := GenerateV0TestPod(name, &resources, cfg)
+			container, err := NewContainerWithPod(name, input.info, resources, *cfg, pod)
 			require.Nil(t, err)
 			containerEnv := container.Env()
 			// Checks if everything in want is in containerEnv
@@ -660,7 +666,8 @@ func TestServiceMeshEnabled(t *testing.T) {
 		serviceMeshEnabledParam:   "true",
 	}
 
-	c, err := NewContainer(taskID, titusInfo, *resources, config)
+	pod := GenerateV0TestPod(taskID, resources, &config)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, config, pod)
 	require.Nil(t, err)
 	assert.True(t, c.ServiceMeshEnabled())
 	scConfs, err := c.SidecarConfigs()
@@ -677,9 +684,9 @@ func TestServiceMeshEnabledWithConfig(t *testing.T) {
 		ContainerServiceMeshEnabled: true,
 	}
 
-	taskID, titusInfo, resources, _, _, err := ContainerTestArgs()
+	taskID, titusInfo, resources, pod, _, err := ContainerTestArgs()
 	require.Nil(t, err)
-	c, err := NewContainer(taskID, titusInfo, *resources, config)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, config, pod)
 	require.Nil(t, err)
 	assert.False(t, c.ServiceMeshEnabled())
 	scConfs, err := c.SidecarConfigs()
@@ -696,9 +703,9 @@ func TestServiceMeshEnabledWithEmptyConfigValue(t *testing.T) {
 		ProxydServiceImage:          "",
 	}
 
-	taskID, titusInfo, resources, _, _, err := ContainerTestArgs()
+	taskID, titusInfo, resources, pod, _, err := ContainerTestArgs()
 	require.Nil(t, err)
-	c, err := NewContainer(taskID, titusInfo, *resources, config)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, config, pod)
 	require.Nil(t, err)
 	assert.False(t, c.ServiceMeshEnabled())
 	scConfs, err := c.SidecarConfigs()
@@ -711,10 +718,12 @@ func TestServiceMeshEnabledWithEmptyConfigValue(t *testing.T) {
 func TestSubnetIDHasSpaces(t *testing.T) {
 	config := config.Config{}
 
-	taskID, titusInfo, resources, _, _, err := ContainerTestArgs()
+	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
 	require.Nil(t, err)
 	titusInfo.PassthroughAttributes[subnetsParam] = "subnet-foo, subnet-bar "
-	c, err := NewContainer(taskID, titusInfo, *resources, config)
+	// TODO: This doesn't work on a V1 pod for some reason
+	pod := GenerateV0TestPod(taskID, resources, conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, config, pod)
 	require.Nil(t, err)
 	ret := c.SubnetIDs()
 	require.NotNil(t, ret)

--- a/executor/runtime/types/types_test.go
+++ b/executor/runtime/types/types_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFlatStringEntrypointIsParsed(t *testing.T) {
+func TestFlatStringEntrypointIsParsedWithCinfo(t *testing.T) {
 	input := `/titusimage-1.2.0/bin/titusimage -id 0e2d2a2e-1f6f-42ac-80f5-a502646423a1 -email changed@netflix.com -audience "changed test abcdefg" -description "changed test abcdefg" -type WHAT -query "set hive.auto.convert.join=false; set hive.mapred.mode=unstrict; select distinct my_id from vault.ad_dfa_dcid_profile_last_seen_d m join (select account_id, sum(standard_sanitized_duration_sec) duration from dse.loc_acct_device_ttl_sum where show_title_id = 80028732 and country_iso_code in ('FR') and region_date >= 20151227 group by account_id having duration >= 360) x on m.account_id = x.account_id where my_id != '0' and last_seen_dateint >= 20150127" -reuse true`
 	expected := `["/titusimage-1.2.0/bin/titusimage", "-id", "0e2d2a2e-1f6f-42ac-80f5-a502646423a1", "-email", "changed@netflix.com", "-audience", "changed test abcdefg", "-description", "changed test abcdefg", "-type", "WHAT", "-query", "set hive.auto.convert.join=false; set hive.mapred.mode=unstrict; select distinct my_id from vault.ad_dfa_dcid_profile_last_seen_d m join (select account_id, sum(standard_sanitized_duration_sec) duration from dse.loc_acct_device_ttl_sum where show_title_id = 80028732 and country_iso_code in ('FR') and region_date >= 20151227 group by account_id having duration >= 360) x on m.account_id = x.account_id where my_id != '0' and last_seen_dateint >= 20150127", "-reuse", "true"]`
 
 	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
+	pod := GenerateV0TestPod(taskID, resources, conf)
 	assert.NoError(t, err)
 	titusInfo.EntrypointStr = &input
 	titusInfo.Process = &titus.ContainerInfo_Process{
@@ -22,7 +23,7 @@ func TestFlatStringEntrypointIsParsed(t *testing.T) {
 		Command:    []string{"shouldBeIgnored"},
 	}
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 
 	var expectedSlice []string
@@ -36,21 +37,22 @@ func TestFlatStringEntrypointIsParsed(t *testing.T) {
 }
 
 func TestCustomCmd(t *testing.T) {
-	t.Run("WithNilEntrypoint", testCustomCmdWithEntrypoint(nil))
-	t.Run("WithEmptyEntrypoint", testCustomCmdWithEntrypoint([]string{}))
-	t.Run("WithEntrypoint", testCustomCmdWithEntrypoint([]string{"/bin/sh", "-c"}))
+	t.Run("WithNilEntrypoint", testCustomCmdWithEntrypointWithCinfo(nil))
+	t.Run("WithEmptyEntrypoint", testCustomCmdWithEntrypointWithCinfo([]string{}))
+	t.Run("WithEntrypoint", testCustomCmdWithEntrypointWithCinfo([]string{"/bin/sh", "-c"}))
 }
 
-func testCustomCmdWithEntrypoint(entrypoint []string) func(*testing.T) {
+func testCustomCmdWithEntrypointWithCinfo(entrypoint []string) func(*testing.T) {
 	return func(t *testing.T) {
 		taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
+		pod := GenerateV0TestPod(taskID, resources, conf)
 		assert.NoError(t, err)
 		titusInfo.Process = &titus.ContainerInfo_Process{
 			Entrypoint: entrypoint,
 			Command:    []string{"sleep", "1"},
 		}
 
-		c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+		c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 		assert.NoError(t, err)
 
 		entry, cmd := c.Process()
@@ -63,7 +65,7 @@ func testCustomCmdWithEntrypoint(entrypoint []string) func(*testing.T) {
 
 func TestFlatStringEntryPointMustBeNilForCustomCmd(t *testing.T) {
 	empty := ""
-	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, pod, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
 	titusInfo.EntrypointStr = &empty
@@ -71,7 +73,7 @@ func TestFlatStringEntryPointMustBeNilForCustomCmd(t *testing.T) {
 		Entrypoint: []string{"will be", "ignored"},
 		Command:    []string{"this", "one", "too"},
 	}
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 
 	entrypoint, cmd := c.Process()
@@ -80,10 +82,10 @@ func TestFlatStringEntryPointMustBeNilForCustomCmd(t *testing.T) {
 }
 
 func TestDefaultIsNil(t *testing.T) {
-	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, pod, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 
 	entrypoint, cmd := c.Process()
@@ -92,10 +94,10 @@ func TestDefaultIsNil(t *testing.T) {
 }
 
 func TestDefaultHostnameStyle(t *testing.T) {
-	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, pod, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 
 	hostname, err := ComputeHostname(c)
@@ -108,7 +110,9 @@ func TestEc2HostnameStyle(t *testing.T) {
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[hostnameStyleParam] = "ec2"
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	// TODO: This doesn't work on a V1 pod for some reason
+	pod := GenerateV0TestPod(taskID, resources, conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	c.SetVPCAllocation(&vpcapi.Assignment{
 		Assignment: &vpcapi.Assignment_AssignIPResponseV3{
@@ -132,7 +136,9 @@ func TestInvalidHostnameStyle(t *testing.T) {
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[hostnameStyleParam] = "foo"
 
-	_, err = NewContainer(taskID, titusInfo, *resources, *conf)
+	// TODO: This doesn't work on a V1 pod for some reason
+	pod := GenerateV0TestPod(taskID, resources, conf)
+	_, err = NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.Error(t, err, "unknown hostname style: foo")
 
 	tc := &TitusInfoContainer{
@@ -145,10 +151,10 @@ func TestInvalidHostnameStyle(t *testing.T) {
 }
 
 func TestDefaultNetworkMode(t *testing.T) {
-	taskID, titusInfo, resources, _, conf, err := ContainerTestArgs()
+	taskID, titusInfo, resources, pod, conf, err := ContainerTestArgs()
 	assert.NoError(t, err)
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	assert.Equal(t, titus.NetworkConfiguration_UnknownNetworkMode.String(), c.EffectiveNetworkMode())
 }
@@ -158,7 +164,9 @@ func TestIPv6NetworkModeRespectsThePassthroughBool(t *testing.T) {
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[assignIPv6AddressParam] = "true"
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	// TODO: This doesn't work on a V1 pod for some reason
+	pod := GenerateV0TestPod(taskID, resources, conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	assert.Equal(t, titus.NetworkConfiguration_Ipv6AndIpv4.String(), c.EffectiveNetworkMode())
 }
@@ -168,7 +176,9 @@ func TestTtyEnabled(t *testing.T) {
 	assert.NoError(t, err)
 	titusInfo.PassthroughAttributes[ttyEnabledParam] = "true"
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	// TODO: This doesn't work on a V1 pod for some reason
+	pod := GenerateV0TestPod(taskID, resources, conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	assert.True(t, c.TTYEnabled())
 }
@@ -179,7 +189,9 @@ func TestOomScoreAdj(t *testing.T) {
 	oomScore := int32(99)
 	titusInfo.OomScoreAdj = &oomScore
 
-	c, err := NewContainer(taskID, titusInfo, *resources, *conf)
+	// TODO: This doesn't work on a V1 pod for some reason
+	pod := GenerateV0TestPod(taskID, resources, conf)
+	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 	assert.Equal(t, oomScore, *c.OomScoreAdj())
 }

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -364,6 +364,7 @@ func createContainerInfoTask(jobInput *JobInput, jobID string, task *runner.Task
 
 	ci.AllowCpuBursting = proto.Bool(jobInput.CPUBursting)
 	task.TitusInfo = ci
+	task.Pod = runtimeTypes.GenerateV0TestPod(task.TaskID, nil, nil)
 
 	return nil
 }

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -159,13 +159,13 @@ func dockerPull(t *testing.T, imgName string, imgDigest string) (*dockerTypes.Im
 
 	drt, ok := rt.(*docker.DockerRuntime)
 	require.True(t, ok, "DockerRuntime cast should succeed")
-	taskID, titusInfo, resources, _, conf, err := runtimeTypes.ContainerTestArgs()
+	taskID, titusInfo, resources, pod, conf, err := runtimeTypes.ContainerTestArgs()
 	assert.NoError(t, err)
 	titusInfo.ImageName = protobuf.String(imgName)
 	titusInfo.ImageDigest = protobuf.String(imgDigest)
 	titusInfo.IamProfile = protobuf.String("arn:aws:iam::0:role/DefaultContainerRole")
 
-	c, err := runtimeTypes.NewContainer(taskID, titusInfo, *resources, *conf)
+	c, err := runtimeTypes.NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
 
 	res, err := drt.DockerPull(ctx, c)

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -30,10 +30,10 @@ const (
 	TASK_FAILED = "TASK_FAILED" // nolint:golint
 )
 
-var shouldUsePodspecInTest bool
+var UseV1PodspecInTest bool
 
 func TestMain(m *testing.M) {
-	flag.BoolVar(&shouldUsePodspecInTest, "shouldUsePodspecInTest", true, "Use pod schema v1 instead of cinfo in tests")
+	flag.BoolVar(&UseV1PodspecInTest, "useV1PodspecInTest", true, "Use pod schema v1 instead of cinfo in tests")
 	flag.Parse()
 	if testing.Verbose() {
 		log.SetLevel(log.DebugLevel)
@@ -113,13 +113,13 @@ func skipOnDarwin(t *testing.T) {
 }
 
 func skipIfNotPod(t *testing.T) {
-	if !shouldUsePodspecInTest {
+	if !UseV1PodspecInTest {
 		t.Skip("Skipping this test as it requires the pod spec")
 	}
 }
 
 func generateJobID(testName string) string {
-	if shouldUsePodspecInTest {
+	if UseV1PodspecInTest {
 		return testName + "WithPod"
 	}
 	return testName + "WithCinfo"
@@ -181,7 +181,7 @@ func TestSimpleJob(t *testing.T) {
 		Version:       busybox.tag,
 		EntrypointOld: "echo Hello Titus",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -200,7 +200,7 @@ func TestSimpleJobWithBadEnvironment(t *testing.T) {
 			"AlsoBAD":                          "",
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -216,7 +216,7 @@ func TestCustomCmd(t *testing.T) {
 			Cmd: []string{"echo", "Hello Titus"},
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -232,7 +232,7 @@ func TestInvalidFlatStringAsCmd(t *testing.T) {
 			Cmd: []string{"echo Hello Titus"}, // this will exit with status 127 since there is no such binary
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
@@ -253,7 +253,7 @@ func TestEntrypointAndCmd(t *testing.T) {
 			Cmd:        []string{"echo Hello Titus"},
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -269,7 +269,7 @@ func TestEntrypointAndCmdFromImage(t *testing.T) {
 			// entrypoint and cmd baked into the image will exit with status 123
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
@@ -289,7 +289,7 @@ func TestOverrideCmdFromImage(t *testing.T) {
 			Cmd: []string{"exit 5"},
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
 	defer cancel()
@@ -310,7 +310,7 @@ func TestResetEntrypointFromImage(t *testing.T) {
 			Cmd:        []string{"/bin/sh", "-c", "exit 6"},
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
@@ -330,7 +330,7 @@ func TestResetCmdFromImage(t *testing.T) {
 			Cmd: []string{""},
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -344,7 +344,7 @@ func TestNoCapPtraceByDefault(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: "/bin/sh -c '! (/sbin/capsh --print | tee /logs/no-ptrace.log | grep sys_ptrace')",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -363,7 +363,7 @@ func TestCanAddCapabilities(t *testing.T) {
 			},
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -381,7 +381,7 @@ func TestDefaultCapabilities(t *testing.T) {
 		// Older kernels (3.13 on jenkins) have a different bitmask, so we check both the new and old formats
 		EntrypointOld: `/bin/bash -c 'cat /proc/self/status | tee /logs/capabilities.log | egrep "CapEff:\s+(00000020a80425fb|00000000a80425fb)"'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -395,7 +395,7 @@ func TestMakesPTY(t *testing.T) {
 		Version:       pty.tag,
 		EntrypointOld: "/bin/bash -c '/usr/bin/unbuffer /usr/bin/tty | grep /dev/pts'",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -411,7 +411,7 @@ func TestStdoutGoesToLogFile(t *testing.T) {
 		Version:       busybox.tag,
 		EntrypointOld: cmd,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -427,7 +427,7 @@ func TestStderrGoesToLogFile(t *testing.T) {
 		Version:       busybox.tag,
 		EntrypointOld: cmd,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -442,7 +442,7 @@ func TestImageByDigest(t *testing.T) {
 		ImageDigest:   byDigest.digest,
 		EntrypointOld: cmd,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -461,7 +461,7 @@ func TestImageByDigestIgnoresTag(t *testing.T) {
 		ImageDigest:   byDigest.digest,
 		EntrypointOld: cmd,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -477,9 +477,9 @@ func TestImageInvalidDigestFails(t *testing.T) {
 		ImageDigest:   digest,
 		EntrypointOld: "/bin/true",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
-	if shouldUsePodspecInTest {
+	if UseV1PodspecInTest {
 		// In the pods container implementation, the docker image format is checked before starting
 		err := StartJobExpectingFailure(t, ji)
 		assert.Error(t, err, "error parsing docker image")
@@ -502,7 +502,7 @@ func TestImageNonExistingDigestFails(t *testing.T) {
 		ImageDigest:   digest,
 		EntrypointOld: "/bin/true",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	status, err := RunJob(t, ji)
 	if err != nil {
@@ -520,7 +520,7 @@ func TestImagePullError(t *testing.T) {
 		Version:       "purposelyDoesntExist",
 		EntrypointOld: "/usr/bin/true",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	status, err := RunJob(t, ji)
 	if err != nil {
@@ -540,7 +540,7 @@ func TestCancelPullBigImage(t *testing.T) { // nolint: gocyclo
 		JobID:      generateJobID(t.Name()),
 		ImageName:  bigImage.name,
 		Version:    bigImage.tag,
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	})
 
 	require.NoError(t, err)
@@ -585,7 +585,7 @@ func TestBadEntrypoint(t *testing.T) {
 		Version:       busybox.tag,
 		EntrypointOld: "bad",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	// We expect this to fail
 	if RunJobExpectingSuccess(t, ji) {
@@ -598,7 +598,7 @@ func TestNoEntrypoint(t *testing.T) {
 	ji := &JobInput{
 		ImageName:  noEntrypoint.name,
 		Version:    noEntrypoint.tag,
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	// We expect this to fail
 	if RunJobExpectingSuccess(t, ji) {
@@ -615,7 +615,7 @@ func TestCanWriteInLogsAndSubDirs(t *testing.T) {
 		Version:       busybox.tag,
 		EntrypointOld: cmd,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -636,7 +636,7 @@ func TestShutdown(t *testing.T) {
 		Version:       busybox.tag,
 		EntrypointOld: "sleep 6000",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 
 	jobRunner, err := StartJob(t, ctx, ji)
@@ -681,7 +681,7 @@ func TestMetadataProxyInjection(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: "/bin/bash -c 'curl -sf http://169.254.169.254/latest/meta-data/local-ipv4 | grep 192.0.2.1'",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -697,7 +697,7 @@ func TestMetadataProxyFromLocalhost(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: `/bin/bash -c 'curl -sf --interface 127.0.0.1 http://169.254.169.254/latest/meta-data/local-ipv4'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -713,7 +713,7 @@ func TestMetadataProxyOnIPv6(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: `/bin/bash -c 'curl -sf http://[fd00:ec2::254]/latest/meta-data/local-ipv4'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -729,7 +729,7 @@ func TestMetadataProxyPublicIP(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: "/bin/bash -c 'curl -sf http://169.254.169.254/latest/meta-data/public-ipv4 | grep 203.0.113.11",
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -747,7 +747,7 @@ func testTerminateTimeoutWrapped(t *testing.T, jobID string, killWaitSeconds uin
 		Version:         ignoreSignals.tag,
 		KillWaitSeconds: killWaitSeconds,
 		JobID:           generateJobID(t.Name()),
-		UsePodSpec:      shouldUsePodspecInTest,
+		UsePodSpec:      UseV1PodspecInTest,
 	}
 	// Start the executor
 	jobResponse, err := StartJob(t, ctx, ji)
@@ -817,7 +817,7 @@ func TestOOMAdj(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: `/bin/bash -c 'cat /proc/1/oom_score | grep 999'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -834,7 +834,7 @@ func TestOOMKill(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: `stress --vm 100 --vm-keep --vm-hang 100`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 
 	// Start the executor
@@ -865,7 +865,7 @@ func TestSchedBatch(t *testing.T) {
 		EntrypointOld: `/bin/bash -c 'schedtool 0 | grep SCHED_BATCH | grep 19'`,
 		JobID:         generateJobID(t.Name()),
 		SchedPolicy:   "batch",
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -879,7 +879,7 @@ func TestSchedNormal(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: `/bin/bash -c 'schedtool 0 | grep SCHED_NORMAL'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -894,7 +894,7 @@ func TestSchedIdle(t *testing.T) {
 		EntrypointOld: `/bin/bash -c 'schedtool 0 | grep SCHED_IDLE'`,
 		JobID:         generateJobID(t.Name()),
 		SchedPolicy:   "idle",
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -908,7 +908,7 @@ func TestNewEnvironmentLocationPositive(t *testing.T) {
 		Version:       envLabel.tag,
 		EntrypointOld: `cat /etc/nflx/base-environment.d/200titus`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -922,7 +922,7 @@ func TestNewEnvironmentLocationNegative(t *testing.T) {
 		Version:       envLabel.tag,
 		EntrypointOld: `cat /etc/profile.d/netflix_environment.sh`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingFailure(t, ji) {
 		t.Fail()
@@ -936,7 +936,7 @@ func TestOldEnvironmentLocationPositive(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: `cat /etc/profile.d/netflix_environment.sh`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -949,7 +949,7 @@ func TestOldEnvironmentLocationNegative(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: `cat /etc/nflx/base-environment.d/200titus`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingFailure(t, ji) {
 		t.Fail()
@@ -966,7 +966,7 @@ func TestNoCPUBursting(t *testing.T) {
 		// Make sure quota is set
 		EntrypointOld: `/bin/bash -c 'cat /sys/fs/cgroup/cpuacct/cpu.cfs_quota_us|grep -v - -1'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -984,7 +984,7 @@ func TestCPUBursting(t *testing.T) {
 		EntrypointOld: `/bin/bash -c 'cat /sys/fs/cgroup/cpuacct/cpu.cfs_quota_us|grep - -1'`,
 		JobID:         generateJobID(t.Name()),
 		CPUBursting:   true,
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1003,7 +1003,7 @@ func TestTwoCPUs(t *testing.T) {
 		EntrypointOld: `/bin/bash -c 'cat /sys/fs/cgroup/cpuacct/cpu.shares|grep 200'`,
 		JobID:         generateJobID(t.Name()),
 		CPU:           &cpuCount,
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1018,7 +1018,7 @@ func TestTty(t *testing.T) {
 		EntrypointOld: `/usr/bin/tty`,
 		JobID:         generateJobID(t.Name()),
 		Tty:           true,
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1033,7 +1033,7 @@ func TestTtyNegative(t *testing.T) {
 		EntrypointOld: `/usr/bin/tty`,
 		JobID:         generateJobID(t.Name()),
 		// Tty not specified
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	if !RunJobExpectingFailure(t, ji) {
 		t.Fail()
@@ -1083,7 +1083,7 @@ func TestMetatron(t *testing.T) {
 			"\"",
 		}, " "),
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1109,7 +1109,7 @@ func TestMetatronFailure(t *testing.T) {
 			"TITUS_TEST_FAIL_METATRON_INIT": "true",
 		},
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 
 	jobResponse, err := StartJob(t, ctx, ji)
@@ -1134,7 +1134,7 @@ func TestRunTmpFsMount(t *testing.T) {
 		Mem:           &mem,
 		EntrypointOld: `/bin/bash -c 'findmnt -l -t tmpfs -o target,size | grep -e "/run[^/]" | grep 128M'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1149,7 +1149,7 @@ func TestExecSlashRun(t *testing.T) {
 		Version:       ubuntu.tag,
 		EntrypointOld: `/bin/bash -c 'cp /bin/ls /run/ && /run/ls'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1166,7 +1166,7 @@ func TestSystemdImageMount(t *testing.T) {
 		Mem:           &mem,
 		EntrypointOld: `/bin/bash -c 'findmnt -l -t tmpfs -o target,size | grep -e "/run/lock[^/]" | grep 5M'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1185,7 +1185,7 @@ func TestShm(t *testing.T) {
 		ShmSize:       &shmSize,
 		EntrypointOld: `/bin/bash -c 'df | grep -e '^shm' | grep 196608'`,
 		JobID:         generateJobID(t.Name()),
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1214,7 +1214,7 @@ func TestContainerLogViewer(t *testing.T) {
 			"curl -sf $url | grep -q stdout-should-go-to-log" +
 			"'",
 		JobID:      generateJobID(t.Name()),
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1228,7 +1228,7 @@ func TestNegativeSeccomp(t *testing.T) {
 		Version:   ubuntu.tag,
 		// Make sure that the process exits due to timeout, and not due to permission denied error
 		EntrypointOld: "/usr/bin/negative-seccomp",
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 	if !RunJobExpectingSuccess(t, ji) {
 		t.Fail()
@@ -1249,7 +1249,7 @@ func TestGPUManager1GPU(t *testing.T) {
 		JobID:         generateJobID(t.Name()),
 		GPUManager:    g,
 		GPU:           &gpu,
-		UsePodSpec:    shouldUsePodspecInTest,
+		UsePodSpec:    UseV1PodspecInTest,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFailureTimeout)
@@ -1284,7 +1284,7 @@ func TestBasicMultiContainer(t *testing.T) {
 	ji := &JobInput{
 		ImageName:  busybox.name,
 		Version:    busybox.tag,
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 		// This sentinel container is a second process we can look out
 		// for, in order to detect if multi-container workloads are setup
 		ExtraContainers: []corev1.Container{
@@ -1318,7 +1318,7 @@ func TestMultiContainerDoesPlatformFirst(t *testing.T) {
 	ji := &JobInput{
 		ImageName:  busybox.name,
 		Version:    busybox.tag,
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 		// This sentinel container is a second process we can look out
 		// for, in order to detect if multi-container workloads are setup
 		ExtraContainers: []corev1.Container{
@@ -1360,7 +1360,7 @@ func TestBasicMultiContainerFailingHealthcheck(t *testing.T) {
 	ji := &JobInput{
 		ImageName:  busybox.name,
 		Version:    busybox.tag,
-		UsePodSpec: shouldUsePodspecInTest,
+		UsePodSpec: UseV1PodspecInTest,
 		ExtraContainers: []corev1.Container{
 			{
 				Name:    "failing-sidecar",

--- a/hack/tests-with-dind.sh
+++ b/hack/tests-with-dind.sh
@@ -88,11 +88,11 @@ log "Running tests with CInfo"
 docker exec $TTYFLAG --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
   go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
     -covermode=count -coverprofile=coverage-standalone.out \
-    -coverpkg=github.com/Netflix/... ./executor/standalone/... -short=false -shouldUsePodspecInTest=false 2>&1 | tee test-standalone.log
+    -coverpkg=github.com/Netflix/... ./executor/standalone/... -short=false -useV1PodspecInTest=false 2>&1 | tee test-standalone.log
 log "Running tests with Pod Spec v1"
 docker exec $TTYFLAG --privileged -e DEBUG=${debug} -e SHORT_CIRCUIT_QUITELITE=true -e GOPATH=${GOPATH} "$titus_agent_name" \
   go test -timeout ${TEST_TIMEOUT:-20m} ${TEST_FLAGS:-} \
     -covermode=count -coverprofile=coverage-standalone.out \
-    -coverpkg=github.com/Netflix/... ./executor/standalone/... -short=false -shouldUsePodspecInTest=true 2>&1 | tee test-standalone-podspec.log
+    -coverpkg=github.com/Netflix/... ./executor/standalone/... -short=false -useV1PodspecInTest=true 2>&1 | tee test-standalone-podspec.log
 
 log "Integration tests complete (rc: $?)"


### PR DESCRIPTION
In practice, we always have a pod. Long gone are the days
where we don't have a pod object at all.

But, the difference is whether we have a v0 pod or a v1 pod.

In this refactor, I removed all places where a pod was nil, which is
not a realistic reflection of the code we run in real life.

And in some places I added a "v0" pod in its place. I'm worried that
all the places where I *needed* a v0 pod indicates that we have a bug in our
podContainer implementation.

These todos can be addressed on the next pass.

Rob did a great job of doing cinfo/pod tests on the standalone stuff,
but this is in the types test area, which doesn't have the duplication.
