### PR TITLE
Don't set EC2_LOCAL_IPV4 in ipv6+transition mode

### DIFF
--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -1225,7 +1225,14 @@ func populateContainerEnv(c Container, config config.Config, userEnv map[string]
 	}
 	vpcAllocation := c.VPCAllocation()
 	if a := vpcAllocation.IPV4Address(); a != nil {
-		env[metadataserverTypes.EC2IPv4EnvVarName] = a.Address.Address
+		if c.EffectiveNetworkMode() == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() {
+			// IPv4 Transition mode is a special case, where we don't want to just set this
+			// variable to the transition mode. Instead we want to set it to a "dummy" value
+			// (127.0.0.1) so applications don't break.
+			env[metadataserverTypes.EC2IPv4EnvVarName] = "127.0.0.1"
+		} else {
+			env[metadataserverTypes.EC2IPv4EnvVarName] = a.Address.Address
+		}
 	}
 
 	if a := vpcAllocation.IPV6Address(); a != nil {


### PR DESCRIPTION
I think eventually the transition ip will be contained in a different
part of the vpcservice response?
When that happens, the v4 allocation in transition mode will truly be nil.

Till then, we need this thing to prevent EC2_LOCAL_IPV4 from "leaking"
the transition ip.
