### PR TITLE
Do not skip locked subnet_usable_prefix

### DIFF
--- a/vpc/service/branch_enis.go
+++ b/vpc/service/branch_enis.go
@@ -1150,7 +1150,7 @@ WHERE subnets.subnet_id = $1
   AND subnet_cidr_reservations_v6.type = 'explicit'
   ORDER BY random()
   FOR
-  NO KEY UPDATE OF subnet_usable_prefix SKIP LOCKED
+  NO KEY UPDATE OF subnet_usable_prefix
   LIMIT 1
 `, subnetID, vpcService.subnetCIDRReservationDescription)
 	var prefix string


### PR DESCRIPTION
    Right now, if the subnet_usable_prefix table has a lock on it we skip
    the row. Unfortunately, when many queries are hitting the table, we
    can get into contention, and this can then cause branch ENI creation
    to fail.

