### PR TITLE
Only make metatron creds on a pod object if we have some

### DIFF
--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -1234,7 +1234,7 @@ func populateContainerEnv(c Container, config config.Config, userEnv map[string]
 
 	env["TITUS_IAM_ROLE"] = ptr.StringPtrDerefOr(c.IamRole(), "")
 
-	if config.MetatronEnabled {
+	if config.MetatronEnabled && c.MetatronCreds() != nil {
 		// When set, the metadata service will return signed identity documents suitable for bootstrapping Metatron
 		env[metadataserverTypes.TitusMetatronVariableName] = True
 	} else {

--- a/executor/runtime/types/container_test.go
+++ b/executor/runtime/types/container_test.go
@@ -198,6 +198,7 @@ func TestMetatronEnabled(t *testing.T) {
 		NetworkConfigInfo: &titus.ContainerInfo_NetworkConfigInfo{
 			BandwidthLimitMbps: &expectedNetwork,
 		},
+		MetatronCreds:    &titus.ContainerInfo_MetatronCreds{},
 		AllowCpuBursting: &batch,
 		IamProfile:       protobuf.String("arn:aws:iam::0:role/DefaultContainerRole"),
 	}

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -259,6 +259,14 @@ func (c *PodContainer) ContainerInfo() (*titus.ContainerInfo, error) {
 	e, _ := json.Marshal(userContainer.Env)
 	logrus.StandardLogger().Debugf("container config env = %s", e)
 
+	var metatronCreds *titus.ContainerInfo_MetatronCreds
+	if c.podConfig.WorkloadMetadata != nil && c.podConfig.WorkloadMetadataSig != nil {
+		metatronCreds = &titus.ContainerInfo_MetatronCreds{
+			AppMetadata: c.podConfig.WorkloadMetadata,
+			MetadataSig: c.podConfig.WorkloadMetadataSig,
+		}
+	}
+
 	// Only populate ContainerInfo with the fields necessary for a valid task identity document
 	cInfo := &titus.ContainerInfo{
 		ImageName: c.ImageName(),
@@ -276,10 +284,7 @@ func (c *PodContainer) ContainerInfo() (*titus.ContainerInfo, error) {
 			SecurityGroups: sgIDs,
 		},
 		JobGroupSequence: &seq,
-		MetatronCreds: &titus.ContainerInfo_MetatronCreds{
-			AppMetadata: c.podConfig.WorkloadMetadata,
-			MetadataSig: c.podConfig.WorkloadMetadataSig,
-		},
+		MetatronCreds:    metatronCreds,
 		UserProvidedEnv:  userProvidedEnv,
 		TitusProvidedEnv: titusProvidedEnv,
 		ImageDigest:      c.ImageDigest(),

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -328,7 +328,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 		"TITUS_IMAGE_DIGEST":                imgDigest,
 		"TITUS_IMAGE_NAME":                  "titusoss/alpine",
 		"TITUS_IMDS_REQUIRE_TOKEN":          "token",
-		"TITUS_METATRON_ENABLED":            True,
+		"TITUS_METATRON_ENABLED":            False,
 		"TITUS_NUM_CPU":                     "2",
 		"TITUS_NUM_DISK":                    "10000",
 		"TITUS_NUM_GPU":                     "1",
@@ -574,6 +574,20 @@ func TestNewPodContainerMetatronDisabled(t *testing.T) {
 	c, err := NewPodContainer(pod, *conf)
 	assert.NilError(t, err)
 	assert.Equal(t, c.Env()["TITUS_METATRON_ENABLED"], "false")
+}
+
+func TestNewPodContainerMetatronDisabledWhenNoCreds(t *testing.T) {
+	pod, conf, err := PodContainerTestArgs()
+	assert.NilError(t, err)
+
+	c, err := NewPodContainer(pod, *conf)
+	assert.NilError(t, err)
+	cInfo, err := c.ContainerInfo()
+	assert.NilError(t, err)
+	creds := cInfo.GetMetatronCreds()
+	assert.Equal(t, creds == nil, true)
+	assert.Equal(t, c.Env()["TITUS_METATRON_ENABLED"], "false")
+	assert.Equal(t, shouldStartMetatronSync(conf, c), false)
 }
 
 func TestPodContainerClusterName(t *testing.T) {
@@ -1368,7 +1382,7 @@ func TestContainerInfoGenerationBasic(t *testing.T) {
 		JobGroupSequence: ptr.StringPtr(""),
 		JobGroupStack:    ptr.StringPtr(""),
 		JobGroupDetail:   ptr.StringPtr(""),
-		MetatronCreds:    &titus.ContainerInfo_MetatronCreds{},
+		MetatronCreds:    nil,
 		NetworkConfigInfo: &titus.ContainerInfo_NetworkConfigInfo{
 			EniLablel:      ptr.StringPtr("0"),
 			SecurityGroups: []string{},


### PR DESCRIPTION
Previously, we would create a metatronCreds entry in our cInfo
object for pods, *even* if we didn't have creds to work with.

Even though the struct instance had null fields, we still had a struct.

This makes it so the struct pointer stays nil if we don't have
metatron creds in the first place.
