### PR TITLE
Make dirs on share source volume mounts if we need to TITUS-5850

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -2055,9 +2055,14 @@ func (r *DockerRuntime) getContainerSharedVolumeSourceMounts(mainContainerRoot s
 			if v.FlexVolume.Options["sourceContainer"] != "main" && v.FlexVolume.Options["sourceContainer"] != "" {
 				return nil, fmt.Errorf("only 'main' SharedContainerVolume volumes are supported. Volume: %+v", v)
 			}
+			source := filepath.Join(mainContainerRoot, v.FlexVolume.Options["sourcePath"])
+			err := mkdirAllInContainer(source)
+			if err != nil {
+				return mounts, fmt.Errorf("Unable to use shared volume source %s with a sourcePath of %s: %w", volumeMount.Name, v.FlexVolume.Options["sourcePath"], err)
+			}
 			m := mount.Mount{
 				Type:        "bind",
-				Source:      filepath.Join(mainContainerRoot, v.FlexVolume.Options["sourcePath"]),
+				Source:      source,
 				Target:      volumeMount.MountPath,
 				ReadOnly:    volumeMount.ReadOnly,
 				BindOptions: &mount.BindOptions{Propagation: v1MountPropToDockerProp(volumeMount)},

--- a/executor/runtime/docker/docker_unsupported.go
+++ b/executor/runtime/docker/docker_unsupported.go
@@ -57,3 +57,11 @@ func mountTmpfs(path string, size string) error {
 func unmountTmpfs(path string) error {
 	return nil
 }
+
+func makeBackingFsDev(home, tempdir string) error {
+	return nil
+}
+
+func mkdirAllInContainer(source string) error {
+	return nil
+}


### PR DESCRIPTION
For users of sharedContainerVolumeSource, we can't always depend on the
source dir existing. Ideally it would, but sometimes it is just a
scratch container, or who knows. Often it is simply outside of their
control.

For those cases, we create the dir for them as best we can.
