### PR TITLE
Make sure /titus/etc/ssh (dirs) have perms 755

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1273,6 +1273,14 @@ func (r *DockerRuntime) pushEnvironment(ctx context.Context, c runtimeTypes.Cont
 		log.Fatal(err)
 	}
 
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "titus/etc",
+		Mode:     0755,
+		Typeflag: tar.TypeDir,
+	}); err != nil {
+		log.Fatal(err)
+	}
+
 	if r.cfg.MetatronEnabled {
 		// `/metatron` is a shared folder between all containers in a pod, but it must exist first
 		// so that it can be shared

--- a/executor/runtime/docker/docker_ssh.go
+++ b/executor/runtime/docker/docker_ssh.go
@@ -103,6 +103,14 @@ func addContainerSSHDConfig(c runtimeTypes.Container, tw *tar.Writer, cfg config
 }
 
 func addContainerSSHDConfigWithData(c runtimeTypes.Container, tw *tar.Writer, cfg config.Config, caData []byte) error {
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "titus/etc/ssh",
+		Mode:     0755,
+		Typeflag: tar.TypeDir,
+	}); err != nil {
+		log.Fatal(err)
+	}
+
 	sshConfigBytes := []byte(sshdConfig)
 	err := tw.WriteHeader(&tar.Header{
 		Name: "/titus/etc/ssh/sshd_config",


### PR DESCRIPTION
If /titus, or /titus/etc, or /titus/etc/ssh have world
writable permissions, SSH refuses to use them for authz.

In newer versions of Docker, if the directory is not explicitly
part of the tarball, it create it with 777 perms.
