### PR TITLE
Added libseccomp-dev to build deps

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -5,7 +5,7 @@ log() {
     echo -e "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $1" >&2
 }
 
-apt-get -y install shellcheck
+apt-get -y install shellcheck libseccomp-dev
 
 GO_VERSION=1.13.14
 GO_INSTALL_DIR=${HOME}/go_installs/${GO_VERSION}

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -10,7 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install curl && 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     apt-get install -y build-essential make cmake g++ gcc libc6-dev pkg-config \
         libattr1-dev git curl wget jq ruby ruby-dev rubygems lintian unzip bison flex clang llvm musl-tools \
-        linux-libc-dev=5.9~rc4-1~exp1 libcap-dev && \
+        linux-libc-dev=5.9~rc4-1~exp1 libcap-dev libseccomp-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN gem install --no-ri --no-rdoc fpm

--- a/hack/ci-builder/Dockerfile
+++ b/hack/ci-builder/Dockerfile
@@ -5,7 +5,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
 COPY docker-repo.gpg /tmp
 RUN apt-key add /tmp/docker-repo.gpg
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y wget build-essential docker-ce ruby ruby-dev ruby-bundler gcc g++ make pkg-config shellcheck && apt-get clean
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y wget build-essential docker-ce ruby ruby-dev ruby-bundler gcc g++ make pkg-config shellcheck libseccomp-dev && apt-get clean
 COPY --from=golang:1.13-stretch /usr/local/go /usr/local/go
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
It is hard for me to test my seccomp rebase, because it adds a
dependency on libseccomp-dev.

But I never get to the step where new ci-builder images are uploaded,
because the tests don't pass!

I figure I can just merge this into master first (doesn't hurt), which
will make my life easier when interacting with CI.
