### PR TITLE
Allow true ipv6 containers in Titus

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -424,10 +424,16 @@ func (r *DockerRuntime) mainContainerDockerConfig(c runtimeTypes.Container, bind
 
 	maybeAddOptimisticDad(hostCfg.Sysctls)
 
-	// TODO(Sargun): Add IPv6 address
 	ipv4Addr := c.IPv4Address()
 	if ipv4Addr != nil {
 		hostCfg.ExtraHosts = append(hostCfg.ExtraHosts, fmt.Sprintf("%s:%s", hostname, *ipv4Addr))
+	}
+	// Only in IPv6-Only modes do we set the extra hosts entry for our v6 address
+	if c.EffectiveNetworkMode() == titus.NetworkConfiguration_Ipv6Only.String() || c.EffectiveNetworkMode() == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() {
+		ipv6Addr := c.IPv6Address()
+		if ipv6Addr != nil {
+			hostCfg.ExtraHosts = append(hostCfg.ExtraHosts, fmt.Sprintf("%s:%s", hostname, *ipv6Addr))
+		}
 	}
 
 	for _, containerName := range volumeContainers {

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -723,6 +723,17 @@ func (c *TitusInfoContainer) IPv4Address() *string {
 	return &addr.Address.Address
 }
 
+func (c *TitusInfoContainer) IPv6Address() *string {
+	if c.vpcAllocation == nil {
+		return nil
+	}
+	addr := c.vpcAllocation.IPV6Address()
+	if addr == nil {
+		return nil
+	}
+	return &addr.Address.Address
+}
+
 func (c *TitusInfoContainer) IsSystemD() bool {
 	return c.isSystemD
 }

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -409,6 +409,21 @@ func (c *PodContainer) IPv4Address() *string {
 		if t.AssignIPResponseV3.Ipv4Address != nil {
 			return &t.AssignIPResponseV3.Ipv4Address.Address.Address
 		}
+		return nil
+	}
+	panic("Unxpected state")
+}
+
+func (c *PodContainer) IPv6Address() *string {
+	if c.vpcAllocation == nil {
+		return nil
+	}
+	switch t := c.vpcAllocation.Assignment.(type) {
+	case *vpcapi.Assignment_AssignIPResponseV3:
+		if t.AssignIPResponseV3.Ipv6Address != nil {
+			return &t.AssignIPResponseV3.Ipv6Address.Address.Address
+		}
+		return nil
 	}
 	panic("Unxpected state")
 }

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -173,6 +173,7 @@ type Container interface {
 	ImageVersion() *string
 	ImageTagForMetrics() map[string]string
 	IPv4Address() *string
+	IPv6Address() *string
 	IsSystemD() bool
 	JobGroupDetail() string
 	JobGroupStack() string
@@ -247,9 +248,8 @@ func ComputeHostname(c Container) (string, error) {
 	case ec2HostnameStyle:
 		ipAddr := c.IPv4Address()
 		if ipAddr == nil {
-			return "", &InvalidConfigurationError{Reason: errors.New("Unable to get container IP address")}
+			return "ip-127-0-0-1", nil
 		}
-
 		hostname := fmt.Sprintf("ip-%s", strings.Replace(*ipAddr, ".", "-", 3))
 		return hostname, nil
 	default:
@@ -481,8 +481,12 @@ type NetworkConfigurationDetails struct {
 func (n *NetworkConfigurationDetails) ToMap() map[string]string {
 	m := make(map[string]string)
 	m["IsRoutableIp"] = strconv.FormatBool(n.IsRoutableIP)
-	m["IpAddress"] = n.IPAddress
-	m["EniIpAddress"] = n.EniIPAddress
+	if n.IPAddress != "" {
+		m["IpAddress"] = n.IPAddress
+	}
+	if n.EniIPAddress != "" {
+		m["EniIpAddress"] = n.EniIPAddress
+	}
 	m["EniId"] = n.EniID
 	m["ResourceId"] = n.ResourceID
 	if n.EniIPv6Address != "" {

--- a/metadataserver/iam.go
+++ b/metadataserver/iam.go
@@ -78,6 +78,7 @@ func newIamProxy(ctx context.Context, config types.MetadataServerConfiguration, 
 	if conn != nil {
 		iamServiceClient = iamapi.NewIAMClient(conn)
 	} else if config.Region != "" {
+		// TODO: Use dual stack endpoints when available someday
 		endpoint := fmt.Sprintf("sts.%s.amazonaws.com", config.Region)
 		if config.STSEndpoint != "" {
 			endpoint = config.STSEndpoint

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -346,7 +346,7 @@ func (b *Backend) handleUpdate(ctx context.Context, update runner.Update) {
 			b.pod.Status.PodIPs = []v1.PodIP{
 				{IP: update.Details.NetworkConfiguration.ElasticIPAddress},
 			}
-		} else {
+		} else if update.Details.NetworkConfiguration.IPAddress != "" {
 			b.pod.Status.PodIPs = []v1.PodIP{
 				{IP: update.Details.NetworkConfiguration.IPAddress},
 			}

--- a/vpc/tool/assign3/assign_network.go
+++ b/vpc/tool/assign3/assign_network.go
@@ -208,6 +208,8 @@ func doAllocateNetwork(ctx context.Context, instanceIdentityProvider identity.In
 
 func shouldAssignV6(args Arguments) bool {
 	switch args.NetworkMode {
+	case titus.NetworkConfiguration_Ipv6Only.String():
+		return true
 	case titus.NetworkConfiguration_Ipv6AndIpv4.String():
 		return true
 	case titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String():

--- a/vpc/tool/container2/setup_container_linux.go
+++ b/vpc/tool/container2/setup_container_linux.go
@@ -203,9 +203,11 @@ func configureLink(ctx context.Context, nsHandle *netlink.Handle, link netlink.L
 		return errors.Wrap(err, "Unable to set link up")
 	}
 
-	err = addIPv4AddressAndRoutes(ctx, nsHandle, link, assignment.Ipv4Address, assignment.Routes)
-	if err != nil {
-		return err
+	if assignment.Ipv4Address != nil {
+		err = addIPv4AddressAndRoutes(ctx, nsHandle, link, assignment.Ipv4Address, assignment.Routes)
+		if err != nil {
+			return fmt.Errorf("Unable to setup IPv4 address: %w", err)
+		}
 	}
 
 	if assignment.Ipv6Address != nil {


### PR DESCRIPTION
On true Ipv6 mode, this code crashes becase the ipv4 assignment is nil
