### PR TITLE
Renamed some cInfo references

### DIFF
--- a/cmd/titus-metadata-service/main.go
+++ b/cmd/titus-metadata-service/main.go
@@ -73,15 +73,15 @@ func makeFDListener(fd int64) net.Listener {
 	return l
 }
 
-func readTaskConfigFile(taskID string) (*titus.ContainerInfo, error) {
+func readTaskContainerInfoFile(taskID string) (*titus.ContainerInfo, error) {
 	if taskID == "" {
-		log.Errorf("task ID is empty: can't read task config file")
+		log.Errorf("task ID is empty: can't read task cinfo file")
 		return nil, fmt.Errorf("task ID env var unset: %s", taskInstanceIDEnvVar)
 	}
 	confFile := filepath.Join(runtimeTypes.TitusEnvironmentsDir, fmt.Sprintf("%s.json", taskID))
 	contents, err := ioutil.ReadFile(confFile) // nolint: gosec
 	if err != nil {
-		log.WithError(err).Errorf("Error reading task config file %s", confFile)
+		log.WithError(err).Errorf("Error reading task cinfo file %s", confFile)
 		return nil, err
 	}
 
@@ -375,10 +375,10 @@ func main() {
 			} else {
 				mdscfg.Signer = signer
 			}
-			if container, err := readTaskConfigFile(titusTaskInstanceID); err != nil {
+			if cInfo, err := readTaskContainerInfoFile(titusTaskInstanceID); err != nil {
 				log.WithError(err).Fatal("Cannot read container config file")
 			} else {
-				mdscfg.Container = container
+				mdscfg.ContainerInfo = cInfo
 			}
 			if pod, err := readTaskPodFile(titusTaskInstanceID); err != nil {
 				// TOOD: Make this fatal once we depend on this functionality

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -26,14 +26,14 @@ import (
 
 // Task contains all information for running a task
 type Task struct {
-	TaskID    string
-	TitusInfo *titus.ContainerInfo
-	Pod       *corev1.Pod
-	Mem       int64
-	CPU       int64
-	Gpu       int64
-	Disk      int64
-	Network   int64
+	TaskID  string
+	cInfo   *titus.ContainerInfo
+	Pod     *corev1.Pod
+	Mem     int64
+	CPU     int64
+	Gpu     int64
+	Disk    int64
+	Network int64
 }
 
 // Runner maintains in memory state for the Task runner

--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -219,14 +219,14 @@ func TestCancelDuringPrepare(t *testing.T) { // nolint: gocyclo
 
 	pod, _ := runtimeTypes.ContainerTestArgs()
 	task := Task{
-		TaskID:    taskID,
-		TitusInfo: nil,
-		Mem:       1,
-		CPU:       1,
-		Gpu:       0,
-		Disk:      1,
-		Network:   1,
-		Pod:       pod,
+		TaskID:  taskID,
+		cInfo:   nil,
+		Mem:     1,
+		CPU:     1,
+		Gpu:     0,
+		Disk:    1,
+		Network: 1,
+		Pod:     pod,
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
 		r.c = c

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1171,13 +1171,13 @@ func (r *DockerRuntime) Prepare(ctx context.Context, pod *v1.Pod) error { // nol
 	if err != nil {
 		goto error
 	}
-	logger.G(ctx).Info("Titus environment pushed")
+	logger.G(ctx).Info("Titus environment file created")
 
-	err = r.createTitusContainerConfigFile(ctx, r.c, r.startTime)
+	err = r.createTitusContainerInfoFile(ctx, r.c, r.startTime)
 	if err != nil {
 		goto error
 	}
-	logger.G(ctx).Info("Titus Configuration pushed")
+	logger.G(ctx).Info("Titus cInfo file created")
 
 	sharedMountDirs = getSharedMountDirsFromPod(pod)
 	err = r.pushEnvironment(ctx, r.c, myImageInfo, sharedMountDirs)
@@ -1213,10 +1213,10 @@ func getSharedMountDirsFromPod(pod *v1.Pod) []string {
 
 // Creates the file $titusEnvironments/ContainerID.json as a serialized version of the ContainerInfo protobuf struct
 // so other systems can load it
-func (r *DockerRuntime) createTitusContainerConfigFile(ctx context.Context, c runtimeTypes.Container, startTime time.Time) error {
+func (r *DockerRuntime) createTitusContainerInfoFile(ctx context.Context, c runtimeTypes.Container, startTime time.Time) error {
 	containerConfigFile := filepath.Join(runtimeTypes.TitusEnvironmentsDir, fmt.Sprintf("%s.json", c.TaskID()))
 
-	cfg, err := runtimeTypes.ContainerConfig(c, startTime)
+	cfg, err := runtimeTypes.GenerateSyntheticContainerInfoPass2(c, startTime)
 	if err != nil {
 		return err
 	}

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -153,7 +153,7 @@ func populateContainerEnv(c Container, config config.Config, userEnv map[string]
 	// -Hard coded environment variables
 	// -Copied environment variables from the host
 	// -Resource env variables
-	// -User provided environment in POD (if pod unset, then fall back to containerinfo)
+	// -User provided environment in POD
 	// -Network Config
 	// -Executor overrides
 

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -50,7 +50,6 @@ var virtualKubeletHardcodedEnvVars = []string{
 var _ Container = (*PodContainer)(nil)
 
 // PodContainer is an implementation of Container backed only by a kubernetes pod.
-// This is currently using the base64'ed ContainerInfo until all fields are ported over to annotations
 type PodContainer struct {
 	capabilities   *corev1.Capabilities
 	config         config.Config
@@ -224,7 +223,9 @@ func (c *PodContainer) CombinedAppStackDetails() string {
 	return combinedAppStackDetails(c)
 }
 
-func (c *PodContainer) ContainerInfo() (*titus.ContainerInfo, error) {
+// SyntheticContainerInfo returns an older style proto ContainerInfo object, for backwards compatibility
+// for the titus-imds, which uses it to serve the task-identity document.
+func (c *PodContainer) SyntheticContainerInfo() (*titus.ContainerInfo, error) {
 	// TODO: this needs to be removed once Metatron supports the v2 identity endpoint (TITUS-5823)
 	userContainer := podCommon.GetUserContainer(c.pod)
 	appName := c.AppName()

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -598,7 +598,7 @@ func TestNewPodContainerMetatronDisabledWhenNoCreds(t *testing.T) {
 
 	c, err := NewPodContainer(pod, *conf)
 	assert.NilError(t, err)
-	cInfo, err := c.ContainerInfo()
+	cInfo, err := c.SyntheticContainerInfo()
 	assert.NilError(t, err)
 	creds := cInfo.GetMetatronCreds()
 	assert.Equal(t, creds == nil, true)
@@ -1389,7 +1389,7 @@ func TestContainerInfoGenerationBasic(t *testing.T) {
 	c, err := NewPodContainer(pod, *conf)
 	assert.NilError(t, err)
 
-	cInfo, err := c.ContainerInfo()
+	cInfo, err := c.SyntheticContainerInfo()
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Diff(cInfo, &titus.ContainerInfo{
 		AppName:          ptr.StringPtr(""),
@@ -1477,7 +1477,7 @@ func TestContainerInfoGenerationAllFields(t *testing.T) {
 	c, err := NewPodContainer(pod, *conf)
 	assert.NilError(t, err)
 
-	cInfo, err := c.ContainerInfo()
+	cInfo, err := c.SyntheticContainerInfo()
 	assert.NilError(t, err)
 	expMetatronCreds := &titus.ContainerInfo_MetatronCreds{
 		AppMetadata: ptr.StringPtr("app-meta"),
@@ -1538,7 +1538,7 @@ func TestContainerInfoGenerationNoUserEnvVars(t *testing.T) {
 	c, err := NewPodContainer(pod, *conf)
 	assert.NilError(t, err)
 
-	cInfo, err := c.ContainerInfo()
+	cInfo, err := c.SyntheticContainerInfo()
 	assert.NilError(t, err)
 	assert.DeepEqual(t, cInfo.TitusProvidedEnv, map[string]string{
 		"FROM_TITUS_1": "T1",

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -154,7 +154,7 @@ type Container interface {
 	BatchPriority() *string
 	Capabilities() *corev1.Capabilities
 	CombinedAppStackDetails() string
-	ContainerInfo() (*titus.ContainerInfo, error)
+	SyntheticContainerInfo() (*titus.ContainerInfo, error)
 	EBSInfo() EBSInfo
 	Env() map[string]string
 	EnvOverrides() map[string]string
@@ -257,10 +257,11 @@ func ComputeHostname(c Container) (string, error) {
 	}
 }
 
-// Generates a ContainerInfo config suitable for writing out to disk so the metadata proxy can use it
-func ContainerConfig(c Container, startTime time.Time) (*titus.ContainerInfo, error) {
+// Generates a synthetic ContainerInfo config suitable for writing out to disk so the metadata proxy can use it
+// This is a "second pass" mutation of the containerinfo that comes in from the Container interface
+func GenerateSyntheticContainerInfoPass2(c Container, startTime time.Time) (*titus.ContainerInfo, error) {
 	launchTime := uint64(startTime.Unix())
-	ti, err := c.ContainerInfo()
+	ti, err := c.SyntheticContainerInfo()
 	if err != nil {
 		return nil, err
 	}

--- a/metadataserver/identity.go
+++ b/metadataserver/identity.go
@@ -22,11 +22,11 @@ func (ms *MetadataServer) generateTaskIdentity() *titus.TaskIdentity {
 	now := uint64(time.Now().Unix())
 	taskStatus := titus.TaskInfo_RUNNING
 	ti := &titus.TaskIdentity{
-		Container: ms.container,
+		Container: ms.containerInfo,
 		Task: &titus.TaskInfo{
-			ContainerId: ms.container.RunState.TaskId,
-			TaskId:      ms.container.RunState.TaskId,
-			HostName:    ms.container.RunState.HostName,
+			ContainerId: ms.containerInfo.RunState.TaskId,
+			TaskId:      ms.containerInfo.RunState.TaskId,
+			HostName:    ms.containerInfo.RunState.HostName,
 			Status:      &taskStatus,
 		},
 		UnixTimestampSec: &now,
@@ -58,9 +58,9 @@ func (ms *MetadataServer) generateTaskPodIdentity() (*titus.TaskPodIdentity, err
 	ti := &titus.TaskPodIdentity{
 		Pod: podData,
 		TaskInfo: &titus.TaskInfo{
-			ContainerId: ms.container.RunState.TaskId,
-			TaskId:      ms.container.RunState.TaskId,
-			HostName:    ms.container.RunState.HostName,
+			ContainerId: ms.containerInfo.RunState.TaskId,
+			TaskId:      ms.containerInfo.RunState.TaskId,
+			HostName:    ms.containerInfo.RunState.HostName,
 			Status:      &taskStatus,
 		},
 		RequestTimestamp: timestamppb.Now(),

--- a/metadataserver/server.go
+++ b/metadataserver/server.go
@@ -89,7 +89,7 @@ type MetadataServer struct {
 	accountID           string
 	launched            time.Time
 	pod                 *corev1.Pod
-	container           *titus.ContainerInfo
+	containerInfo       *titus.ContainerInfo
 	signer              *identity.Signer
 	// Need to hold `signLock` while accessing `signer`
 	signLock                  sync.RWMutex
@@ -141,7 +141,7 @@ func NewMetaDataServer(ctx context.Context, config types.MetadataServerConfigura
 		launched:                  time.Now(),
 		ec2metadatasvc:            svc,
 		pod:                       config.Pod,
-		container:                 config.Container,
+		containerInfo:             config.ContainerInfo,
 		signer:                    config.Signer,
 		tokenRequired:             config.RequireToken,
 		xForwardedForBlockingMode: config.XFordwardedForBlockingMode,

--- a/metadataserver/server_test.go
+++ b/metadataserver/server_test.go
@@ -717,7 +717,7 @@ func setupMetadataServer(t *testing.T, conf testServerConfig) *MetadataServer {
 			Host:   conf.ss.fakeEC2MetdataServiceListener.Addr().String(),
 		},
 		Pod:           fakePod,
-		Container:     fakeTaskIdent.Container,
+		ContainerInfo: fakeTaskIdent.Container,
 		RequireToken:  conf.requireToken,
 		Region:        "us-east-1",
 		STSEndpoint:   conf.ss.fakeSTSserver.URL,

--- a/metadataserver/types/types.go
+++ b/metadataserver/types/types.go
@@ -35,7 +35,7 @@ type MetadataServerConfiguration struct {
 	PublicIpv4Address          net.IP
 	Ipv6Address                *net.IP
 	Pod                        *corev1.Pod
-	Container                  *titus.ContainerInfo
+	ContainerInfo              *titus.ContainerInfo
 	Signer                     *identity.Signer
 	RequireToken               bool
 	TokenKey                   string


### PR DESCRIPTION
Sometimes we were calling cInfo "config", which made sense at the time.
Also now I would like to be explicit about where the cInfo is
"synthetically" generated from a pod.
