### PR TITLE
Added /run tmpfs for other containers in a pod

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1830,6 +1830,9 @@ func (r *DockerRuntime) k8sContainerToDockerConfigs(v1Container v1.Container, ma
 		VolumesFrom: []string{mainContainerID},
 		Mounts:      mounts,
 		Init:        &b,
+		Tmpfs: map[string]string{
+			"/run": "rw,exec,size=" + defaultRunTmpFsSize,
+		},
 	}
 	// Nothing extra is needed here, because networking is defined in the HostConfig referencing the main container
 	dockerNetworkConfig := &network.NetworkingConfig{}


### PR DESCRIPTION
This matches the /run configuration behavior on the main
container. This allows sidecars to also use /run
in a tmpfs manner, and have faith the files will not
be on disk, etc.
