### PR TITLE
Support concurrent file uploads with deduplication logic

### DIFF
--- a/filesystems/watcher.go
+++ b/filesystems/watcher.go
@@ -633,11 +633,6 @@ func (w *Watcher) uploadAllLogFiles(ctx context.Context) error {
 	return err
 }
 
-type uploaded struct {
-	mtime time.Time
-	size  int64
-}
-
 // uploadLogFile is called to upload a single log file while the
 // task is running. Currently, no error is returned to the caller,
 // it is just logged.

--- a/filesystems/watcher.go
+++ b/filesystems/watcher.go
@@ -561,10 +561,10 @@ func parsecurrentOffsetBytes(name string, currentOffsetBytes []byte) int64 {
 	return currentOffsetInt
 }
 
-func (w *Watcher) concurrentUploadLogFile(logFileList []string, ctx context.Context) error {
+func (w *Watcher) concurrentUploadLogFile(ctx context.Context, logFileList []string) error {
 	// Iterate over each file and setup the work
 	var wg sync.WaitGroup
-	const CONUCRRENT_UPLOADERS = 8
+	const concurrentUploaders = 8
 	var errs *multierror.Error
 
 	// Fill up a buffering channel, so we can drain slowly
@@ -575,7 +575,7 @@ func (w *Watcher) concurrentUploadLogFile(logFileList []string, ctx context.Cont
 	close(uploadFileC)
 
 	// How many workers do we need
-	uploadWorkers := CONUCRRENT_UPLOADERS
+	uploadWorkers := concurrentUploaders
 	if len(logFileList) < uploadWorkers {
 		uploadWorkers = len(logFileList)
 	}
@@ -627,7 +627,7 @@ func (w *Watcher) uploadAllLogFiles(ctx context.Context) error {
 		return err
 	}
 
-	err = w.concurrentUploadLogFile(logFileList, ctx)
+	err = w.concurrentUploadLogFile(ctx, logFileList)
 	tracehelpers.SetStatus(err, span)
 
 	return err
@@ -701,7 +701,7 @@ type uploaded struct {
 }
 
 func buildFileListInDir(dirName string, checkModifiedTimeThreshold bool, uploadThreshold time.Duration) ([]string, error) {
-	dedupUpload := make(map[string]uploaded, 0)
+	dedupUpload := make(map[string]uploaded)
 	return buildFileListInDir2(dirName, []string{}, checkModifiedTimeThreshold, uploadThreshold, dedupUpload)
 }
 

--- a/filesystems/watcher.go
+++ b/filesystems/watcher.go
@@ -610,6 +610,11 @@ func (w *Watcher) concurrentUploadLogFile(ctx context.Context, logFileList []str
 		})
 	}
 
+	if err := g.Wait(); err != nil {
+		log.WithError(err).Errorf("Error during concurrent upload of files: g.Wait()")
+		return err
+	}
+
 	if err := safeError.ErrorOrNil(); err != nil {
 		log.WithError(err).Errorf("Error during concurrent upload of files")
 		return err

--- a/filesystems/watcher.go
+++ b/filesystems/watcher.go
@@ -572,7 +572,7 @@ func (w *Watcher) concurrentUploadLogFile(ctx context.Context, logFileList []str
 	}
 
 	g := &multierror.Group{}
-	// Limit concurrency
+	// Intended to create 1 GoRoutine per file to upload
 	sem := semaphore.NewWeighted(int64(uploadWorkers))
 	for _, fileToUpload := range logFileList {
 		fileToUploadCopy := fileToUpload

--- a/filesystems/watcher.go
+++ b/filesystems/watcher.go
@@ -745,14 +745,13 @@ func buildFileListInDir2(dirName string, fileList []string, checkModifiedTimeThr
 					elem.mtime = fileInfo.ModTime()
 					dedupUpload[fileInfo.Name()] = elem
 				} else {
-					log2.Debugf("ignoring possibly duplicate file ", fileInfo.Name())
 					continue
 				}
 			} else {
 				dedupUpload[fileInfo.Name()] = uploaded{fileInfo.ModTime(), fileInfo.Size()}
 			}
 
-			log2.Debug("append to file list %s ", fqName)
+			log2.Debug("append to file list")
 			result = append(result, fqName)
 		}
 	}

