### PR TITLE
Fixed support for shared volume mount propagation

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1891,7 +1891,7 @@ func v1MountPropToDockerProp(fo v1.MountPropagationMode) mount.Propagation {
 	case v1.MountPropagationHostToContainer:
 		return mount.PropagationRSlave
 	default:
-		return mount.PropagationPrivate
+		return ""
 	}
 }
 

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -98,6 +98,7 @@ type JobInput struct {
 	// Raw k8s containers, expected to come from the control plane
 	ExtraContainers  []corev1.Container
 	ExtraAnnotations map[string]string
+	Volumes          []corev1.Volume
 }
 
 // JobRunResponse returned from RunJob
@@ -401,6 +402,7 @@ func createPodTask(jobInput *JobInput, jobID string, task *runner.Task, env map[
 					Resources: resourceReqs,
 				},
 			},
+			Volumes: jobInput.Volumes,
 		},
 	}
 	pod.Spec.Containers = append(pod.Spec.Containers, jobInput.ExtraContainers...)

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -1357,7 +1357,7 @@ func TestBasicMultiContainerCustomSharedVolumes(t *testing.T) {
 			},
 		},
 	}
-	mountProp := corev1.MountPropagationHostToContainer
+	mountProp := corev1.MountPropagationNone
 	sharedVolumeMount := corev1.VolumeMount{
 		Name:             "shared-from-mains-etc",
 		MountPath:        "/mains-etc",

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -1338,6 +1338,56 @@ func TestBasicMultiContainerSharesCommonVolumes(t *testing.T) {
 	}
 }
 
+func TestBasicMultiContainerCustomSharedVolumes(t *testing.T) {
+	wrapTestStandalone(t)
+	skipIfNotPod(t)
+
+	// In the main container, we expect to see a file created by our sentinel
+	testEntrypointOld := "stat /etc/sentinel"
+	testEntrypointOld = `/bin/sh -vxc "sleep 3;` + testEntrypointOld + `"`
+
+	sharedVolume := corev1.Volume{
+		Name: "shared-from-mains-etc",
+		VolumeSource: corev1.VolumeSource{
+			FlexVolume: &corev1.FlexVolumeSource{
+				Driver: "SharedContainerVolumeSource",
+				Options: map[string]string{
+					"sourcePath": "/etc",
+				},
+			},
+		},
+	}
+	mountProp := corev1.MountPropagationHostToContainer
+	sharedVolumeMount := corev1.VolumeMount{
+		Name:             "shared-from-mains-etc",
+		MountPath:        "/mains-etc",
+		ReadOnly:         false,
+		MountPropagation: &mountProp,
+	}
+
+	ji := &JobInput{
+		ImageName:  busybox.name,
+		Version:    busybox.tag,
+		UsePodSpec: UseV1PodspecInTest,
+		// This sentinel container touches a file, and the main container should
+		// see it if volumes are working
+		ExtraContainers: []corev1.Container{
+			{
+				Name:         "touch-sentinel",
+				Image:        busybox.name + `:` + busybox.tag,
+				Command:      []string{"/bin/sh", "-vxc"},
+				Args:         []string{"touch /mains-etc/sentinel"},
+				VolumeMounts: []corev1.VolumeMount{sharedVolumeMount},
+			},
+		},
+		Volumes:       []corev1.Volume{sharedVolume},
+		EntrypointOld: testEntrypointOld,
+	}
+	if !RunJobExpectingSuccess(t, ji) {
+		t.Fail()
+	}
+}
+
 func TestMultiContainerDoesPlatformFirst(t *testing.T) {
 	wrapTestStandalone(t)
 	skipIfNotPod(t)
@@ -1349,7 +1399,7 @@ func TestMultiContainerDoesPlatformFirst(t *testing.T) {
 	// The main container and the user-sentinel are both 'user' containers,
 	// So we want the main container to waid just a little bit for the user-sentinel
 	// to come up, report back if the platform-sentinel is running or not, and then continue
-	testEntrypointOld = `/bin/sh -c "sleep 3;` + testEntrypointOld + `"`
+	testEntrypointOld = `/bin/sh -c "sleep 6;` + testEntrypointOld + `"`
 
 	ji := &JobInput{
 		ImageName:  busybox.name,


### PR DESCRIPTION
Previously we were passing in literally the v1 k8s mount
propgation string, which docker didn't like.

This adds the appropriate conversion and a test.
