### PR TITLE
Remove docker username from build output

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -25,6 +25,7 @@ export TEST_FLAGS="-v -parallel 1"
 # not leak.
 redact_secrets() {
   sed "s/$DOCKER_PASSWORD/[REDACTED]/"
+  sed "s/$DOCKER_USERNAME/[REDACTED]/"
 }
 
 log "Building executor"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Login into Docker hub
+          name: Login into Docker hub - does not work for forked repos
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run:
           name: Build builder image


### PR DESCRIPTION
### Description of the Change

Remove DOCKER_USERNAME from build.log
