### PR TITLE
Remove need for IAM Proxy

### DIFF
--- a/cmd/titus-metadata-service/main.go
+++ b/cmd/titus-metadata-service/main.go
@@ -166,6 +166,8 @@ func main() {
 		sslCA                      string
 		iamService                 string
 		zipkinURL                  string
+		availabilityZone           string
+		availabilityZoneID         string
 	)
 
 	app.Flags = []cli.Flag{
@@ -195,7 +197,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:        "region",
-			Usage:       "The STS service region to use",
+			Usage:       "The STS service region to use (and the region to optionally return for the region endpoint)",
 			Destination: &region,
 			Value:       "",
 			EnvVar:      "EC2_REGION",
@@ -291,6 +293,18 @@ func main() {
 			EnvVar:      "ZIPKIN",
 			Destination: &zipkinURL,
 		},
+		cli.StringFlag{
+			Name:        "availability-zone",
+			Usage:       "The Availability Zone that we are in",
+			EnvVar:      "EC2_AVAILABILITY_ZONE",
+			Destination: &availabilityZone,
+		},
+		cli.StringFlag{
+			Name:        "availability-zone-id",
+			Usage:       "The Availability Zone ID that we are in",
+			EnvVar:      "EC2_AVAILABILITY_ZONE_ID",
+			Destination: &availabilityZoneID,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -335,6 +349,8 @@ func main() {
 			Ipv4Address:                net.ParseIP(ipv4Address),
 			PublicIpv4Address:          net.ParseIP(publicIpv4Address),
 			Region:                     region,
+			AvailabilityZoneID:         availabilityZoneID,
+			AvailabilityZone:           availabilityZone,
 			RequireToken:               requireToken,
 			TokenKey:                   titusTaskInstanceID + tokenSalt,
 			XFordwardedForBlockingMode: xFordwardedForBlockingMode,

--- a/metadataserver/server.go
+++ b/metadataserver/server.go
@@ -144,6 +144,10 @@ func NewMetaDataServer(ctx context.Context, config types.MetadataServerConfigura
 		signer:                    config.Signer,
 		tokenRequired:             config.RequireToken,
 		xForwardedForBlockingMode: config.XFordwardedForBlockingMode,
+
+		region:             config.Region,
+		availabilityZone:   config.AvailabilityZone,
+		availabilityZoneID: config.AvailabilityZoneID,
 	}
 
 	var conn *grpc.ClientConn

--- a/metadataserver/types/types.go
+++ b/metadataserver/types/types.go
@@ -32,7 +32,6 @@ type MetadataServerConfiguration struct {
 	Ipv4Address                net.IP
 	PublicIpv4Address          net.IP
 	Ipv6Address                *net.IP
-	Region                     string
 	Pod                        *corev1.Pod
 	Container                  *titus.ContainerInfo
 	Signer                     *identity.Signer
@@ -48,4 +47,10 @@ type MetadataServerConfiguration struct {
 	SSLKey     string
 	SSLCert    string
 	IAMService string
+
+	// These are optional, and will be dynamically resolved if not specified.
+	AvailabilityZone   string
+	AvailabilityZoneID string
+	// Region is also used for configuring the STS client to use that region's STS service
+	Region string
 }


### PR DESCRIPTION
This adds the ability for the metadataserver to run without a backing
server. If the environment variables are specified for AZ, region, and
AZ ID, then it'll use those as the "source of truth".

