### PR TITLE
Remove attribute-method for setting TSA for network syscalls

### DIFF
--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -58,7 +58,6 @@ const (
 	LogKeepLocalFileAfterUploadParam        = "titusParameter.agent.log.keepLocalFileAfterUpload"
 	FuseEnabledParam                        = "titusParameter.agent.fuseEnabled"
 	KvmEnabledParam                         = "titusParameter.agent.kvmEnabled"
-	SeccompAgentEnabledForNetSyscallsParam  = "titusParameter.agent.seccompAgentEnabledForNetSyscalls"
 	SeccompAgentEnabledForPerfSyscallsParam = "titusParameter.agent.seccompAgentEnabledForPerfSyscalls"
 	assignIPv6AddressParam                  = "titusParameter.agent.assignIPv6Address"
 	batchPriorityParam                      = "titusParameter.agent.batchPriority"
@@ -174,7 +173,6 @@ type TitusInfoContainer struct {
 	kvmEnabled                         bool
 	nfsMounts                          []NFSMount
 	requireIMDSToken                   string
-	seccompAgentEnabledForNetSyscalls  bool
 	seccompAgentEnabledForPerfSyscalls bool
 	serviceMeshEnabled                 *bool
 	serviceMeshImage                   string
@@ -312,10 +310,6 @@ func NewTitusInfoContainer(taskID string, titusInfo *titus.ContainerInfo, resour
 		{
 			paramName:     KvmEnabledParam,
 			containerAttr: &c.kvmEnabled,
-		},
-		{
-			paramName:     SeccompAgentEnabledForNetSyscallsParam,
-			containerAttr: &c.seccompAgentEnabledForNetSyscalls,
 		},
 		{
 			paramName:     SeccompAgentEnabledForPerfSyscallsParam,
@@ -832,7 +826,7 @@ func (c *TitusInfoContainer) EffectiveNetworkMode() string {
 	if c.podConfig != nil && c.podConfig.NetworkMode != nil {
 		mode = *c.podConfig.NetworkMode
 	}
-	return computeEffectiveNetworkMode(mode, c.AssignIPv6Address(), c.SeccompAgentEnabledForNetSyscalls())
+	return computeEffectiveNetworkMode(mode, c.AssignIPv6Address())
 }
 
 func (c *TitusInfoContainer) NFSMounts() []NFSMount {
@@ -902,10 +896,6 @@ func (c *TitusInfoContainer) Runtime() string {
 
 func (c *TitusInfoContainer) SeccompAgentEnabledForPerfSyscalls() bool {
 	return c.seccompAgentEnabledForPerfSyscalls
-}
-
-func (c *TitusInfoContainer) SeccompAgentEnabledForNetSyscalls() bool {
-	return c.seccompAgentEnabledForNetSyscalls
 }
 
 func (c *TitusInfoContainer) SecurityGroupIDs() *[]string {

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -518,7 +518,7 @@ func (c *PodContainer) EffectiveNetworkMode() string {
 	if c.podConfig != nil && c.podConfig.NetworkMode != nil {
 		mode = *c.podConfig.NetworkMode
 	}
-	return computeEffectiveNetworkMode(mode, c.AssignIPv6Address(), c.SeccompAgentEnabledForNetSyscalls())
+	return computeEffectiveNetworkMode(mode, c.AssignIPv6Address())
 }
 
 func (c *PodContainer) NFSMounts() []NFSMount {
@@ -560,16 +560,6 @@ func (c *PodContainer) Runtime() string {
 		return c.gpuInfo.Runtime()
 	}
 	return DefaultOciRuntime
-}
-
-// SeccompAgentEnabledForNetSyscalls only represents whether a user set the SeccompAgentEnabledForNetSyscalls
-// attribute, and does not represent the source of truth of whether TSA will
-// be activated or not (EffectiveNetworkMode is the source of truth for that)
-func (c *PodContainer) SeccompAgentEnabledForNetSyscalls() bool {
-	if c.podConfig.SeccompAgentNetEnabled != nil {
-		return *c.podConfig.SeccompAgentNetEnabled
-	}
-	return false
 }
 
 func (c *PodContainer) SeccompAgentEnabledForPerfSyscalls() bool {

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -295,7 +295,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 	assert.Equal(t, c.AllowNetworkBursting(), true)
 	assert.Equal(t, c.AppName(), "appName")
 	assert.Equal(t, c.AssignIPv6Address(), true)
-	assert.Equal(t, c.EffectiveNetworkMode(), titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String())
+	assert.Equal(t, c.EffectiveNetworkMode(), titus.NetworkConfiguration_Ipv6AndIpv4.String())
 	assert.DeepEqual(t, c.BandwidthLimitMbps(), &expBwLimit)
 	assert.DeepEqual(t, c.BatchPriority(), ptr.StringPtr("idle"))
 	assert.DeepEqual(t, c.Capabilities(), expCapabilities)
@@ -319,7 +319,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 		"NETFLIX_AUTO_SCALE_GROUP":          "appName-appStack-appDetail-appSeq",
 		"NETFLIX_CLUSTER":                   "appName-appStack-appDetail",
 		"NETFLIX_DETAIL":                    "appDetail",
-		"NETFLIX_NETWORK_MODE":              "IPV6_WITH_TRANSITION",
+		"NETFLIX_NETWORK_MODE":              "DUAL_STACK",
 		"NETFLIX_STACK":                     "appStack",
 		"TITUS_BATCH":                       "idle",
 		"TITUS_HOST_EC2_INSTANCE_ID":        "",
@@ -418,7 +418,6 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 	assert.DeepEqual(t, c.Resources(), expResources)
 	assert.DeepEqual(t, c.RequireIMDSToken(), ptr.StringPtr("token"))
 	assert.Equal(t, c.Runtime(), "runc")
-	assert.Equal(t, c.SeccompAgentEnabledForNetSyscalls(), true)
 	assert.Equal(t, c.SeccompAgentEnabledForPerfSyscalls(), true)
 	assert.DeepEqual(t, c.SecurityGroupIDs(), &expSGs)
 	assert.Equal(t, c.ServiceMeshEnabled(), true)

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -135,7 +135,7 @@ func shouldStartMetatronSync(cfg *config.Config, c Container) bool {
 }
 
 func shouldStartTitusSeccompAgent(cfg *config.Config, c Container) bool {
-	return c.SeccompAgentEnabledForPerfSyscalls() || c.SeccompAgentEnabledForNetSyscalls() || c.EffectiveNetworkMode() == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String()
+	return c.SeccompAgentEnabledForPerfSyscalls() || c.EffectiveNetworkMode() == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String()
 }
 
 func shouldStartServiceMesh(cfg *config.Config, c Container) bool {

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -196,7 +196,6 @@ type Container interface {
 	Resources() *Resources
 	RequireIMDSToken() *string
 	Runtime() string
-	SeccompAgentEnabledForNetSyscalls() bool
 	SeccompAgentEnabledForPerfSyscalls() bool
 	SecurityGroupIDs() *[]string
 	ServiceMeshEnabled() bool
@@ -403,14 +402,12 @@ func GenerateV0TestPod(taskID string, resources *Resources, cfg *config.Config) 
 // Someday when network mode is set across the board, we can drop this function and just fail
 // fast when network mode is Unknown, but till then, this function encpasulates the busines logic
 // of interpretting the legacy attributes and computing what the effective network mode "should" be
-func computeEffectiveNetworkMode(originalNetworkMode string, assignIPv6Address bool, seccompAgentEnabledForNetSyscalls bool) string {
+func computeEffectiveNetworkMode(originalNetworkMode string, assignIPv6Address bool) string {
 	if originalNetworkMode == titus.NetworkConfiguration_UnknownNetworkMode.String() {
 		if assignIPv6Address {
-			if seccompAgentEnabledForNetSyscalls {
-				return titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String()
-			}
 			return titus.NetworkConfiguration_Ipv6AndIpv4.String()
 		}
+		return titus.NetworkConfiguration_Ipv4Only.String()
 	}
 	return originalNetworkMode
 }

--- a/executor/runtime/types/types_test.go
+++ b/executor/runtime/types/types_test.go
@@ -156,7 +156,7 @@ func TestDefaultNetworkMode(t *testing.T) {
 
 	c, err := NewContainerWithPod(taskID, titusInfo, *resources, *conf, pod)
 	assert.NoError(t, err)
-	assert.Equal(t, titus.NetworkConfiguration_UnknownNetworkMode.String(), c.EffectiveNetworkMode())
+	assert.Equal(t, titus.NetworkConfiguration_Ipv4Only.String(), c.EffectiveNetworkMode())
 }
 
 func TestIPv6NetworkModeRespectsThePassthroughBool(t *testing.T) {


### PR DESCRIPTION
Now that we have network mode, and network mode can be set
via the API, spinnaker, CMB, etc, we no longer need this attribute.

I'll search for any jobs using it, but there should be none.
If there are any, they need to start using the real api.
