### PR TITLE
Always set the ContainerStatus to be the image digest

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1751,6 +1751,7 @@ func (r *DockerRuntime) createAllExtraContainers(ctx context.Context, pod *v1.Po
 			}
 			c.Status.ContainerID = cid
 			c.Status.State = v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "User Container created. Waiting to start."}}
+			c.Status.Image = c.ImageInspect.RepoDigests[0]
 			l.Debugf("Created %s, CID: %s", c.Name, cid)
 			return nil
 		})
@@ -1764,6 +1765,7 @@ func (r *DockerRuntime) createAllExtraContainers(ctx context.Context, pod *v1.Po
 			}
 			c.Status.ContainerID = cid
 			c.Status.State = v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "Platform Container created. Waiting to start."}}
+			c.Status.Image = c.ImageInspect.RepoDigests[0]
 			l.Debugf("Created %s, CID: %s", c.Name, cid)
 			return nil
 		})

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -750,9 +750,8 @@ func NewExtraContainersFromPod(pod corev1.Pod) ([]*ExtraContainer, []*ExtraConta
 			Ready:        false,
 			RestartCount: 0,
 			Image:        c.Image,
-			ImageID:      "",
 			ContainerID:  "",
-			Started:      nil,
+			Started:      BoolPtr(false),
 		}
 		if podCommon.IsPlatformSidecarContainer(c.Name, &pod) {
 			extraPlatformContainers = append(extraPlatformContainers, &ExtraContainer{

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -364,7 +364,6 @@ func (b *Backend) handleUpdate(ctx context.Context, update runner.Update) {
 		Ready:                true,
 		RestartCount:         0,
 		Image:                b.pod.Spec.Containers[0].Image,
-		ImageID:              "",
 		ContainerID:          update.ContainerID,
 	}
 	statuses := append([]v1.ContainerStatus{mainContainerStatus}, update.ExtraContainerStatuses...)


### PR DESCRIPTION
With extra containers / platform sidecars, we can't always control that
we get a digest for the image field in the k8s pod spec.

But when report the container status, we *can* know exactly what image
we launched based on our imageinspect. This PR makes it so we report
that exact digest *always*.

Previously for some extra containers the only thing we could report is
just "busybox" or whatever.