--- a/filesystems/watcher.go
+++ b/filesystems/watcher.go
@@ -602,55 +602,6 @@ func (w *Watcher) concurrentUploadLogFile(ctx context.Context, logFileList []str
 	return nil
 }
 
-/*
-func (w *Watcher) concurrentUploadLogFile(ctx context.Context, logFileList []string, dedupCache ccache.Cache) error {
-	// Iterate over each file and setup the work
-	var wg sync.WaitGroup
-	var errs *multierror.Error
-
-	// Fill up a buffering channel, so we can drain slowly
-	uploadFileC := make(chan string, len(logFileList))
-	for _, j := range logFileList {
-		uploadFileC <- j
-	}
-	close(uploadFileC)
-
-	// How many workers do we need
-	uploadWorkers := concurrentUploaders
-	if len(logFileList) < uploadWorkers {
-		uploadWorkers = len(logFileList)
-	}
-	wg.Add(uploadWorkers)
-
-	// Define what the worker should do
-	uploadWork := func(ch <-chan string) {
-		defer wg.Done()
-		for logFile := range ch {
-			if ctx.Err() != nil {
-				errs = multierror.Append(errs, ctx.Err())
-				break
-			}
-			if CheckFileForStdio(logFile) {
-				continue
-			}
-			err := w.uploadLogfile(ctx, logFile, true)
-			errs = multierror.Append(errs, err)
-		}
-	}
-	// Start the workers
-	for i := 0; i < uploadWorkers; i++ {
-		go uploadWork(uploadFileC)
-	}
-
-	wg.Wait()
-	err := errs.ErrorOrNil()
-	if err != nil {
-		w.metrics.Counter("titus.executor.logsUploadError", len(errs.Errors), nil)
-	}
-
-	return err
-}*/
-
 // uploadAllLogFiles is called to upload all of the files in the directories
 // being watched.
 func (w *Watcher) uploadAllLogFiles(ctx context.Context, dedupCache *ccache.Cache) error {

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.19.10
-	k8s.io/apimachinery v0.19.10
+	k8s.io/apimachinery v0.22.0
 	k8s.io/client-go v10.0.0+incompatible
 	k8s.io/kubernetes v1.18.4
 	k8s.io/utils v0.0.0-20201104234853-8146046b121e

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible
-	github.com/karlseguin/ccache/v2 v2.0.7-0.20200814031513-0dbf3f125f13
+	github.com/karlseguin/ccache/v2 v2.0.8
 	github.com/leanovate/gopter v0.0.0-20170420174722-9e6101e5a875
 	github.com/lib/pq v1.3.0
 	github.com/m7shapan/cidr v0.0.0-20200427124835-7eba0889a5d2

--- a/go.sum
+++ b/go.sum
@@ -519,6 +519,8 @@ github.com/lucas-clemente/quic-clients v0.1.0/go.mod h1:y5xVIEoObKqULIKivu+gD/LU
 github.com/lucas-clemente/quic-go v0.10.2/go.mod h1:hvaRS9IHjFLMq76puFJeWNfmn+H70QZ/CXoxqw9bzao=
 github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced/go.mod h1:NCcRLrOTZbzhZvixZLlERbJtDtYsmMw8Jc4vS8Z0g58=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
+github.com/m7shapan/cidr v0.0.0-20200427124835-7eba0889a5d2 h1:ZE8LWAc5ROIC9QJrfx5v8IZXjS6ZdCCCA+WhC7fZhao=
+github.com/m7shapan/cidr v0.0.0-20200427124835-7eba0889a5d2/go.mod h1:DMBq1OXADdf9jRU7u4S3sjINlAV7/yLzYl+YOFeFuQU=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=

--- a/go.sum
+++ b/go.sum
@@ -480,6 +480,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karlseguin/ccache/v2 v2.0.7-0.20200814031513-0dbf3f125f13 h1:IRtbBdf9nezZrJHWPJ1atlyY7hByAnLd/Vp0zrr3LV0=
 github.com/karlseguin/ccache/v2 v2.0.7-0.20200814031513-0dbf3f125f13/go.mod h1:2BDThcfQMf/c0jnZowt16eW405XIqZPavt+HoYEtcxQ=
+github.com/karlseguin/ccache/v2 v2.0.8 h1:lT38cE//uyf6KcFok0rlgXtGFBWxkI6h/qg4tbFyDnA=
+github.com/karlseguin/ccache/v2 v2.0.8/go.mod h1:2BDThcfQMf/c0jnZowt16eW405XIqZPavt+HoYEtcxQ=
 github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003 h1:vJ0Snvo+SLMY72r5J4sEfkuE7AFbixEP2qRbEcum/wA=
 github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -65,16 +65,9 @@ func NewUploaderWithBackend(backend Backend) *Uploader {
 	return &Uploader{backend}
 }
 
-type uploadFileInfo struct {
-	src  string
-	dest string
-}
-
 // Upload of all of files in a directory but not its subdirectories. Performs the uploads in parallel.
 func uploadDir(ctx context.Context, uploader Backend, local string, remote string, ctypeFunc ContentTypeInferenceFunction) error {
 	var errs *multierror.Error
-	fileUploadJobs := []uploadFileInfo{}
-	const concurrentUploaders = 8
 
 	fi, err := os.Stat(local)
 	if err != nil {
@@ -86,60 +79,41 @@ func uploadDir(ctx context.Context, uploader Backend, local string, remote strin
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		} else {
-			log.WithField("file", local).Info("is a directory - to read files")
-			//uploadErrs := make([]error, len(finfos))
-			uploadErrs := make(map[string]error)
-			// Iterate over each file and setup the work
+			uploadErrs := make([]error, len(finfos))
+
+			// Iterate over each file and upload it
 			var wg sync.WaitGroup
 
-			for _, finfo := range finfos {
+			for i, finfo := range finfos {
 				if finfo.IsDir() {
 					continue // don't upload subdirs
 				}
-				srcFile := path.Join(local, finfo.Name())
-				fileUploadJobs = append(fileUploadJobs, uploadFileInfo{srcFile, path.Join(remote, finfo.Name())})
-			}
 
-			// Fill up a buffering channel, so we can drain slowly
-			uploadFileC := make(chan uploadFileInfo, len(fileUploadJobs))
-			for _, j := range fileUploadJobs {
-				uploadFileC <- j
-			}
-			close(uploadFileC)
+				wg.Add(1)
+				go func(i int, fi os.FileInfo) {
+					qlocal := path.Join(local, fi.Name())
+					qremote := path.Join(remote, fi.Name())
 
-			// How many workers do we need
-			uploadWorkers := concurrentUploaders
-			if len(fileUploadJobs) < uploadWorkers {
-				uploadWorkers = len(fileUploadJobs)
-			}
-			wg.Add(uploadWorkers)
-
-			// Define what the worker should do
-			uploadWork := func(ch <-chan uploadFileInfo) {
-				defer wg.Done()
-				for job := range ch {
-					if err = uploader.Upload(ctx, job.src, job.dest, ctypeFunc); err != nil {
-						log.WithField("local", job.src).WithField("remote", job.dest).Error(err)
-						// Note this usage is not thread safe - refer to errGroup implementation in watcher.go
-						uploadErrs[job.src] = err
+					log.WithField("local", qlocal).WithField("remote", qremote).Info("uploading")
+					if err = uploader.Upload(ctx, qlocal, qremote, ctypeFunc); err != nil {
+						log.WithField("local", qlocal).WithField("remote", qremote).Error(err)
+						uploadErrs[i] = err
 					}
-				}
-			}
 
-			// Start the workers
-			for i := 0; i < uploadWorkers; i++ {
-				go uploadWork(uploadFileC)
+					wg.Done()
+				}(i, finfo)
 			}
-
 			wg.Wait()
 
-			for _, v := range uploadErrs {
+			for _, err := range uploadErrs {
 				if err != nil {
-					errs = multierror.Append(errs, v)
+					errs = multierror.Append(errs, err)
 				}
 			}
 		}
+
 	}
+
 	return errs.ErrorOrNil()
 }
 
@@ -154,7 +128,7 @@ func (e *Uploader) Upload(ctx context.Context, local, remote string, ctypeFunc C
 		return uploadDir(ctx, e.backend, local, remote, ctypeFunc)
 	}
 
-	log.WithField("local", local).WithField("remote", remote).Info("uploading a file")
+	log.WithField("local", local).WithField("remote", remote).Info("uploading")
 	return e.backend.Upload(ctx, local, remote, ctypeFunc)
 }
 

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -120,6 +120,7 @@ func uploadDir(ctx context.Context, uploader Backend, local string, remote strin
 				for job := range ch {
 					if err = uploader.Upload(ctx, job.src, job.dest, ctypeFunc); err != nil {
 						log.WithField("local", job.src).WithField("remote", job.dest).Error(err)
+						// Note this usage is not thread safe - refer to errGroup implementation in watcher.go
 						uploadErrs[job.src] = err
 					}
 				}
@@ -150,7 +151,6 @@ func (e *Uploader) Upload(ctx context.Context, local, remote string, ctypeFunc C
 	}
 
 	if fi.IsDir() {
-		log.WithField("Going to upload ", local).WithField("to remote", remote).Info(" - directory")
 		return uploadDir(ctx, e.backend, local, remote, ctypeFunc)
 	}
 

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -74,7 +74,7 @@ type uploadFileInfo struct {
 func uploadDir(ctx context.Context, uploader Backend, local string, remote string, ctypeFunc ContentTypeInferenceFunction) error {
 	var errs *multierror.Error
 	fileUploadJobs := []uploadFileInfo{}
-	const CONUCRRENT_UPLOADERS = 5
+	const concurrentUploaders = 8
 
 	fi, err := os.Stat(local)
 	if err != nil {
@@ -88,7 +88,7 @@ func uploadDir(ctx context.Context, uploader Backend, local string, remote strin
 		} else {
 			log.WithField("file", local).Info("is a directory - to read files")
 			//uploadErrs := make([]error, len(finfos))
-			uploadErrs := make(map[string]error, 0)
+			uploadErrs := make(map[string]error)
 			// Iterate over each file and setup the work
 			var wg sync.WaitGroup
 
@@ -108,7 +108,7 @@ func uploadDir(ctx context.Context, uploader Backend, local string, remote strin
 			close(uploadFileC)
 
 			// How many workers do we need
-			uploadWorkers := CONUCRRENT_UPLOADERS
+			uploadWorkers := concurrentUploaders
 			if len(fileUploadJobs) < uploadWorkers {
 				uploadWorkers = len(fileUploadJobs)
 			}


### PR DESCRIPTION
Container shutdown is slow because of serialized file uploads. 
Add logic to make them concurrent with a limit of 8 go routines per upload. Also, add some deduplication logic to avoid duplicate file uploads.

The changes to upload.go have not been tested as we don't use the directory upload logic yet. I've left similar changes to limit concurrent uploads for whenever we decide to use that logic.

I ran a cursory test to check the number of worker threads when the worker threads exceed the files to be uploaded. I haven't run a test to see if the [slow container shutdown](https://jira.netflix.net/browse/TITUS-4144?filter=-1) is solved with this change.