### PR TITLE
RFC: Added host entries for all containers in a pod

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -159,7 +159,7 @@ func (r *Runner) prepareContainer(ctx context.Context) update {
 	}()
 	// When Create() returns the host may have been modified to create storage and pull the image.
 	// These steps may or may not have completed depending on if/where a failure occurred.
-	if err := r.runtime.Prepare(prepareCtx); err != nil {
+	if err := r.runtime.Prepare(prepareCtx, r.pod); err != nil {
 		r.metrics.Counter("titus.executor.launchTaskFailed", 1, nil)
 		logger.G(ctx).WithError(err).Error("Task failed to create main container")
 		// Treat registry pull errors as LOST and non-existent images as FAILED.

--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -52,7 +52,7 @@ type runtimeMock struct {
 	killCallback    func(c runtimeTypes.Container) error
 }
 
-func (r *runtimeMock) Prepare(ctx context.Context) error {
+func (r *runtimeMock) Prepare(ctx context.Context, pod *v1.Pod) error {
 	if r.c == nil {
 		panic("Container is nil")
 	}

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -511,7 +511,7 @@ type Runtime interface {
 	// TODO(fabio): better (non-Docker specific) abstraction for binds
 	// The context passed to the Prepare, and Start function is valid over the lifetime of the container,
 	// NOT per-operation
-	Prepare(containerCtx context.Context) error
+	Prepare(containerCtx context.Context, pod *corev1.Pod) error
 	// Start a container -- Returns an optional Log Directory if an external Logger is desired
 	Start(containerCtx context.Context, pod *corev1.Pod) (string, *Details, <-chan StatusMessage, error)
 	// Kill a container. MUST be idempotent.


### PR DESCRIPTION
I want to make it easier for containers to live in a world
where there could be port conflicts.

This isnt a 100% solution, but it at least allows in theory
containers in a pod to play nice and bind only to their own
"localhost" address.

With this in place, multiple containers in a pod could all
listen on $TITUS_CONTAINER_NAME:80 and it would work!
