### PR TITLE
Enabled MOTD on titus-ssh

### DIFF
--- a/executor/runtime/docker/docker_ssh.go
+++ b/executor/runtime/docker/docker_ssh.go
@@ -78,7 +78,7 @@ PasswordAuthentication no
 
 X11Forwarding yes
 X11DisplayOffset 10
-PrintMotd no
+PrintMotd yes
 PrintLastLog no
 TCPKeepAlive yes
 #UseLogin no

--- a/root/etc/apparmor.d/docker_fuse
+++ b/root/etc/apparmor.d/docker_fuse
@@ -96,6 +96,6 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
     /dev/{null,ptmx,tty,urandom,log} rwmlk,
     /dev/pts/* rwmlk,
 
-    /etc/{gai.conf,group,nsswitch.conf,passwd,shadow} rmkl,
+    /etc/{gai.conf,group,nsswitch.conf,passwd,shadow,motd} rmkl,
   }
 }

--- a/root/etc/apparmor.d/docker_titus
+++ b/root/etc/apparmor.d/docker_titus
@@ -84,6 +84,6 @@ profile docker_titus flags=(attach_disconnected,mediate_deleted) {
     /dev/{null,ptmx,tty,urandom,log} rwmlk,
     /dev/pts/* rwmlk,
 
-    /etc/{gai.conf,group,nsswitch.conf,passwd,shadow} rmkl,
+    /etc/{gai.conf,group,nsswitch.conf,passwd,shadow,motd} rmkl,
   }
 }


### PR DESCRIPTION
These changes allow the /etc/motd to be printed when one logs into
a Titus container, just like EC2.
