### PR TITLE
Removed unused old container params and task id label

### DIFF
--- a/cmd/titus-metadata-service/main.go
+++ b/cmd/titus-metadata-service/main.go
@@ -38,7 +38,6 @@ import (
 const (
 	// 169 is the first octet of 169.254...
 	defaultListeningPort = 8169
-	taskInstanceIDEnvVar = "TITUS_TASK_INSTANCE_ID"
 	certRefreshTime      = 5 * time.Minute
 )
 
@@ -76,7 +75,7 @@ func makeFDListener(fd int64) net.Listener {
 func readTaskContainerInfoFile(taskID string) (*titus.ContainerInfo, error) {
 	if taskID == "" {
 		log.Errorf("task ID is empty: can't read task cinfo file")
-		return nil, fmt.Errorf("task ID env var unset: %s", taskInstanceIDEnvVar)
+		return nil, fmt.Errorf("task ID env var unset: %s", runtimeTypes.TitusTaskInstanceIDEnvVar)
 	}
 	confFile := filepath.Join(runtimeTypes.TitusEnvironmentsDir, fmt.Sprintf("%s.json", taskID))
 	contents, err := ioutil.ReadFile(confFile) // nolint: gosec
@@ -97,7 +96,7 @@ func readTaskContainerInfoFile(taskID string) (*titus.ContainerInfo, error) {
 func readTaskPodFile(taskID string) (*corev1.Pod, error) {
 	if taskID == "" {
 		log.Errorf("task ID is empty: can't read pod config file")
-		return nil, fmt.Errorf("task ID env var unset: %s", taskInstanceIDEnvVar)
+		return nil, fmt.Errorf("task ID env var unset: %s", runtimeTypes.TitusTaskInstanceIDEnvVar)
 	}
 
 	// This filename is from VK, which is /run/titus-executor/$namespace__$podname/pod.json
@@ -221,7 +220,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:        "titus-task-instance-id",
-			EnvVar:      taskInstanceIDEnvVar,
+			EnvVar:      runtimeTypes.TitusTaskInstanceIDEnvVar,
 			Destination: &titusTaskInstanceID,
 		},
 		cli.StringFlag{

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -18,26 +18,18 @@ import (
 )
 
 const (
-	appNameLabelKey        = "com.netflix.titus.appName"
-	commandLabelKey        = "com.netflix.titus.command"
-	entrypointLabelKey     = "com.netflix.titus.entrypoint"
-	cpuLabelKey            = "com.netflix.titus.cpu"
-	iamRoleLabelKey        = "ec2.iam.role"
-	memLabelKey            = "com.netflix.titus.mem"
-	diskLabelKey           = "com.netflix.titus.disk"
-	networkLabelKey        = "com.netflix.titus.network"
-	workloadTypeLabelKey   = "com.netflix.titus.workload.type"
-	ownerEmailLabelKey     = "com.netflix.titus.owner.email"
-	jobTypeLabelKey        = "com.netflix.titus.job.type"
-	TitusTaskInstanceIDKey = "TITUS_TASK_INSTANCE_ID"
-
-	// Passthrough params
-	LogKeepLocalFileAfterUploadParam        = "titusParameter.agent.log.keepLocalFileAfterUpload"
-	FuseEnabledParam                        = "titusParameter.agent.fuseEnabled"
-	KvmEnabledParam                         = "titusParameter.agent.kvmEnabled"
-	SeccompAgentEnabledForPerfSyscallsParam = "titusParameter.agent.seccompAgentEnabledForPerfSyscalls"
-	AccountIDParam                          = "titusParameter.agent.accountId"
-	TrafficSteeringEnabledParam             = "titusParameter.agent.trafficSteeringEnabled"
+	appNameLabelKey           = "com.netflix.titus.appName"
+	commandLabelKey           = "com.netflix.titus.command"
+	entrypointLabelKey        = "com.netflix.titus.entrypoint"
+	cpuLabelKey               = "com.netflix.titus.cpu"
+	iamRoleLabelKey           = "ec2.iam.role"
+	memLabelKey               = "com.netflix.titus.mem"
+	diskLabelKey              = "com.netflix.titus.disk"
+	networkLabelKey           = "com.netflix.titus.network"
+	workloadTypeLabelKey      = "com.netflix.titus.workload.type"
+	ownerEmailLabelKey        = "com.netflix.titus.owner.email"
+	jobTypeLabelKey           = "com.netflix.titus.job.type"
+	TitusTaskInstanceIDEnvVar = "TITUS_TASK_INSTANCE_ID"
 
 	// DefaultOciRuntime is the default oci-compliant runtime used to run system services
 	DefaultOciRuntime = "runc"
@@ -74,7 +66,6 @@ func addLabels(taskID string, c Container, resources *Resources) map[string]stri
 	labels := map[string]string{
 		models.ExecutorPidLabel: fmt.Sprintf("%d", os.Getpid()),
 		models.TaskIDLabel:      taskID,
-		TitusTaskInstanceIDKey:  taskID,
 	}
 
 	iamRole := c.IamRole()

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -404,7 +404,6 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 		memLabelKey:             strconv.Itoa(int(expResources.Mem)),
 		diskLabelKey:            strconv.Itoa(int(expResources.Disk)),
 		networkLabelKey:         strconv.Itoa(int(expResources.Network)),
-		TitusTaskInstanceIDKey:  taskID,
 		workloadTypeLabelKey:    string(BurstWorkloadType),
 		models.ExecutorPidLabel: strconv.Itoa(os.Getpid()),
 		models.TaskIDLabel:      taskID,

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -370,7 +370,7 @@ func createPodTask(jobInput *JobInput, jobID string, task *runner.Task, env map[
 	systemEnvVars := []corev1.EnvVar{
 		{
 			// This needs to be set for the IMDS to start up
-			Name:  runtimeTypes.TitusTaskInstanceIDKey,
+			Name:  runtimeTypes.TitusTaskInstanceIDEnvVar,
 			Value: task.TaskID,
 		},
 		{


### PR DESCRIPTION
These older params are no longer used since v1 pods.

Also I've unified the `TitusTaskInstanceIDEnvVar` const
in both the executor and imds, and not set a label for it.
(surely the label is not actually used)
