### PR TITLE
Added first pass at preStop exec support. TITUS-5870

### DIFF
--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -142,7 +142,7 @@ func (r *Runner) prepareContainer(ctx context.Context) update {
 	go func() {
 		select {
 		case <-r.killChan:
-			logger.G(ctx).Debug("Got cancel in prepare")
+			logger.G(ctx).Debug("Got request to stop while still in the prepare phase")
 			prepareCancel()
 		case <-prepareCtx.Done():
 		}

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	ptr "k8s.io/utils/pointer"
 
 	"github.com/Netflix/titus-executor/api/netflix/titus"
@@ -573,6 +574,10 @@ func (c *PodContainer) OomScoreAdj() *int32 {
 
 func (c *PodContainer) OwnerEmail() *string {
 	return c.podConfig.WorkloadOwnerEmail
+}
+
+func (c *PodContainer) Pod() *v1.Pod {
+	return c.pod
 }
 
 func (c *PodContainer) Process() ([]string, []string) {

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -16,6 +16,7 @@ import (
 	dockerTypes "github.com/docker/docker/api/types" // nolint: staticcheck
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -194,6 +195,7 @@ type Container interface {
 	NFSMounts() []NFSMount
 	OomScoreAdj() *int32
 	OwnerEmail() *string
+	Pod() *v1.Pod
 	Process() ([]string, []string)
 	QualifiedImageName() string
 	Resources() *Resources

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -117,7 +117,7 @@ func (jobRunResponse *JobRunResponse) WaitForSuccess() bool {
 	if err != nil {
 		return false
 	}
-	res := status == "TASK_FINISHED"
+	res := status == titusdriver.Finished.String()
 	if !res {
 		jobRunResponse.logContainerStdErrOut()
 	}
@@ -132,7 +132,7 @@ func (jobRunResponse *JobRunResponse) WaitForFailure() bool {
 	if err != nil {
 		return false
 	}
-	res := status == "TASK_FAILED"
+	res := status == titusdriver.Failed.String()
 	if !res {
 		jobRunResponse.logContainerStdErrOut()
 	}
@@ -188,12 +188,12 @@ func (jobRunResponse *JobRunResponse) WaitForFailureStatus(ctx context.Context) 
 // if it completed successfully.
 func (jobRunResponse *JobRunResponse) WaitForCompletion() (string, error) {
 	for status := range jobRunResponse.runner.UpdatesChan {
-		if status.State.String() == "TASK_RUNNING" || status.State.String() == "TASK_STARTING" {
+		if status.State.String() == titusdriver.Running.String() || status.State.String() == titusdriver.Starting.String() {
 			continue // Ignore non-terminal states
 		}
 		return status.State.String(), nil
 	}
-	return "TASK_LOST", errStatusChannelClosed
+	return titusdriver.Lost.String(), errStatusChannelClosed
 }
 
 // ListenForRunning sends true on the returned channel when the task is running, or false if it terminates

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -27,10 +27,6 @@ import (
 	"github.com/Netflix/titus-executor/api/netflix/titus"
 )
 
-const (
-	TASK_FAILED = "TASK_FAILED" // nolint:golint
-)
-
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if testing.Verbose() {
@@ -466,7 +462,7 @@ func TestImageNonExistingDigestFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != TASK_FAILED {
+	if status != titusdriver.Failed.String() {
 		t.Fatalf("Expected status=FAILED, got: %s", status)
 	}
 }
@@ -483,7 +479,7 @@ func TestImagePullError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != TASK_FAILED {
+	if status != titusdriver.Failed.String() {
 		t.Fatalf("Expected status=FAILED, got: %s", status)
 	}
 }
@@ -503,7 +499,7 @@ func TestCancelPullBigImage(t *testing.T) { // nolint: gocyclo
 
 	select {
 	case taskStatus := <-jobResponse.UpdateChan:
-		if taskStatus.State.String() != "TASK_STARTING" {
+		if taskStatus.State.String() != titusdriver.Starting.String() {
 			t.Fatal("Task never observed in TASK_STARTING, instead: ", taskStatus)
 		}
 	case <-time.After(15 * time.Second):
@@ -707,7 +703,7 @@ func testTerminateTimeoutWrapped(t *testing.T, jobID string, killWaitSeconds uin
 			t.Fatal("Task exited prematurely (before becoming healthy)")
 		}
 		log.Infof("Received status update %+v", status)
-		if status.State.String() == "TASK_RUNNING" && strings.Contains(status.Mesg, "health_status: healthy") {
+		if status.State.String() == titusdriver.Running.String() && strings.Contains(status.Mesg, "health_status: healthy") {
 			break
 		}
 	}
@@ -790,7 +786,7 @@ func TestOOMKill(t *testing.T) {
 	// Wait until the task is running
 	for status := range jobResponse.UpdateChan {
 		if status.State.IsTerminalStatus() {
-			if status.State.String() != "TASK_FAILED" {
+			if status.State.String() != titusdriver.Failed.String() {
 				t.Fail()
 			}
 			if !strings.Contains(status.Mesg, "OOMKilled") {
@@ -1430,7 +1426,7 @@ func TestPreStopHookRunsFirst(t *testing.T) {
 
 	select {
 	case taskStatus := <-jobResponse.UpdateChan:
-		if taskStatus.State.String() != "TASK_STARTING" {
+		if taskStatus.State.String() != titusdriver.Starting.String() {
 			t.Fatal("Task never observed in TASK_STARTING, instead: ", taskStatus)
 		}
 	case <-time.After(15 * time.Second):


### PR DESCRIPTION
This adds initial support for the k8s preStop hook.
https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-implementations

We don't implement everything here, only the "exec" form of "preStop",
which should be the 99% use for us at Netflix.

Some deviations from the k8s kubelet behavior:
* Unlike kubelet, failing hooks do not fail a container (they are best
effort)
* Unlike kubelet, hooks are guaranteed exactly once
* Unlike kubelet, logs for the hooks go to /logs, not the k8s events log

Timing of the hook is like kubelet, where it happens *before* the
container gets TERM/KILL.
