### PR TITLE
Added an imageinspect on all extra containers and correctly set entrypoint for them

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1633,7 +1633,7 @@ func (r *DockerRuntime) pullAllExtraContainers(ctx context.Context, pod *v1.Pod)
 			}
 			imageInspect, err2 := imageExists(ctx, r.client, image)
 			if err2 != nil {
-				return fmt.Errorf("Failed to inspect %s after pull: %s", image, err2)
+				return fmt.Errorf("Failed to inspect %s after pull: %w", image, err2)
 			}
 			c2.ImageInspect = imageInspect
 			return nil
@@ -1654,7 +1654,7 @@ func (r *DockerRuntime) createAllExtraContainers(ctx context.Context, pod *v1.Po
 	for idx := range r.c.ExtraUserContainers() {
 		c := r.c.ExtraUserContainers()[idx]
 		group.Go(func(ctx context.Context) error {
-			cid, err := r.createExtraContainerInDocker(ctx, c.V1Container, mainContainerID, mainContainerRoot, pod)
+			cid, err := r.createExtraContainerInDocker(ctx, c, mainContainerID, mainContainerRoot, pod)
 			if err != nil {
 				return fmt.Errorf("Failed to create %s user container: %w", c.Name, err)
 			}
@@ -1667,7 +1667,7 @@ func (r *DockerRuntime) createAllExtraContainers(ctx context.Context, pod *v1.Po
 	for idx := range r.c.ExtraPlatformContainers() {
 		c := r.c.ExtraPlatformContainers()[idx]
 		group.Go(func(ctx context.Context) error {
-			cid, err := r.createExtraContainerInDocker(ctx, c.V1Container, mainContainerID, mainContainerRoot, pod)
+			cid, err := r.createExtraContainerInDocker(ctx, c, mainContainerID, mainContainerRoot, pod)
 			if err != nil {
 				return fmt.Errorf("Failed to create %s platform container: %w", c.Name, err)
 			}
@@ -1739,26 +1739,27 @@ func (r *DockerRuntime) startUserDefinedContainers(ctx context.Context, tiniConn
 	return group.Wait()
 }
 
-func (r *DockerRuntime) createExtraContainerInDocker(ctx context.Context, v1Container v1.Container, mainContainerID string, mainContainerRoot string, pod *v1.Pod) (string, error) {
+func (r *DockerRuntime) createExtraContainerInDocker(ctx context.Context, c *runtimeTypes.ExtraContainer, mainContainerID string, mainContainerRoot string, pod *v1.Pod) (string, error) {
 	l := log.WithField("taskID", r.c.TaskID())
-	containerName := r.c.TaskID() + "-" + v1Container.Name
-	dockerContainerConfig, dockerHostConfig, dockerNetworkConfig, err := r.k8sContainerToDockerConfigs(v1Container, mainContainerID, mainContainerRoot, pod)
+	containerName := r.c.TaskID() + "-" + c.Name
+	dockerContainerConfig, dockerHostConfig, dockerNetworkConfig, err := r.k8sContainerToDockerConfigs(c, mainContainerID, mainContainerRoot, pod)
 	if err != nil {
 		return "", fmt.Errorf("error creating the %s container: %s", containerName, err)
 	}
 	l.WithFields(map[string]interface{}{
 		"dockerCfg": logger.ShouldJSON(ctx, *dockerContainerConfig),
 		"hostCfg":   logger.ShouldJSON(ctx, *dockerHostConfig),
-	}).Infof("Creating other container in docker: %s", v1Container.Name)
+	}).Infof("Creating other container in docker: %s", c.Name)
 	containerCreateBody, err := r.client.ContainerCreate(ctx, dockerContainerConfig, dockerHostConfig, dockerNetworkConfig, containerName)
 	if err != nil {
 		return "", err
 	}
-	l.Debugf("Finished creating container %s, CID: %s, Env: %+v", v1Container.Name, containerCreateBody.ID, dockerContainerConfig.Env)
+	l.Debugf("Finished creating container %s, CID: %s, Env: %+v", c.Name, containerCreateBody.ID, dockerContainerConfig.Env)
 	return containerCreateBody.ID, nil
 }
 
-func (r *DockerRuntime) k8sContainerToDockerConfigs(v1Container v1.Container, mainContainerID string, mainContainerRoot string, pod *v1.Pod) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
+func (r *DockerRuntime) k8sContainerToDockerConfigs(c *runtimeTypes.ExtraContainer, mainContainerID string, mainContainerRoot string, pod *v1.Pod) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
+	v1Container := c.V1Container
 	// These labels are needed for titus-node-problem-detector and titus-isolate
 	// to know that this container is actually part of the "main" one.
 	labels := map[string]string{
@@ -1836,26 +1837,15 @@ func (r *DockerRuntime) k8sContainerToDockerConfigs(v1Container v1.Container, ma
 		}...)
 	}
 	b := true
-	// What docker calls "command", is what k8s calls "Args"
-	dockerCmd := v1Container.Args
-	// What docker calls "entrypoint", k8s calls "command", but in addition, we prepend tini
-	// The reason we do this is because, even with init=true, docker will only inject tini
-	// on containers running in a private pid namespace.
-	// On titus, we want tini on *every* container, because it gives us features like stdout/err
-	// TODO: get the entrypoint that comes from the *image* and use it here if `v1Container.Command` is null
-	// Because as is, we are *setting* the entrypoint all the time here, which means docker is going
-	// to ignore whatever entrypoing is on the *image*. We want the normal docker behavior here,
-	// but we *also* want tini.
-	dockerEntrypoint := append([]string{"/sbin/docker-init", "-s", "--"}, v1Container.Command...)
 	healthcheck := v1ContainerHealthcheckToDockerHealthcheck(v1Container.LivenessProbe)
 	dockerContainerConfig := &container.Config{
 		// Hostname must be empty here because setting the hostname is incompatible with
 		// a container:foo network mode
 		Hostname:    "",
-		Cmd:         dockerCmd,
+		Cmd:         v1Container.Args,
 		Image:       v1Container.Image,
 		WorkingDir:  v1Container.WorkingDir,
-		Entrypoint:  dockerEntrypoint,
+		Entrypoint:  computeExtraContainersDockerEntrypoint(c),
 		Labels:      labels,
 		Env:         append(baseEnv, v1ConatinerEnvToList(v1Container.Env)...),
 		Healthcheck: healthcheck,
@@ -1893,6 +1883,34 @@ func (r *DockerRuntime) k8sContainerToDockerConfigs(v1Container v1.Container, ma
 	// Nothing extra is needed here, because networking is defined in the HostConfig referencing the main container
 	dockerNetworkConfig := &network.NetworkingConfig{}
 	return dockerContainerConfig, dockerHostConfig, dockerNetworkConfig, nil
+}
+
+// computeExtraContainersDockerEntrypoint takes an extra container, and tries our best to take multiple
+// inputs, and computing the most sane entrypoint we can come up with given our requirements. That is:
+// 1. We have input k8s container "Command" (docker entrypoint)
+// 2. We have the original docker entrypoint on the image
+// 3. We have tini, which we need to inject ourselves because we want tini goodness (stdout/err, seccomp, etc)
+//
+// Given those 3 things, we must return *something* that docker can actually run.
+func computeExtraContainersDockerEntrypoint(c *runtimeTypes.ExtraContainer) []string {
+	// What docker calls "entrypoint", k8s calls "command", but in addition, we prepend tini
+	// The reason we do this is because, even with init=true, docker will only inject tini
+	// on containers running in a private pid namespace.
+	// On titus, we want tini on *every* container, because it gives us features like stdout/err
+	originalEntrypoint := getExtraContainerEntrypoint(c)
+	return append([]string{"/sbin/docker-init", "-s", "--"}, originalEntrypoint...)
+}
+
+// getExtraContainerEntrypoint computes the original entrypoint that the user
+// wants to run, given two sources:
+// 1. the input k8s pod "command" (takes precedence)
+// 2. the input ENTRYPOINT on the image (should be used if no command is specified on the container spec)
+func getExtraContainerEntrypoint(c *runtimeTypes.ExtraContainer) []string {
+	if len(c.V1Container.Command) > 0 {
+		return c.V1Container.Command
+	}
+	// Otherwise we provide whatever the original image had, even if it is an empty array
+	return c.ImageInspect.ContainerConfig.Entrypoint
 }
 
 func v1ConatinerEnvToList(v1Env []v1.EnvVar) []string {

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -14,6 +14,7 @@ import (
 	vpcapi "github.com/Netflix/titus-executor/vpc/api"
 	podCommon "github.com/Netflix/titus-kube-common/pod"
 	resourceCommon "github.com/Netflix/titus-kube-common/resource"
+	dockerTypes "github.com/docker/docker/api/types"
 	"github.com/golang/protobuf/proto" // nolint: staticcheck
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -129,9 +130,10 @@ type SidecarContainerConfig struct {
 // ExtraContainer stores data about the other containers running alongside the
 // main container in the C&W implementation of pods
 type ExtraContainer struct {
-	Name        string                 // Name of the container from the pod spec
-	V1Container corev1.Container       // The k8s definition of the container from the pod object
-	Status      corev1.ContainerStatus // Status of the container, shows up in podstatus
+	Name         string                    // Name of the container from the pod spec
+	V1Container  corev1.Container          // The k8s definition of the container from the pod object
+	Status       corev1.ContainerStatus    // Status of the container, shows up in podstatus
+	ImageInspect *dockerTypes.ImageInspect // Inspect of the image that the extra container will run
 }
 
 type NFSMount struct {


### PR DESCRIPTION
Normally, we would be able to pass through our container spec's
command/entrypoint as is, and let docker let the image
defaults take over if unset.
    
However, on Titus sidecars, we want tini, which means we must manipulate the entrypoint.
    
On the main container, we don't need to do this to get tini because
we run with `init:true`, and this injects tini for us into the
final entrypoint calculation. This does *not* happen on sidecars
with share pid namespaces, so we must inject it ourselves.

But we *still* want to default to use the image's entrypoint if available, just like docker/k8s would.

This code inspects the image so that we can do that.