### PR TITLE
Enbled X11 forwarding for Titus ssh

### DIFF
--- a/executor/runtime/docker/docker_ssh.go
+++ b/executor/runtime/docker/docker_ssh.go
@@ -76,7 +76,7 @@ PasswordAuthentication no
 #GSSAPIAuthentication no
 #GSSAPICleanupCredentials yes
 
-X11Forwarding no
+X11Forwarding yes
 X11DisplayOffset 10
 PrintMotd no
 PrintLastLog no


### PR DESCRIPTION
Currently users have to jump through a lot
of hoops to get X11 working (basically running a second sshd).

Enabling this allows users to x11 forward without
going through hoops.
