### PR TITLE
Change the subnet reconcilation code to run shorter queries

### DIFF
--- a/vpc/service/service.go
+++ b/vpc/service/service.go
@@ -417,6 +417,11 @@ func (vpcService *vpcService) getLongLivedTasks() []longLivedTask {
 			itemLister: nilItemEnumerator,
 			workFunc:   vpcService.deleteFailedAssignments,
 		},
+		{
+			taskName:   "subnets",
+			itemLister: vpcService.getRegionAccounts,
+			workFunc:   vpcService.doReconcileSubnetsForRegionAccountLoop,
+		},
 		vpcService.reconcileBranchENIsLongLivedTask(),
 		vpcService.associateActionWorker().longLivedTask(),
 		vpcService.disassociateActionWorker().longLivedTask(),
@@ -444,12 +449,6 @@ type taskLoop struct {
 
 func (vpcService *vpcService) getTaskLoops() []taskLoop {
 	return []taskLoop{
-		{
-			// This was bumped to subnets2 because the "new" version adds prefixes.
-			taskName:   "subnets2",
-			itemLister: vpcService.getRegionAccounts,
-			workFunc:   vpcService.reconcileSubnetsForRegionAccount,
-		},
 		{
 			taskName:   "elastic_ip",
 			itemLister: vpcService.getRegionAccounts,


### PR DESCRIPTION
There was contention between assigning prefixes to ENIs, and
(re)populating the subnets table. This changes it to be a bit
more conservative about how much work is done in a single
transaction.
