### PR TITLE
Moved all pulling actions for all containers into the Prepare phase

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -160,7 +160,7 @@ func (r *Runner) prepareContainer(ctx context.Context) update {
 	}()
 	// When Create() returns the host may have been modified to create storage and pull the image.
 	// These steps may or may not have completed depending on if/where a failure occurred.
-	if err := r.runtime.Prepare(prepareCtx); err != nil {
+	if err := r.runtime.Prepare(prepareCtx, r.pod); err != nil {
 		r.metrics.Counter("titus.executor.launchTaskFailed", 1, nil)
 		logger.G(ctx).WithError(err).Error("Task failed to create main container")
 		// Treat registry pull errors as LOST and non-existent images as FAILED.

--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -53,7 +53,7 @@ type runtimeMock struct {
 	killCallback    func(c runtimeTypes.Container) error
 }
 
-func (r *runtimeMock) Prepare(ctx context.Context) error {
+func (r *runtimeMock) Prepare(ctx context.Context, pod *v1.Pod) error {
 	if r.c == nil {
 		panic("Container is nil")
 	}

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -515,7 +515,7 @@ type Runtime interface {
 	// TODO(fabio): better (non-Docker specific) abstraction for binds
 	// The context passed to the Prepare, and Start function is valid over the lifetime of the container,
 	// NOT per-operation
-	Prepare(containerCtx context.Context) error
+	Prepare(containerCtx context.Context, pod *corev1.Pod) error
 	// Start a container -- Returns an optional Log Directory if an external Logger is desired
 	Start(containerCtx context.Context, pod *corev1.Pod) (string, *Details, <-chan StatusMessage, error)
 	// Kill a container. MUST be idempotent.


### PR DESCRIPTION
This puts all pulls (even multi-container workloads) into the
Prepare (StartInitiated) phase instead of waiting for it to
be considerd "Started".

If a pull fails for a multi-container workload, I think it would be better
to fail a little faster.
