### PR TITLE
Added new network annotations to replace the old ones

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -446,6 +446,30 @@ func (n *NetworkConfigurationDetails) ToMap() map[string]string {
 	return m
 }
 
+func (n *NetworkConfigurationDetails) ToAnnotationMap() map[string]string {
+	a := map[string]string{}
+	if n.NetworkMode != "" {
+		a[podCommon.AnnotationKeyEffectiveNetworkMode] = n.NetworkMode
+	}
+	if n.IPAddress != "" {
+		a[podCommon.AnnotationKeyIPAddress] = n.IPAddress
+	}
+	if n.EniIPAddress != "" {
+		a[podCommon.AnnotationKeyIPv4Address] = n.EniIPAddress
+	}
+	if n.EniIPv6Address != "" {
+		a[podCommon.AnnotationKeyIPv6Address] = n.EniIPv6Address
+	}
+	if n.EniID != "" {
+		a[podCommon.AnnotationKeyBranchEniID] = n.EniID
+	}
+	if n.NetworkMode == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() {
+		// TODO: Use the transition IP when available from the vpc allocation object
+		a[podCommon.AnnotationKeyIPv4TransitionAddress] = n.EniIPAddress
+	}
+	return a
+}
+
 // Details contains additional details about a container that are
 // not returned by normal container start calls.
 type Details struct {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Netflix/metrics-client-go v0.0.0-20171019173821-bb173f41fc07
 	github.com/Netflix/spectator-go v0.0.0-20190913215732-d4e0463555ef
 	github.com/Netflix/titus-api-definitions v0.0.3-rc.17
-	github.com/Netflix/titus-kube-common v0.23.0
+	github.com/Netflix/titus-kube-common v0.25.0
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
 	github.com/apex/log v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/Netflix/titus-kube-common v0.21.2 h1:QiMxmEq2ZDqrM/p1pfinpTwEN52XoRsY
 github.com/Netflix/titus-kube-common v0.21.2/go.mod h1:WiYKaBxoim+zOj+5k23D5JUMOerfF+Wuhb5ujrwYdM8=
 github.com/Netflix/titus-kube-common v0.23.0 h1:7OX3YL2bgBwQz+FCQfAxyA9COMWjvJti4je4r7Ey03M=
 github.com/Netflix/titus-kube-common v0.23.0/go.mod h1:/l93ATTo1UY6kwPRqYSDU015Pr10yxK1jd6qnV0G3ec=
+github.com/Netflix/titus-kube-common v0.25.0 h1:2NVy4GuxI6T+SYUf5vnkgQPoyKcCkukOHz5o+WUPdJU=
+github.com/Netflix/titus-kube-common v0.25.0/go.mod h1:/l93ATTo1UY6kwPRqYSDU015Pr10yxK1jd6qnV0G3ec=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -372,11 +372,21 @@ func (b *Backend) handleUpdate(ctx context.Context, update runner.Update) {
 
 	b.pod.Status.ContainerStatuses = statuses
 
+	// Backwards compatibility, sets "un-adorned" annotations like "IpAddress" on the pod.
 	if update.Details != nil && update.Details.NetworkConfiguration != nil {
 		for k, v := range update.Details.NetworkConfiguration.ToMap() {
 			b.pod.Annotations[k] = v
 		}
 	}
+	b.setPodUpdateAnnotations(update)
+}
+
+// setPodUpdateAnnotations takes an update and then annotates a pod with special annotations representing
+// those updates, particularlly those based on network stuff.
+// These annotations allow us to get data "back out" from the executor up to the control-plane, without having
+// to depend on the limitations of the PodStatus structure.
+func (b *Backend) setPodUpdateAnnotations(update runner.Update) {
+	b.pod.SetAnnotations(update.Details.NetworkConfiguration.ToAnnotationMap())
 }
 
 func (b *Backend) RunWithStatusFile(ctx context.Context, statuses *os.File) error {


### PR DESCRIPTION
We currently set "unadorned" annotations, which served us as we
transitioned from `NetworkConfiguratoinDetails` passed out as json to
mesos.

Now, since we are on v1 pods, I would like to start using more "proper"
annotations, `network.netflix.net/address-ipv4`, etc from kube-common.

I'll leave the old annotations (eg `EniID`) until the control-plane
codebase understands the new ones.
