### PR TITLE
First pass at implementing naive HighScale network mode

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -719,7 +719,7 @@ func prepareNetworkDriver(ctx context.Context, cfg Config, c runtimeTypes.Contai
 		"--security-groups", strings.Join(*sgIDs, ","),
 		"--task-id", c.TaskID(),
 		"--bandwidth", strconv.FormatInt(bw, 10),
-		"--network-mode", c.EffectiveNetworkMode(),
+		"--network-mode", c.EffectiveNetworkMode(), // TODO: Deal with HighScale mode either here, or use the effective mode (which is fallback)
 	}
 
 	if c.SignedAddressAllocationUUID() != nil {

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -412,6 +412,10 @@ func computeEffectiveNetworkMode(originalNetworkMode string, assignIPv6Address b
 		}
 		return titus.NetworkConfiguration_Ipv4Only.String()
 	}
+	if originalNetworkMode == titus.NetworkConfiguration_HighScale.String() {
+		// HighScale is really an alias for the Transition Mode today
+		return titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String()
+	}
 	return originalNetworkMode
 }
 

--- a/vpc/tool/assign3/assign_network.go
+++ b/vpc/tool/assign3/assign_network.go
@@ -183,7 +183,7 @@ func doAllocateNetwork(ctx context.Context, instanceIdentityProvider identity.In
 		}
 	} else if shouldAssignV4 {
 		assignIPRequest.Ipv4 = &vpcapi.AssignIPRequestV3_Ipv4AddressRequested{Ipv4AddressRequested: true}
-	} else if args.NetworkMode == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() {
+	} else if args.NetworkMode == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() || args.NetworkMode == titus.NetworkConfiguration_HighScale.String() {
 		assignIPRequest.Ipv4 = &vpcapi.AssignIPRequestV3_TransitionRequested{}
 	} else {
 		logger.G(ctx).WithField("assignIPRequest", assignIPRequest).Debug("Experimental: Not assigning IPv4")
@@ -212,7 +212,7 @@ func shouldAssignV6(args Arguments) bool {
 		return true
 	case titus.NetworkConfiguration_Ipv6AndIpv4.String():
 		return true
-	case titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String():
+	case titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String(), titus.NetworkConfiguration_HighScale.String():
 		return true
 	default:
 		return false


### PR DESCRIPTION
This does the bare minimum to get HighScale network mode to work.
No work is done in this PR to deal with autodetection of subnets/vpcs.
This is to be done on future PRs.

Note that the "Effective" network mode here is the IPv6OnlyTransition
one, so much of the logic in titus-executor and applications that read
$TITUS_NETWORK_MODE will not need to change.
