### PR TITLE
Added NETFLIX_IPV6_HOSTNAME

### DIFF
--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -1232,6 +1232,7 @@ func populateContainerEnv(c Container, config config.Config, userEnv map[string]
 		env[metadataserverTypes.EC2IPv6sEnvVarName] = a.Address.Address
 		env[metadataserverTypes.NetflixIPv6EnvVarName] = a.Address.Address
 		env[metadataserverTypes.NetflixIPv6sEnvVarName] = a.Address.Address
+		env[metadataserverTypes.NetflixIPv6HostnameEnvVar] = computeNetflixIPv6Hostname(a.Address.Address)
 	}
 
 	if a := vpcAllocation.ElasticAddress(); a != nil {
@@ -1380,4 +1381,9 @@ func GetHumanFriendlyNetworkMode(mode string) string {
 	default:
 		return ""
 	}
+}
+
+func computeNetflixIPv6Hostname(ipv6 string) string {
+	sanitizedv6 := strings.ReplaceAll(ipv6, ":", "-")
+	return fmt.Sprintf("ip-%s.node.netflix.net", sanitizedv6)
 }

--- a/executor/runtime/types/container_test.go
+++ b/executor/runtime/types/container_test.go
@@ -731,3 +731,10 @@ func TestSubnetIDHasSpaces(t *testing.T) {
 	require.NotNil(t, ret)
 	assert.Equal(t, "subnet-foo,subnet-bar", strings.Join(*ret, ","))
 }
+
+func TestComputeNetflixIPv6Hostname(t *testing.T) {
+	ip := "2001:db8::2:1"
+	expected := "ip-2001-db8--2-1.node.netflix.net"
+	actual := computeNetflixIPv6Hostname(ip)
+	assert.Equal(t, expected, actual)
+}

--- a/metadataserver/types/types.go
+++ b/metadataserver/types/types.go
@@ -21,6 +21,7 @@ const (
 	NetflixAccountIDVarName   = "NETFLIX_ACCOUNT_ID"
 	NetflixIPv6EnvVarName     = "NETFLIX_IPV6"
 	NetflixIPv6sEnvVarName    = "NETFLIX_IPV6S"
+	NetflixIPv6HostnameEnvVar = "NETFLIX_IPV6_HOSTNAME"
 )
 
 // MetadataServerConfiguration is a configuration for metadata service + IAM Proxy


### PR DESCRIPTION
This adds a new standard environment variable to give
applications a dns-resolvable hostname that resolves
to their assigned ipv6.
