### PR TITLE
Fix locked subnet usable prefix

### DIFF
--- a/vpc/service/branch_enis.go
+++ b/vpc/service/branch_enis.go
@@ -1150,7 +1150,7 @@ WHERE subnets.subnet_id = $1
   AND subnet_cidr_reservations_v6.type = 'explicit'
   ORDER BY random()
   FOR
-  NO KEY UPDATE OF subnet_usable_prefix
+  NO KEY UPDATE OF subnet_usable_prefix SKIP LOCKED
   LIMIT 1
 `, subnetID, vpcService.subnetCIDRReservationDescription)
 	var prefix string

--- a/vpc/service/generate_assignment_id.go
+++ b/vpc/service/generate_assignment_id.go
@@ -586,6 +586,7 @@ FROM
    JOIN branch_eni_attachments ON branch_enis.branch_eni = branch_eni_attachments.branch_eni
    WHERE subnet_id = $1
      AND trunk_eni = $2
+     AND (SELECT count(*) FROM subnet_usable_prefix WHERE subnet_usable_prefix.branch_eni_id = branch_enis.id) > 0
      AND state = 'attached') valid_branch_enis
 WHERE c = 0
 ORDER BY c DESC, branch_eni_attached_at ASC


### PR DESCRIPTION
Fix query to make sure that there is a prefix on an ENI when reusing an existing ENI