### PR TITLE
Removed last use of TITUS_TASK_INSTANCE_ID

### DIFF
--- a/cmd/titus-metadata-service/main.go
+++ b/cmd/titus-metadata-service/main.go
@@ -75,7 +75,7 @@ func makeFDListener(fd int64) net.Listener {
 func readTaskContainerInfoFile(taskID string) (*titus.ContainerInfo, error) {
 	if taskID == "" {
 		log.Errorf("task ID is empty: can't read task cinfo file")
-		return nil, fmt.Errorf("task ID env var unset: %s", runtimeTypes.TitusTaskInstanceIDEnvVar)
+		return nil, fmt.Errorf("TITUS_TASK_ID env var unset?")
 	}
 	confFile := filepath.Join(runtimeTypes.TitusEnvironmentsDir, fmt.Sprintf("%s.json", taskID))
 	contents, err := ioutil.ReadFile(confFile) // nolint: gosec
@@ -96,7 +96,7 @@ func readTaskContainerInfoFile(taskID string) (*titus.ContainerInfo, error) {
 func readTaskPodFile(taskID string) (*corev1.Pod, error) {
 	if taskID == "" {
 		log.Errorf("task ID is empty: can't read pod config file")
-		return nil, fmt.Errorf("task ID env var unset: %s", runtimeTypes.TitusTaskInstanceIDEnvVar)
+		return nil, fmt.Errorf("TITUS_TASK_ID env var unset?")
 	}
 
 	// This filename is from VK, which is /run/titus-executor/$namespace__$podname/pod.json
@@ -220,7 +220,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:        "titus-task-instance-id",
-			EnvVar:      runtimeTypes.TitusTaskInstanceIDEnvVar,
+			EnvVar:      "TITUS_TASK_ID",
 			Destination: &titusTaskInstanceID,
 		},
 		cli.StringFlag{

--- a/cmd/titus-standalone/pod.jsonnet
+++ b/cmd/titus-standalone/pod.jsonnet
@@ -73,10 +73,6 @@
             "value": "443"
           },
           {
-            "name": "TITUS_TASK_INSTANCE_ID",
-            "value": "843863f1-41a2-4a73-89bc-89c506bc1e14"
-          },
-          {
             "name": "TITUS_TASK_ID",
             "value": "843863f1-41a2-4a73-89bc-89c506bc1e14"
           },

--- a/executor/runtime/types/container.go
+++ b/executor/runtime/types/container.go
@@ -18,18 +18,17 @@ import (
 )
 
 const (
-	appNameLabelKey           = "com.netflix.titus.appName"
-	commandLabelKey           = "com.netflix.titus.command"
-	entrypointLabelKey        = "com.netflix.titus.entrypoint"
-	cpuLabelKey               = "com.netflix.titus.cpu"
-	iamRoleLabelKey           = "ec2.iam.role"
-	memLabelKey               = "com.netflix.titus.mem"
-	diskLabelKey              = "com.netflix.titus.disk"
-	networkLabelKey           = "com.netflix.titus.network"
-	workloadTypeLabelKey      = "com.netflix.titus.workload.type"
-	ownerEmailLabelKey        = "com.netflix.titus.owner.email"
-	jobTypeLabelKey           = "com.netflix.titus.job.type"
-	TitusTaskInstanceIDEnvVar = "TITUS_TASK_INSTANCE_ID"
+	appNameLabelKey      = "com.netflix.titus.appName"
+	commandLabelKey      = "com.netflix.titus.command"
+	entrypointLabelKey   = "com.netflix.titus.entrypoint"
+	cpuLabelKey          = "com.netflix.titus.cpu"
+	iamRoleLabelKey      = "ec2.iam.role"
+	memLabelKey          = "com.netflix.titus.mem"
+	diskLabelKey         = "com.netflix.titus.disk"
+	networkLabelKey      = "com.netflix.titus.network"
+	workloadTypeLabelKey = "com.netflix.titus.workload.type"
+	ownerEmailLabelKey   = "com.netflix.titus.owner.email"
+	jobTypeLabelKey      = "com.netflix.titus.job.type"
 
 	// DefaultOciRuntime is the default oci-compliant runtime used to run system services
 	DefaultOciRuntime = "runc"

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -378,12 +378,7 @@ func createPodTask(jobInput *JobInput, jobID string, task *runner.Task, env map[
 	// Now that the user env vars are added, the system ones come after
 	systemEnvVars := []corev1.EnvVar{
 		{
-			// This needs to be set for the IMDS to start up
-			Name:  runtimeTypes.TitusTaskInstanceIDEnvVar,
-			Value: task.TaskID,
-		},
-		{
-			// This needs to be set for the logviewer to work properly
+			// This needs to be set for the logviewer, imds, and many other things to work properly
 			Name:  "TITUS_TASK_ID",
 			Value: task.TaskID,
 		},
@@ -485,7 +480,6 @@ func StartTestTask(t *testing.T, ctx context.Context, jobInput *JobInput) (*JobR
 
 	env := map[string]string{
 		"TITUS_TASK_ID":                       taskID,
-		"TITUS_TASK_INSTANCE_ID":              taskID,
 		metadataserverTypes.EC2IPv4EnvVarName: "192.0.2.1",
 	}
 

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -1129,7 +1129,7 @@ func TestContainerLogViewer(t *testing.T) {
 			"echo stdout-should-go-to-log;" +
 			"source /etc/profile.d/netflix_environment.sh;" +
 			"i=0;" +
-			"url=\"http://localhost:8004/logs/${TITUS_TASK_INSTANCE_ID}?f=stdout\"; " +
+			"url=\"http://localhost:8004/logs/${TITUS_TASK_ID}?f=stdout\"; " +
 			"while [[ $i -lt 10 ]] && ! curl -s $url | grep -q stdout-should-go-to-log ; do " +
 			"  sleep 1;" +
 			"  echo $i;" +

--- a/pod.json
+++ b/pod.json
@@ -53,10 +53,6 @@
             "value": "0"
           },
           {
-            "name": "TITUS_TASK_INSTANCE_ID",
-            "value": "843863f1-41a2-4a73-89bc-89c506bc1e14"
-          },
-          {
             "name": "TITUS_TASK_ID",
             "value": "843863f1-41a2-4a73-89bc-89c506bc1e14"
           },


### PR DESCRIPTION
I hope I'm not missing any historical context about this variable.
It seems redundant in the face of TITUS_TASK_ID.

This PR removes the last trace of it, as it looks like it was only for
the imds.

It is not a documented var on titus-docs, customers should not be using
it.
