### PR TITLE
Added more network annotations

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -449,13 +449,16 @@ func (n *NetworkConfigurationDetails) ToMap() map[string]string {
 
 func (n *NetworkConfigurationDetails) ToAnnotationMap() map[string]string {
 	a := map[string]string{}
+	// This Network Mode is the "effective" one, which may not be the original specified
+	// network mode (which is often unset/unknown)
 	if n.NetworkMode != "" {
 		a[podCommon.AnnotationKeyEffectiveNetworkMode] = n.NetworkMode
 	}
-	if n.IPAddress != "" {
-		a[podCommon.AnnotationKeyIPAddress] = n.IPAddress
+	if p := pickPrimaryIP(n); p != "" {
+		a[podCommon.AnnotationKeyIPAddress] = p
 	}
-	if n.EniIPAddress != "" {
+	// In transition mode, we don't want to "leak" the v4 as the primary ip
+	if n.EniIPAddress != "" && n.NetworkMode != titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() {
 		a[podCommon.AnnotationKeyIPv4Address] = n.EniIPAddress
 	}
 	if n.EniIPv6Address != "" {
@@ -468,7 +471,33 @@ func (n *NetworkConfigurationDetails) ToAnnotationMap() map[string]string {
 		// TODO: Use the transition IP when available from the vpc allocation object
 		a[podCommon.AnnotationKeyIPv4TransitionAddress] = n.EniIPAddress
 	}
+	if n.ElasticIPAddress != "" {
+		a[podCommon.AnnotationKeyElasticIPv4Address] = n.ElasticIPAddress
+	}
 	return a
+}
+
+// pickPrimaryIP applies a series of heuristics to pick the "best" IP that should describe the task.
+// This IP is what ends up show in spinnaker or what gets sshd to, among other things.
+func pickPrimaryIP(n *NetworkConfigurationDetails) string {
+	// If we have an Elastic IP, we consider that to be the main one
+	if n.ElasticIPAddress != "" {
+		return n.ElasticIPAddress
+	}
+
+	// In transition mode, we don't want to "leak" the v4 as the primary ip
+	// But otherwise, for compatibility reasons, we consider this to be the "main" IP
+	if n.IPAddress != "" && n.NetworkMode != titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() {
+		return n.IPAddress
+	}
+
+	// If we have an v6 Address, we can use that
+	if n.ElasticIPAddress != "" {
+		return n.ElasticIPAddress
+	}
+
+	// Otherwise we don't have one to use
+	return ""
 }
 
 // Details contains additional details about a container that are

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Netflix/metrics-client-go v0.0.0-20171019173821-bb173f41fc07
 	github.com/Netflix/spectator-go v0.0.0-20190913215732-d4e0463555ef
 	github.com/Netflix/titus-api-definitions v0.0.3-rc.17
-	github.com/Netflix/titus-kube-common v0.25.0
+	github.com/Netflix/titus-kube-common v0.26.0
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
 	github.com/apex/log v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/Netflix/titus-kube-common v0.23.0 h1:7OX3YL2bgBwQz+FCQfAxyA9COMWjvJti
 github.com/Netflix/titus-kube-common v0.23.0/go.mod h1:/l93ATTo1UY6kwPRqYSDU015Pr10yxK1jd6qnV0G3ec=
 github.com/Netflix/titus-kube-common v0.25.0 h1:2NVy4GuxI6T+SYUf5vnkgQPoyKcCkukOHz5o+WUPdJU=
 github.com/Netflix/titus-kube-common v0.25.0/go.mod h1:/l93ATTo1UY6kwPRqYSDU015Pr10yxK1jd6qnV0G3ec=
+github.com/Netflix/titus-kube-common v0.26.0 h1:hqBLHo1Lt4P0hEPtrzQpSvHo4RQ0GzgsX9sSxUg0UQo=
+github.com/Netflix/titus-kube-common v0.26.0/go.mod h1:/l93ATTo1UY6kwPRqYSDU015Pr10yxK1jd6qnV0G3ec=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
This extracts more logic into the setting of our network-related
annotations to replace the "legacy" ones.

When we start using these new annotations, they can be taken "as is"
without any additional logic by the control-plane or anyone else looking
at the pod. (and we can deprecate the legacy annotations)
