### PR TITLE
Allow tini to start titus-metratrond

### DIFF
--- a/root/lib/systemd/system/titus-sidecar-metatron-sync@.service
+++ b/root/lib/systemd/system/titus-sidecar-metatron-sync@.service
@@ -9,8 +9,9 @@ PartOf=titus-container@%i.target
 
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
+Environment="TINI_HANDOFF=true"
 # Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work
-ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /sbin/docker-init -s -- /titus/metatron/bin/titus-metatrond
+ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec -e TITUS_UNIX_CB_PATH="" -e TITUS_REDIRECT_STDOUT="" -e TITUS_REDIRECT_STDERR="" --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /sbin/docker-init -s -- /titus/metatron/bin/titus-metatrond
 
 Restart=on-failure
 RestartSec=3

--- a/root/lib/systemd/system/titus-sidecar-metatron-sync@.service
+++ b/root/lib/systemd/system/titus-sidecar-metatron-sync@.service
@@ -10,7 +10,7 @@ PartOf=titus-container@%i.target
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
 # Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work
-ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/metatron/bin/titus-metatrond
+ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /sbin/docker-init -s -- /titus/metatron/bin/titus-metatrond
 
 Restart=on-failure
 RestartSec=3

--- a/tini/src/tini.c
+++ b/tini/src/tini.c
@@ -319,7 +319,7 @@ int spawn(const signal_configuration_t *const sigconf_ptr, char *const argv[],
 	// but the stderr fd fails. Fortunately, this should make the init in the container bail entirely.
 	// This will have the side-effect of closing all of our file descriptors.
 	redir_path = getenv(REDIRECT_STDOUT);
-	if (redir_path) {
+	if (redir_path && strlen(redir_path) > 0) {
 		new_stdout_fd = open(redir_path, O_WRONLY | O_CREAT | O_APPEND,
 				     S_IRUGO | S_IWUGO);
 		if (new_stdout_fd == -1) {
@@ -336,7 +336,7 @@ int spawn(const signal_configuration_t *const sigconf_ptr, char *const argv[],
 	}
 
 	redir_path = getenv(REDIRECT_STDERR);
-	if (redir_path) {
+	if (redir_path && strlen(redir_path) > 0) {
 		new_stderr_fd = open(redir_path, O_WRONLY | O_CREAT | O_APPEND,
 				     S_IRUGO | S_IWUGO);
 		if (new_stderr_fd == -1) {
@@ -850,6 +850,12 @@ void maybe_unix_cb()
 			"No UNIX_CB_PATH set, not connecting back to callback socket")
 		return;
 	}
+
+	if (strlen(socket_path) == 0) {
+        PRINT_INFO(
+            "No UNIX_CB_PATH set, not connecting back to callback socket")
+            return;
+    }
 
 	rootfd = open("/", O_RDONLY);
 	if (rootfd == -1) {


### PR DESCRIPTION
In order for metatron client on Titus ipv6only containers in prod to connect to metatron servers and because of the way[ NLBs NAT IPv6 to IPv4 for NLBs,](https://docs.google.com/document/d/1A-ix_JXPDCYXYOfwJ_kzLC43OVaKTUbGX-3TFXgclkk/edit#), one of the needs is to get TSA to intercept connect requests for metatron client like it does for the container. 

In this diff we allow Tini to start metatron client so that the client can get its call intercepted by TSA.

Verified by changing the .service file manually on the agent.

This has the unintended side effect of metatron logs getting redirected to stdout and stderr. Working on that in the interim.
