### PR TITLE
Make sure that all containers in a pod have the same security settings

### DIFF
--- a/executor/runtime/docker/capabilities.go
+++ b/executor/runtime/docker/capabilities.go
@@ -100,11 +100,6 @@ func setupAdditionalCapabilities(c runtimeTypes.Container, hostCfg *container.Ho
 		hostCfg.Sysctls["net.ipv4.conf.all.arp_ignore"] = "1"
 	}
 
-	if c.IsSystemD() {
-		// Tell Tini to exec systemd so it's pid 1
-		c.SetEnv("TINI_HANDOFF", trueString)
-	}
-
 	hostCfg.SecurityOpt = append(hostCfg.SecurityOpt, "apparmor:"+apparmorProfile)
 	asset := seccomp.MustAsset(seccompProfile)
 	var buf bytes.Buffer

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -458,6 +458,8 @@ func (r *DockerRuntime) mainContainerDockerConfig(c runtimeTypes.Container, bind
 	if c.IsSystemD() {
 		// systemd requires `/run/lock` to be a separate mount from `/run`
 		hostCfg.Tmpfs["/run/lock"] = "rw,exec,size=" + defaultRunLockTmpFsSize
+		// Systemd *must* be pid1. Setting this variable instructs tini to exec into systemd so it can be pid 1
+		c.SetEnv("TINI_HANDOFF", trueString)
 	}
 
 	if shmSize := c.ShmSizeMiB(); shmSize != nil {
@@ -1850,6 +1852,13 @@ func (r *DockerRuntime) k8sContainerToDockerConfigs(v1Container v1.Container, ma
 			"/run": "rw,exec,size=" + defaultRunTmpFsSize,
 		},
 	}
+
+	// Security options are inherited from the main container's configuration
+	err := setupAdditionalCapabilities(r.c, dockerHostConfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	// Nothing extra is needed here, because networking is defined in the HostConfig referencing the main container
 	dockerNetworkConfig := &network.NetworkingConfig{}
 	return dockerContainerConfig, dockerHostConfig, dockerNetworkConfig, nil


### PR DESCRIPTION
Previously, I was not setting the dockerconfig setting for security
options.

This PR reuses our existing function to set these on the main container,
except now it applies to *all* containers in a pod, ensuring they all
share the same seccomp policy and apparmor profile.

TINI_HANDOFF was taken out because it isn't really a security setting, and
I didn't want it applying to extra containers (They are not running systemd)
