### PR TITLE
Added a command to switch between multiple containers in a pod

### DIFF
--- a/hack/images/titus-sshd/Dockerfile
+++ b/hack/images/titus-sshd/Dockerfile
@@ -64,6 +64,7 @@ RUN ln -s /etc/passwd /titus/sshd/etc/
 RUN ln -s /etc/hosts /titus/sshd/etc/
 RUN ln -s /titus/sshd/bin/busybox /titus/sshd/bin/sh
 ADD run-titus-sshd /titus/sshd/run-titus-sshd
+ADD switch-container /titus/sshd/usr/bin/switch-container
 # The /titus/sshd volume is considered immutable, but sshd_config is generated
 # dynamically from the titus-agent, so we symlink it in from /titus/etc
 RUN rm /titus/sshd/etc/ssh/sshd_config && ln -s /titus/etc/ssh/sshd_config /titus/sshd/etc/ssh/sshd_config

--- a/hack/images/titus-sshd/switch-container
+++ b/hack/images/titus-sshd/switch-container
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# switch-container: wrapper around nsenter to allow users to
+# switch from one container to another.
+# Requires the nsenter command and root privileges.
+# Also depends on all containers sharing a PID namespace.
+
+declare -A container_pid_map
+function scan_pids {
+for pidpath in /proc/[0-9]*; do
+  container=$(/titus/sshd/bin/busybox strings "$pidpath/environ" 2>/dev/null | grep TITUS_CONTAINER_NAME | cut -f 2 -d =)
+  [[ -z $container ]] && continue
+  container_pid_map[$container]=$(basename "$pidpath")
+done
+}
+
+function list_containers {
+echo "Available running containers in this pod:" >&2
+for c in "${!container_pid_map[@]}"; do
+  echo " - $c (pid ${container_pid_map[$c]})" >&2
+done
+echo "" >&2
+}
+
+scan_pids
+if [[ ! -n $1 ]]; then
+  echo "Please provide a container name as the first argument to this command." >&2
+  list_containers
+  exit 3
+fi
+
+target_container=$1
+target=${container_pid_map[$target_container]}
+if [[ -n $target ]]; then
+  echo "Targeting the $target_container container to ns-enter into (pid $target)" >&2
+else
+  echo "Couldn't find target '$target_container'. Is it running in this pod?" >&2
+  list_containers
+  exit 3
+fi
+
+exec nsenter --all --target "$target" --setuid "$(id -u)" --setgid "$(id -g)" --root="/proc/$target/root" --wd="/proc/$target/root/"


### PR DESCRIPTION
Not as advanced as the "run one sshd per container", but is cheap.

I don't think we should consider this a stable interface, but a
good enough solution for sidecar authors to troubleshoot their stuff.

If shipit, I can add new links (once the titus api understand podstatus output)
for each container, which a one-click link that copies

    ssh $task -- switch-container $container

To make it easy


----

Pros:
* lightweight

Cons:
* more brittle
* depends on more binaries (nsenter)
* requires the main container's ssh to work first
* requires shared pid namespace
* won't support (maybe could be hacked?) rsync, scp