### PR TITLE
Added ContainerID and Image to the main container status in the pod spec

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -443,6 +443,7 @@ func (r *Runner) updateStatusWithDetails(ctx context.Context, status titusdriver
 	l := logger.G(ctx).WithField("msg", msg).WithField("taskStatus", status)
 	select {
 	case r.UpdatesChan <- Update{
+		ContainerID:             r.container.ID(),
 		TaskID:                  r.container.TaskID(),
 		State:                   status,
 		Mesg:                    msg,
@@ -458,6 +459,7 @@ func (r *Runner) updateStatusWithDetails(ctx context.Context, status titusdriver
 
 // Update encapsulates information on the updatechan about Task status updates
 type Update struct {
+	ContainerID             string
 	TaskID                  string
 	State                   titusdriver.TitusTaskState
 	Mesg                    string

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -701,7 +701,7 @@ func NewExtraContainersFromPod(pod corev1.Pod) ([]*ExtraContainer, []*ExtraConta
 			Name: c.Name,
 			State: corev1.ContainerState{
 				Waiting: &corev1.ContainerStateWaiting{
-					Reason:  c.Name + "has yet to be initialized by the runtime",
+					Reason:  c.Name + " has yet to be initialized by the runtime",
 					Message: "Not created yet",
 				},
 			},

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -377,9 +377,9 @@ func (b *Backend) handleUpdate(ctx context.Context, update runner.Update) {
 		LastTerminationState: v1.ContainerState{},
 		Ready:                true,
 		RestartCount:         0,
-		Image:                "",
+		Image:                b.pod.Spec.Containers[0].Image,
 		ImageID:              "",
-		ContainerID:          "",
+		ContainerID:          update.ContainerID,
 	}
 	statuses := append([]v1.ContainerStatus{mainContainerStatus}, update.ExtraContainerStatuses...)
 	statuses = append(statuses, update.PlatformSidecarStatuses...)


### PR DESCRIPTION
This fills in one some of the missing fields for the main container.

I want these fields to be populated for debugging purposes, as well
as just making the pod more "real", and so that in the future
titus-storage can use the containerIDs as a way to mount into them.
(other containers already have it, just the main containerID was missing)