### PR TITLE
Added sshdmulti for multiple containers

### DIFF
--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -426,31 +426,12 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 
 	sidecars, err := c.SidecarConfigs()
 	assert.NilError(t, err)
-	//sort.Slice(sidecars, func(i, j int) bool { return sidecars[i].ServiceName < sidecars[j].ServiceName })
-	sidecarNames := []string{}
 	svcMeshImage := ""
 	for _, sc := range sidecars {
-		sidecarNames = append(sidecarNames, sc.ServiceName)
 		if sc.ServiceName == SidecarServiceServiceMesh {
 			svcMeshImage = sc.Image
 		}
 	}
-	assert.DeepEqual(t, sidecarNames,
-		[]string{
-			SidecarTitusContainer,
-			SidecarServiceSpectatord,
-			SidecarServiceAtlasd,
-			SidecarServiceAtlasAgent,
-			SidecarServiceSshd,
-			SidecarServiceMetadataProxy,
-			SidecarServiceMetatron,
-			SidecarServiceLogViewer,
-			SidecarServiceServiceMesh,
-			SidecarServiceAbMetrix,
-			SidecarSeccompAgent,
-			SidecarTitusStorage,
-			SidecarContainerTools,
-		})
 	assert.Equal(t, svcMeshImage, expSvcMeshImage)
 
 	assert.DeepEqual(t, c.SignedAddressAllocationUUID(), ptr.StringPtr("static-ip-uuid"))

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -12,6 +12,7 @@ const (
 	SidecarServiceMetatron      = "metatron"
 	SidecarServiceServiceMesh   = "servicemesh"
 	SidecarServiceSshd          = "sshd"
+	SidecarServiceSshdMulti     = "sshdmulti"
 	SidecarServiceSpectatord    = "spectatord"
 	SidecarServiceAtlasd        = "atlasd"
 	SidecarServiceAtlasAgent    = "atlas-agent"
@@ -60,6 +61,12 @@ var sideCars = []ServiceOpts{
 		Volumes: map[string]struct{}{
 			"/titus/sshd": {},
 		},
+	},
+	{
+		ServiceName:  SidecarServiceSshdMulti,
+		UnitName:     "titus-sidecar-sshdmulti",
+		EnabledCheck: shouldStartSSHDMulti,
+		Required:     false,
 	},
 	{
 		ServiceName: SidecarServiceMetadataProxy,
@@ -186,6 +193,13 @@ func shouldStartAtlasAgent(cfg *config.Config, c Container) bool {
 
 func shouldStartSSHD(cfg *config.Config, c Container) bool {
 	return cfg.ContainerSSHD
+}
+
+// shouldStartSSHDMulti returns true only if SSHd is enabled and
+// we have 1 or more extra containers to even spawn sshs for
+func shouldStartSSHDMulti(cfg *config.Config, c Container) bool {
+	extraContainerCount := len(c.ExtraPlatformContainers()) + len(c.ExtraUserContainers())
+	return shouldStartSSHD(cfg, c) && extraContainerCount > 0
 }
 
 func shouldStartLogViewer(cfg *config.Config, c Container) bool {

--- a/root/apps/titus-executor/bin/titus-sshd-multi
+++ b/root/apps/titus-executor/bin/titus-sshd-multi
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Spawns and extra sshd for ever additional container past
+# the main container in a Pod.
+
+function listExtraContainersFor {
+  # It is important to get the names of the extra containers in the same order that they
+  # are reported in the pod, because that is what the control-plane knows.
+  # The order here ensures that we pick a port number that matches with what
+  # other systems will assume.
+  if [[ -f "/run/titus-executor/default__$1/pod.json" ]]; then
+    jq -r '.spec.containers[1:] | .[].name' "/run/titus-executor/default__$1/pod.json"
+  fi
+}
+
+function spawnSshdForContainer {
+  local cName=$1
+  local port=$2
+  echo "Spawning titus-sshd for docker container $cName on port $port"
+  PID1=$(docker inspect "${TASK_ID}-$cName" --format '{{.State.Pid}}')
+  TITUS_PID_1_DIR="/proc/$PID1/root/proc/1" /apps/titus-executor/bin/titus-nsenter /titus/sshd/run-titus-sshd -D -e -p "$port"
+}
+
+port=23
+for container in $(listExtraContainersFor "$TASK_ID") ; do
+  spawnSshdForContainer "$container" "$port" 2>&1 | sed "s/^/sshd-$container: /g" &
+  (( port++ ))
+done
+wait

--- a/root/lib/systemd/system/titus-sidecar-sshdmulti@.service
+++ b/root/lib/systemd/system/titus-sidecar-sshdmulti@.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=SSHD-multi for other containers for %i
+ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
+
+StartLimitIntervalSec=30
+StartLimitBurst=5
+CollectMode=inactive-or-failed
+PartOf=titus-container@%i.target
+
+[Service]
+# TSA is used in the main container processes to handle certain syscalls
+# To ensure a sane user experience, we want sshd-spawned processes to
+# get TSA help too. This environment variable ensures that will happen.
+Environment=TITUS_NSENTER_USE_TSA=true
+EnvironmentFile=/var/lib/titus-environments/%i.env
+ExecStart=/apps/titus-executor/bin/titus-sshd-multi
+LimitNOFILE=65535
+## TODO: Wire up more "lockdown" so this unit can't wreck havoc if it gets compromised
+PrivateTmp=yes
+
+RestartSec=3
+# ssh-multi is considered best effort, and if we crash
+# super hard, we won't try to restart
+Restart=never
+KillMode=mixed


### PR DESCRIPTION
This adds a new "sshdMulti" Titus System Service to run
multiple sshds for each container in a pod.

In the C&W way, the main container is untouched, and the sshd runs
as normal as before.

The Mulit one is special and spawns one per extra container, incrementing
the port number by one each.

No additional supervision is added though. They are second-class in that way.

Some concerns:

1. Gotta get 7523+ ports open, seems tractable
2. I'm a bit worried about all the extra ram that will go towards the host (not task!)
