### PR TITLE
Ignore injected variables from platform-sidecars for identity

### DIFF
--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -224,7 +224,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 		podCommon.AnnotationKeyNetworkSubnetIDs:              strings.Join(expSubnets, ","),
 		podCommon.AnnotationKeyNetworkJumboFramesEnabled:     True,
 		podCommon.AnnotationKeyNetworkStaticIPAllocationUUID: "static-ip-uuid",
-		// Add servicemesh sidecar
+		// Add servicemesh titus system service
 		podCommon.AnnotationKeyServicePrefix + "/servicemesh.v1.enabled": True,
 		podCommon.AnnotationKeyServicePrefix + "/servicemesh.v1.image":   "titusoss/servicemesh:latest",
 	})
@@ -1450,10 +1450,19 @@ func TestContainerInfoGenerationAllFields(t *testing.T) {
 			Name:  "FROM_TITUS_2",
 			Value: "T2",
 		},
+		{
+			Name:  "FROM_MUTATOR_1",
+			Value: "M1",
+		},
+		{
+			Name:  "FROM_MUTATOR_2",
+			Value: "M2",
+		},
 	}
 
 	addPodAnnotations(pod, map[string]string{
 		podCommon.AnnotationKeyPodTitusSystemEnvVarNames:   "FROM_TITUS_1, FROM_TITUS_2",
+		podCommon.AnnotationKeyPodInjectedEnvVarNames:      "FROM_MUTATOR_1, FROM_MUTATOR_2",
 		podCommon.AnnotationKeyWorkloadName:                testAppName,
 		podCommon.AnnotationKeyWorkloadDetail:              testAppDetail,
 		podCommon.AnnotationKeyWorkloadOwnerEmail:          testAppOwner,

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Netflix/metrics-client-go v0.0.0-20171019173821-bb173f41fc07
 	github.com/Netflix/spectator-go v0.0.0-20190913215732-d4e0463555ef
 	github.com/Netflix/titus-api-definitions v0.0.3-rc.9
-	github.com/Netflix/titus-kube-common v0.21.1
+	github.com/Netflix/titus-kube-common v0.21.2
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
 	github.com/apex/log v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/Netflix/titus-api-definitions v0.0.3-rc.9 h1:xJIFlNXfnGVrLIM2m/QTuZvz
 github.com/Netflix/titus-api-definitions v0.0.3-rc.9/go.mod h1:eECoVkmltHzQUz/9gpDKfBvdjYhCVRPGLJz4YuVVRcE=
 github.com/Netflix/titus-kube-common v0.21.1 h1:cA8/oJWNLZi6bNRGmYNWuFbsoDpP0PGkXfhqw5kyY2Q=
 github.com/Netflix/titus-kube-common v0.21.1/go.mod h1:WiYKaBxoim+zOj+5k23D5JUMOerfF+Wuhb5ujrwYdM8=
+github.com/Netflix/titus-kube-common v0.21.2 h1:QiMxmEq2ZDqrM/p1pfinpTwEN52XoRsYabWnYg1nwL0=
+github.com/Netflix/titus-kube-common v0.21.2/go.mod h1:WiYKaBxoim+zOj+5k23D5JUMOerfF+Wuhb5ujrwYdM8=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
When platform sidecars mutate the environment of our user containers,
we need to *ignore* that modification for identity purposes,
otherwise the identity check will fail.
