### PR TITLE
bump the task max for the titus executor systemd unit

### DIFF
--- a/root/lib/systemd/system/titus-executor@.service
+++ b/root/lib/systemd/system/titus-executor@.service
@@ -9,7 +9,7 @@ KillSignal=SIGINT
 KillMode=mixed
 TimeoutStopSec=600
 TimeoutStartSec=1200
-TasksMax=50000
+TasksMax=105000
 RemainAfterExit=yes
 # The runtime directory gets removed upon unit shutdown
 RuntimeDirectory=titus-executor/%i


### PR DESCRIPTION
The pid max for the docker container is 100k, but the executor
is 50k. That means that the container workload can cause
the executor to fail.
