### PR TITLE
Send the effective networkMode back to the control-plane

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1447,6 +1447,7 @@ func (r *DockerRuntime) Start(parentCtx context.Context, pod *v1.Pod) (string, *
 			IsRoutableIP: true,
 			IPAddress:    ipv4addr.Address.Address,
 			EniIPAddress: ipv4addr.Address.Address,
+			NetworkMode:  r.c.EffectiveNetworkMode(),
 			ResourceID:   fmt.Sprintf("resource-eni-%d", allocation.DeviceIndex()-1),
 			EniID:        eni.NetworkInterfaceId,
 		},

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -473,6 +473,7 @@ type NetworkConfigurationDetails struct {
 	ElasticIPAddress string
 	EniIPAddress     string
 	EniIPv6Address   string
+	NetworkMode      string
 	EniID            string
 	ResourceID       string
 }
@@ -490,7 +491,7 @@ func (n *NetworkConfigurationDetails) ToMap() map[string]string {
 	if n.ElasticIPAddress != "" {
 		m["ElasticIPAddress"] = n.ElasticIPAddress
 	}
-
+	m["NetworkMode"] = n.NetworkMode
 	return m
 }
 


### PR DESCRIPTION
We only get 1 ipv4 and 1 ipv6 to send back to the control-plane
in the form of the pod status.

In the IPv6Only+transition mode, that ipv4 represents the transition ip,
and should not be considered the "normal" ip for the pod.

For this reason, it is helpful to send the effective network-mode
back to the control-plane with the rest of the network configuration
updates, so that it can make better decisions about what data (ip addresses)
it is getting.

Pairs with
https://github.com/Netflix/titus-control-plane/pull/1086
