### PR TITLE
WIP: Mount /mnt-shared in pods

### DIFF
--- a/cmd/titus-storage/bind.go
+++ b/cmd/titus-storage/bind.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func mntSharedRunner(ctx context.Context, command string, config MountConfig) error {
+	switch command {
+	case "start":
+		return mntSharedStart(ctx, config)
+	case "stop":
+		return nil
+	default:
+		return fmt.Errorf("Command %q unsupported. Must be either start or stop", command)
+	}
+}
+
+func mntSharedStart(ctx context.Context, config MountConfig) error {
+	mc := MountCommand{
+		// TODO: centralize this path logic
+		source:     "/run/titus-executor/default__" + config.taskID + "/mounts/mnt-shared",
+		mountPoint: "/mnt-shared",
+		pid1Dir:    config.pid1Dir,
+	}
+	return mountBindInContainer(ctx, mc)
+}

--- a/cmd/titus-storage/main.go
+++ b/cmd/titus-storage/main.go
@@ -59,6 +59,11 @@ func main() {
 				return err
 			}
 			defer exclusiveLock.Unlock()
+			err = mntSharedRunner(ctx, command, mountConfig)
+			if err != nil {
+				l.WithError(err)
+				// TODO: eventually return error when this becomes important
+			}
 			if mountConfig.ebsVolumeID != "" {
 				err := ebsRunner(ctx, command, mountConfig)
 				if err != nil {

--- a/cmd/titus-storage/mount.go
+++ b/cmd/titus-storage/mount.go
@@ -13,10 +13,11 @@ import (
 
 const (
 	mountBlockDeviceCommand = "/apps/titus-executor/bin/titus-mount-block-device"
+	mountBindCommand        = "/apps/titus-executor/bin/titus-mount-bind"
 )
 
 type MountCommand struct {
-	device     string
+	source     string
 	perms      string
 	pid1Dir    string
 	mountPoint string
@@ -41,18 +42,36 @@ func mountBlockDeviceInContainer(ctx context.Context, mc MountCommand) error {
 	if mc.pid1Dir == "" {
 		return fmt.Errorf("env var TITUS_PID_1_DIR is not set, unable to mount")
 	}
-	l.Printf("Running %s to mount %s onto %s in the container", mountBlockDeviceCommand, mc.device, mc.mountPoint)
+	l.Printf("Running %s to mount %s onto %s in the container", mountBlockDeviceCommand, mc.source, mc.mountPoint)
 	cmd := exec.Command(mountBlockDeviceCommand)
 	cmd.Env = []string{
 		"TITUS_PID_1_DIR=" + mc.pid1Dir,
 		"MOUNT_TARGET=" + mc.mountPoint,
-		"MOUNT_OPTIONS=source=" + mc.device,
+		"MOUNT_OPTIONS=source=" + mc.source,
 		"MOUNT_FLAGS=" + flags,
 		"MOUNT_FSTYPE=" + mc.fstype,
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	l.Printf("%s %s", strings.Join(cmd.Env, " "), mountBlockDeviceCommand)
+	return cmd.Run()
+}
+
+func mountBindInContainer(ctx context.Context, mc MountCommand) error {
+	l := logger.GetLogger(ctx)
+	if mc.pid1Dir == "" {
+		return fmt.Errorf("env var TITUS_PID_1_DIR is not set, unable to mount")
+	}
+	l.Printf("Running %s to mount %s onto %s in the container", mountBindCommand, mc.source, mc.mountPoint)
+	cmd := exec.Command(mountBindCommand)
+	cmd.Env = []string{
+		"TITUS_PID_1_DIR=" + mc.pid1Dir,
+		"MOUNT_TARGET=" + mc.mountPoint,
+		"MOUNT_SOURCE=" + mc.source,
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	l.Printf("%s %s", strings.Join(cmd.Env, " "), mountBindCommand)
 	return cmd.Run()
 }
 


### PR DESCRIPTION
This is WIP because I'm torn on where to put it.

a. titus-storage system sidecar, which I think is a nice place to put
all future storage stuff, but currently operates on only the main
container

b. titus-executor, which has a lot of existing things around mount paths

This PR is WIP, I'm mixing both, and I think it would be nice if we
didn't mix too much.

If I do a, then I need to make titus-storage "pod aware" and (finally)
put tini behind all containers.

If I do b, then I need to have titus-executor "for-each" on each
container and run this mount command.

### Description of the Change

**FIXME**: please add at least one sentence explaining why changes here are being made.
