### PR TITLE
Always use byte units from pods

### DIFF
--- a/cmd/titus-standalone/pod.jsonnet
+++ b/cmd/titus-standalone/pod.jsonnet
@@ -7,7 +7,6 @@
     "resourceVersion": "3177086735",
     "creationTimestamp": "2021-02-12T07:20:00Z",
     "labels": {
-      "pod.titus.netflix.com/byteUnits": "true",
       "titus.netflix.com/capacity-group": "default",
       "v3.job.titus.netflix.com/job-id": "34fe318e-c7b6-4fee-a213-ab4f57bb03e6",
       "v3.job.titus.netflix.com/task-id": "843863f1-41a2-4a73-89bc-89c506bc1e14"

--- a/pod.json
+++ b/pod.json
@@ -7,7 +7,6 @@
     "resourceVersion": "3177086735",
     "creationTimestamp": "2021-02-12T07:20:00Z",
     "labels": {
-      "pod.titus.netflix.com/byteUnits": "true",
       "titus.netflix.com/capacity-group": "default",
       "v3.job.titus.netflix.com/job-id": "34fe318e-c7b6-4fee-a213-ab4f57bb03e6",
       "v3.job.titus.netflix.com/task-id": "843863f1-41a2-4a73-89bc-89c506bc1e14"

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -166,11 +166,6 @@ func NewBackend(ctx context.Context, rp runtimeTypes.ContainerRuntimeProvider, p
 		}
 	}
 
-	useBytes, err := podCommon.ByteUnitsEnabled(pod)
-	if err != nil {
-		return nil, errors.Wrap(err, "Could not parse byte units pod annotation")
-	}
-
 	limits := pod.Spec.Containers[0].Resources.Limits
 
 	// TODO: pick one, agreed upon resource name after migration to k8s scheduler is complete.
@@ -195,23 +190,21 @@ func NewBackend(ctx context.Context, rp runtimeTypes.ContainerRuntimeProvider, p
 	memory := limits[v1.ResourceMemory]
 	network := limits[resourceCommon.ResourceNameNetwork]
 
-	if useBytes {
-		// The control plane has passed resource values in bytes, but the runner takes
-		// MiB / MB, so we need to do the conversion.
-		disk, err = resourceBytesToMiB(&disk)
-		if err != nil {
-			return nil, errors.New("error converting disk resource units")
-		}
+	// The control plane has passed resource values in bytes, but the runner takes
+	// MiB / MB, so we need to do the conversion.
+	disk, err = resourceBytesToMiB(&disk)
+	if err != nil {
+		return nil, errors.New("error converting disk resource units")
+	}
 
-		memory, err = resourceBytesToMiB(&memory)
-		if err != nil {
-			return nil, errors.New("error converting memory resource units")
-		}
+	memory, err = resourceBytesToMiB(&memory)
+	if err != nil {
+		return nil, errors.New("error converting memory resource units")
+	}
 
-		network, err = resourceBytesToMB(&network)
-		if err != nil {
-			return nil, errors.New("error converting network resource units")
-		}
+	network, err = resourceBytesToMB(&network)
+	if err != nil {
+		return nil, errors.New("error converting network resource units")
 	}
 
 	be := &Backend{


### PR DESCRIPTION
This cleans up the feature toggle as we transitioned
to use byte units on the pod spec.

We are always using bytes now, this just removes the toggle.
