### PR TITLE
Remove repeated nfvpc field in "Details"

### DIFF
--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -70,7 +70,6 @@ func (r *runtimeMock) Start(ctx context.Context, pod *v1.Pod) (string, *runtimeT
 	close(r.startCalled)
 	r.startCalled = make(chan<- struct{}) // reset subscription
 	details := &runtimeTypes.Details{
-		IPAddresses: make(map[string]string),
 		NetworkConfiguration: &runtimeTypes.NetworkConfigurationDetails{
 			IsRoutableIP: false,
 		},

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1448,9 +1448,6 @@ func (r *DockerRuntime) Start(parentCtx context.Context, pod *v1.Pod) (string, *
 	}
 
 	details = &runtimeTypes.Details{
-		IPAddresses: map[string]string{
-			"nfvpc": ipv4addr.Address.Address,
-		},
 		NetworkConfiguration: &runtimeTypes.NetworkConfigurationDetails{
 			IsRoutableIP: true,
 			IPAddress:    ipv4addr.Address.Address,

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -498,7 +498,6 @@ func (n *NetworkConfigurationDetails) ToMap() map[string]string {
 // Details contains additional details about a container that are
 // not returned by normal container start calls.
 type Details struct {
-	IPAddresses          map[string]string `json:"ipAddresses,omitempty"`
 	NetworkConfiguration *NetworkConfigurationDetails
 }
 


### PR DESCRIPTION
Remove the ipaddresses field with nfvpc. This is from a long time ago, and no longer used.