### PR TITLE
v1 pod schema: use the RO/RW status for efs from volume mounts

### DIFF
--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -802,7 +802,7 @@ func (c *PodContainer) parsePodVolumes() error {
 				MountPoint: filepath.Clean(vm.MountPath),
 				Server:     vol.NFS.Server,
 				ServerPath: filepath.Clean(vol.NFS.Path),
-				ReadOnly:   vol.NFS.ReadOnly,
+				ReadOnly:   vm.ReadOnly,
 			})
 		}
 

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -227,6 +227,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 		{
 			Name:      "efs-fs-abcdef-rwm.subdir1",
 			MountPath: "/efs1",
+			ReadOnly:  true,
 		},
 		{
 			Name:      "dev-shm",
@@ -245,7 +246,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 				NFS: &corev1.NFSVolumeSource{
 					Server:   "fs-abcdef.efs.us-east-1.amazonaws.com",
 					Path:     "/remote-dir",
-					ReadOnly: true,
+					ReadOnly: false,
 				},
 			},
 		},


### PR DESCRIPTION
Previously we were using the RO/RW status from the volume object.
This seems fine, except in the case where a user (our control-plane)
wants to define one volume that can be shared between multiple
volume mounts.

I think it is easier to just have a shared v1Volume, and just respect
the more-specific ReadOnly setting on the v1VolumeMount.