### PR TITLE
Allow other types of VolumeSources in extra containers

### DIFF
--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -1353,7 +1353,8 @@ func TestBasicMultiContainerCustomSharedVolumes(t *testing.T) {
 			FlexVolume: &corev1.FlexVolumeSource{
 				Driver: "SharedContainerVolumeSource",
 				Options: map[string]string{
-					"sourcePath": "/etc",
+					"sourcePath":      "/etc",
+					"sourceContainer": "main",
 				},
 			},
 		},


### PR DESCRIPTION
Previously, this code was too strict and now allowing other
types of volumes to defined.

That is fine, it only cares about sharedVolume types, it
can just ignore the others (like ceph/ebs/nfs).
