### PR TITLE
Always log the full ARN in the imds log output

### DIFF
--- a/metadataserver/server.go
+++ b/metadataserver/server.go
@@ -535,7 +535,7 @@ func (ms *MetadataServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"referer":       r.Header.Get("Referer"),
 		"taskid":        ms.titusTaskInstanceID,
 		"source-addr":   r.RemoteAddr,
-		"assumed-arn":   ms.iamProxy.defaultRole,
+		"assumed-arn":   ms.iamProxy.roles[ms.iamProxy.defaultRole].arn,
 	})
 	ms.internalMux.ServeHTTP(w, r2)
 }


### PR DESCRIPTION
I think this might have gotten lost in the change
to do multi-role.

This implementation isn't the "best" because it only logs
the main default assumed role ARN (and not the log arn, which
could be confusing I suppose).

But the majority of the time we are interested in the ARN
for the container.

We don't have any explicit tests on the logging format, but I
can see this in the logs now:

```
time="2021-07-14T08:31:03-07:00" level=info msg="Request GET /latest/meta-data/placement/availability-zone 'Go-http-client/1.1' from [::1]:62317" assumed-arn="arn:aws:iam::8675309:role/thisIsAFakeRole" method=GET path=/latest/meta-data/placement/availability-zone referer= request-time=102 source-addr="[::1]:62317" taskid=e3c16590-0e2f-440d-9797-a68a19f6101e token-present=false uri=/latest/meta-data/placement/availability-zone user-agent=Go-http-client/1.1
```

Where before it just had `thisIsAFakeRole`.

### Description of the Change

**FIXME**: please add at least one sentence explaining why changes here are being made.
