### PR TITLE
Enable titus-storage to mount /mnt-shared on multi-container workloads TITUS-5894

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -30,6 +30,8 @@ redact_secrets() {
 # For CI/CD, we touch some files to make them new, so that make doesn't think they need
 # to be re-generated
 touch vpc/service/db/migrations/bindata.go
+touch executor/runtime/docker/seccomp/*.json
+touch executor/runtime/docker/seccomp/seccomp.go
 
 log "Building executor"
 make clean

--- a/cmd/common/utils.go
+++ b/cmd/common/utils.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const taskInstanceIDEnvVar = "TITUS_TASK_INSTANCE_ID"
+
+func ReadTaskPodFile(taskID string) (*corev1.Pod, error) {
+	if taskID == "" {
+		log.Errorf("task ID is empty: can't read pod config file")
+		return nil, fmt.Errorf("task ID env var unset: %s", taskInstanceIDEnvVar)
+	}
+
+	// This filename is from VK, which is /run/titus-executor/$namespace__$podname/pod.json
+	// We only use the default namespace, so we hardcode it here.
+	confFile := filepath.Join("/run/titus-executor/default__"+taskID, "pod.json")
+	contents, err := ioutil.ReadFile(confFile) // nolint: gosec
+	if err != nil {
+		log.WithError(err).Errorf("Error reading pod config file %s", confFile)
+		return nil, err
+	}
+
+	var pod corev1.Pod
+	if err = json.Unmarshal(contents, &pod); err != nil {
+		log.WithError(err).Errorf("Error parsing JSON in pod config file %s", confFile)
+		return nil, err
+	}
+
+	return &pod, nil
+}

--- a/cmd/common/utils.go
+++ b/cmd/common/utils.go
@@ -20,7 +20,7 @@ func ReadTaskPodFile(taskID string) (*corev1.Pod, error) {
 
 	// This filename is from VK, which is /run/titus-executor/$namespace__$podname/pod.json
 	// We only use the default namespace, so we hardcode it here.
-	confFile := filepath.Join("/run/titus-executor/default__"+taskID, "pod.json")
+	confFile := filepath.Join("/run", "titus-executor", "default__"+taskID, "pod.json")
 	contents, err := ioutil.ReadFile(confFile) // nolint: gosec
 	if err != nil {
 		log.WithError(err).Errorf("Error reading pod config file %s", confFile)

--- a/cmd/titus-storage/bind.go
+++ b/cmd/titus-storage/bind.go
@@ -34,12 +34,20 @@ func mntSharedStart(ctx context.Context, config MountConfig) error {
 	l.Info("Creating tmpfs at " + path)
 	err = executorDocker.MountTmpfs(path, "5242880")
 	if err != nil {
+		err = fmt.Errorf("Unable to mount tmpfs at %s: %w", path, err)
+		l.Error(err)
+		return err
+	}
+
+	err = makeMountRShared(path)
+	if err != nil {
+		err = fmt.Errorf("Unable to make tmpfs at %s rshared: %w", path, err)
 		l.Error(err)
 		return err
 	}
 
 	for _, c := range config.pod.Spec.Containers {
-		l.Infof("Mounting /mnt-shared into container %s", &c.Name)
+		l.Infof("Mounting /mnt-shared into container %s", c.Name)
 		pid1Dir := executorDocker.GetTitusInitsPath(config.taskID, c.Name)
 		mc := MountCommand{
 			source:     path,

--- a/cmd/titus-storage/bind.go
+++ b/cmd/titus-storage/bind.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
-	"strconv"
 
-	docker "github.com/docker/docker/client"
+	executorDocker "github.com/Netflix/titus-executor/executor/runtime/docker"
+	"github.com/Netflix/titus-executor/logger"
 )
 
 func mntSharedRunner(ctx context.Context, command string, config MountConfig) error {
@@ -14,7 +15,7 @@ func mntSharedRunner(ctx context.Context, command string, config MountConfig) er
 	case "start":
 		return mntSharedStart(ctx, config)
 	case "stop":
-		return nil
+		return mntSharedStop(ctx, config)
 	default:
 		return fmt.Errorf("Command %q unsupported. Must be either start or stop", command)
 	}
@@ -22,40 +23,58 @@ func mntSharedRunner(ctx context.Context, command string, config MountConfig) er
 
 func mntSharedStart(ctx context.Context, config MountConfig) error {
 	var err error
+	l := logger.GetLogger(ctx)
+	path := getMntSharedPath(config.taskID)
 
-	client, err := docker.NewClient("unix:///var/run/docker.sock", "1.26", nil, map[string]string{})
-	for _, cStatus := range config.pod.Status.ContainerStatuses {
-		cID := cStatus.ContainerID
-		pid1, err := cid2Pid1(ctx, client, cID)
-		if err != nil {
-			return fmt.Errorf("Error looking up pid1 for container %s: %w", cID, err)
-		}
-		pid1Dir := pid12Pid1Dir(pid1)
+	l.Info("Creating /mnt/shared for " + path)
+	err = createMntShared(path)
+	if err != nil {
+		return err
+	}
+
+	l.Info("Creating tmpfs for " + path)
+	err = executorDocker.MountTmpfs(path, "5242880")
+	if err != nil {
+		l.Error(err)
+		return err
+	}
+
+	for _, c := range config.pod.Spec.Containers {
+		l.Infof("Mounting /mnt/shared into container %s", &c.Name)
+		pid1Dir := executorDocker.GetTitusInitsPath(config.taskID, c.Name)
 		mc := MountCommand{
-			// TODO: centralize this path logic
-			source:     "/run/titus-executor/default__" + config.taskID + "/mounts/mnt-shared",
+			source:     path,
 			mountPoint: "/mnt-shared",
 			pid1Dir:    pid1Dir,
 		}
 		err = mountBindInContainer(ctx, mc)
 		if err != nil {
-			return fmt.Errorf("Error mounting /mnt/shared in container %s: %w", cID, err)
+			return fmt.Errorf("Error mounting /mnt/shared in container %s: %w", c.Name, err)
 		}
 	}
 	return err
 
 }
 
-func cid2Pid1(ctx context.Context, client *docker.Client, cID string) (int, error) {
-	inspect, err := client.ContainerInspect(ctx, cID)
+func mntSharedStop(ctx context.Context, config MountConfig) error {
+	l := logger.GetLogger(ctx)
+	path := getMntSharedPath(config.taskID)
+	l.Infof("Unmounting tmpfs at %s", path)
+	err := executorDocker.UnmountLazily(path)
 	if err != nil {
-		return 0, err
+		l.Error(err)
 	}
-	containerPID := inspect.State.Pid
-	return containerPID, nil
+	return err
 }
 
-func pid12Pid1Dir(pid1 int) string {
-	pid1Str := strconv.Itoa(pid1)
-	return path.Join("/proc", pid1Str)
+func createMntShared(path string) error {
+	err := os.MkdirAll(path, os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+	return os.Chmod(path, os.FileMode(0755))
+}
+
+func getMntSharedPath(taskID string) string {
+	return path.Join("/run/titus-executor/default__"+taskID, "/mounts/mnt-shared")
 }

--- a/cmd/titus-storage/bind.go
+++ b/cmd/titus-storage/bind.go
@@ -22,17 +22,16 @@ func mntSharedRunner(ctx context.Context, command string, config MountConfig) er
 }
 
 func mntSharedStart(ctx context.Context, config MountConfig) error {
-	var err error
 	l := logger.GetLogger(ctx)
 	path := getMntSharedPath(config.taskID)
 
-	l.Info("Creating /mnt/shared for " + path)
-	err = createMntShared(path)
+	l.Info("Creating /mnt-shared on the host at " + path)
+	err := createMntShared(path)
 	if err != nil {
 		return err
 	}
 
-	l.Info("Creating tmpfs for " + path)
+	l.Info("Creating tmpfs at " + path)
 	err = executorDocker.MountTmpfs(path, "5242880")
 	if err != nil {
 		l.Error(err)
@@ -40,7 +39,7 @@ func mntSharedStart(ctx context.Context, config MountConfig) error {
 	}
 
 	for _, c := range config.pod.Spec.Containers {
-		l.Infof("Mounting /mnt/shared into container %s", &c.Name)
+		l.Infof("Mounting /mnt-shared into container %s", &c.Name)
 		pid1Dir := executorDocker.GetTitusInitsPath(config.taskID, c.Name)
 		mc := MountCommand{
 			source:     path,
@@ -49,7 +48,7 @@ func mntSharedStart(ctx context.Context, config MountConfig) error {
 		}
 		err = mountBindInContainer(ctx, mc)
 		if err != nil {
-			return fmt.Errorf("Error mounting /mnt/shared in container %s: %w", c.Name, err)
+			return fmt.Errorf("Error mounting /mnt-shared in container %s: %w", c.Name, err)
 		}
 	}
 	return err
@@ -76,5 +75,5 @@ func createMntShared(path string) error {
 }
 
 func getMntSharedPath(taskID string) string {
-	return path.Join("/run/titus-executor/default__"+taskID, "/mounts/mnt-shared")
+	return path.Join("run", "titus-executor", "default__"+taskID, "mounts", "mnt-shared")
 }

--- a/cmd/titus-storage/bind.go
+++ b/cmd/titus-storage/bind.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strconv"
+
+	docker "github.com/docker/docker/client"
+)
+
+func mntSharedRunner(ctx context.Context, command string, config MountConfig) error {
+	switch command {
+	case "start":
+		return mntSharedStart(ctx, config)
+	case "stop":
+		return nil
+	default:
+		return fmt.Errorf("Command %q unsupported. Must be either start or stop", command)
+	}
+}
+
+func mntSharedStart(ctx context.Context, config MountConfig) error {
+	var err error
+
+	client, err := docker.NewClient("unix:///var/run/docker.sock", "1.26", nil, map[string]string{})
+	for _, cStatus := range config.pod.Status.ContainerStatuses {
+		cID := cStatus.ContainerID
+		pid1, err := cid2Pid1(ctx, client, cID)
+		if err != nil {
+			return fmt.Errorf("Error looking up pid1 for container %s: %w", cID, err)
+		}
+		pid1Dir := pid12Pid1Dir(pid1)
+		mc := MountCommand{
+			// TODO: centralize this path logic
+			source:     "/run/titus-executor/default__" + config.taskID + "/mounts/mnt-shared",
+			mountPoint: "/mnt-shared",
+			pid1Dir:    pid1Dir,
+		}
+		err = mountBindInContainer(ctx, mc)
+		if err != nil {
+			return fmt.Errorf("Error mounting /mnt/shared in container %s: %w", cID, err)
+		}
+	}
+	return err
+
+}
+
+func cid2Pid1(ctx context.Context, client *docker.Client, cID string) (int, error) {
+	inspect, err := client.ContainerInspect(ctx, cID)
+	if err != nil {
+		return 0, err
+	}
+	containerPID := inspect.State.Pid
+	return containerPID, nil
+}
+
+func pid12Pid1Dir(pid1 int) string {
+	pid1Str := strconv.Itoa(pid1)
+	return path.Join("/proc", pid1Str)
+}

--- a/cmd/titus-storage/ebs.go
+++ b/cmd/titus-storage/ebs.go
@@ -75,7 +75,7 @@ func ebsStart(ctx context.Context, ec2Client *ec2.EC2, c MountConfig, ec2Instanc
 	}
 
 	mc := MountCommand{
-		device:     device,
+		source:     device,
 		fstype:     c.ebsFStype,
 		mountPoint: c.ebsMountPoint,
 		perms:      c.ebsMountPerm,

--- a/cmd/titus-storage/main.go
+++ b/cmd/titus-storage/main.go
@@ -60,7 +60,8 @@ func main() {
 			l.Infof("Running titus-storage with %s", command)
 			pod, err := common.ReadTaskPodFile(mountConfig.taskID)
 			if err != nil {
-				return fmt.Errorf("Error when reading pod.json file: %s", err)
+				l.WithError(err)
+				return fmt.Errorf("Error when reading state.json file: %s", err)
 			}
 			mountConfig.pod = pod
 			// Currently only doing mntShared on multi-container workloads
@@ -70,10 +71,13 @@ func main() {
 					l.WithError(err)
 					return err
 				}
+			} else {
+				l.Info("Not a multi-container workload, not doing shared")
 			}
 			if mountConfig.ebsVolumeID != "" {
 				exclusiveLock, err := getExclusiveLock(ctx)
 				if err != nil {
+					l.WithError(err)
 					return err
 				}
 				defer exclusiveLock.Unlock()

--- a/cmd/titus-storage/main.go
+++ b/cmd/titus-storage/main.go
@@ -59,7 +59,7 @@ func main() {
 			l.Infof("Running titus-storage with %s", command)
 			pod, err := common.ReadTaskPodFile(mountConfig.taskID)
 			if err != nil {
-				l.WithError(err).Error("Error when reading state.json file")
+				l.WithError(err).Error("Error when reading pod.json file")
 				return err
 			}
 			mountConfig.pod = pod

--- a/cmd/titus-storage/mount.go
+++ b/cmd/titus-storage/mount.go
@@ -16,7 +16,7 @@ const (
 )
 
 type MountCommand struct {
-	device     string
+	source     string
 	perms      string
 	pid1Dir    string
 	mountPoint string
@@ -41,12 +41,12 @@ func mountBlockDeviceInContainer(ctx context.Context, mc MountCommand) error {
 	if mc.pid1Dir == "" {
 		return fmt.Errorf("env var TITUS_PID_1_DIR is not set, unable to mount")
 	}
-	l.Printf("Running %s to mount %s onto %s in the container", mountBlockDeviceCommand, mc.device, mc.mountPoint)
+	l.Printf("Running %s to mount %s onto %s in the container", mountBlockDeviceCommand, mc.source, mc.mountPoint)
 	cmd := exec.Command(mountBlockDeviceCommand)
 	cmd.Env = []string{
 		"TITUS_PID_1_DIR=" + mc.pid1Dir,
 		"MOUNT_TARGET=" + mc.mountPoint,
-		"MOUNT_OPTIONS=source=" + mc.device,
+		"MOUNT_OPTIONS=source=" + mc.source,
 		"MOUNT_FLAGS=" + flags,
 		"MOUNT_FSTYPE=" + mc.fstype,
 	}

--- a/cmd/titus-storage/mount_linux.go
+++ b/cmd/titus-storage/mount_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func makeMountRShared(path string) error {
+	var flags uintptr // nolint: gosimple
+	flags = syscall.MS_SHARED
+	options := ""
+	err := syscall.Mount("none", path, "none", flags, options)
+	return os.NewSyscallError("mount", err)
+}

--- a/cmd/titus-storage/mount_unsupported.go
+++ b/cmd/titus-storage/mount_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !linux
+// +build !linux
+
+package main
+
+func makeMountRShared(path string) error {
+	return nil
+}

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -2655,7 +2655,7 @@ func (r *DockerRuntime) setupTitusInit(cName string, unixConn *net.UnixConn) err
 		return fmt.Errorf("Error getting peerinfo for %s: %w", cName, err)
 
 	}
-	target := filepath.Join("proc", strconv.FormatInt(int64(cred.pid), 10))
+	target := filepath.Join("/proc", strconv.FormatInt(int64(cred.pid), 10))
 	link := GetTitusInitsPath(r.c.TaskID(), cName)
 	err = os.MkdirAll(getTitusInitsBase(r.c.TaskID()), 0700)
 	if err != nil {

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1375,7 +1375,7 @@ func (r *DockerRuntime) cleanupAllPodMounts() error {
 	l := log.WithField("taskID", r.c.TaskID())
 	mountsPath := path.Join(r.cfg.RuntimeDir, "mounts")
 	f := func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() && isDirMounted(path) {
+		if info != nil && info.IsDir() && isDirMounted(path) {
 			l.Infof("Cleanup: unmounting %s", path)
 			_ = UnmountLazily(path)
 		}

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -2655,7 +2655,7 @@ func (r *DockerRuntime) setupTitusInit(cName string, unixConn *net.UnixConn) err
 		return fmt.Errorf("Error getting peerinfo for %s: %w", cName, err)
 
 	}
-	target := filepath.Join("/proc/", strconv.FormatInt(int64(cred.pid), 10))
+	target := filepath.Join("proc", strconv.FormatInt(int64(cred.pid), 10))
 	link := GetTitusInitsPath(r.c.TaskID(), cName)
 	err = os.MkdirAll(getTitusInitsBase(r.c.TaskID()), 0700)
 	if err != nil {
@@ -2673,7 +2673,7 @@ func GetTitusInitsPath(taskID string, cName string) string {
 }
 
 func getTitusInitsBase(taskID string) string {
-	return filepath.Join("/run/titus-executor/default__"+taskID, "inits")
+	return filepath.Join("/run", "titus-executor", "default__"+taskID, "inits")
 }
 
 func (r *DockerRuntime) setupPostStartNetworkingAndIsolate(parentCtx context.Context, c runtimeTypes.Container, cred ucred, rootFile *os.File) error { // nolint: gocyclo
@@ -2760,7 +2760,7 @@ func setupNetworking(ctx context.Context, burst bool, c runtimeTypes.Container, 
 	log.Info("Setting up container network")
 	var result vpcTypes.WiringStatus
 
-	pid1DirPath := filepath.Join("/proc/", strconv.Itoa(int(cred.pid)))
+	pid1DirPath := filepath.Join("proc", strconv.Itoa(int(cred.pid)))
 	pid1DirFile, err := os.Open(pid1DirPath)
 	if err != nil {
 		return nil, err

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -45,6 +45,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/ftrvxmtrx/fd"
 	"github.com/hashicorp/go-multierror"
+	"github.com/moby/sys/mountinfo"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -1003,6 +1004,7 @@ func (r *DockerRuntime) Prepare(ctx context.Context, pod *v1.Pod) error { // nol
 			goto error
 		}
 		bindMounts = append(bindMounts, runTmpfs)
+		r.registerRuntimeCleanup(r.cleanupAllPodMounts)
 	}
 
 	systemServices, err = r.c.SystemServices()
@@ -1351,7 +1353,7 @@ func (r *DockerRuntime) createMetatronTmpfs() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = mountTmpfs(podMetatronFsHostPath, defaultRunTmpFsSize)
+	err = MountTmpfs(podMetatronFsHostPath, defaultRunTmpFsSize)
 	v := podMetatronFsHostPath + ":/run/metatron:rw"
 	return v, err
 }
@@ -1361,7 +1363,30 @@ func (r *DockerRuntime) cleanupMetatronTmpfs() error {
 	if err != nil {
 		return err
 	}
-	return unmountTmpfs(podMetatronFsHostPath)
+	if isDirMounted(podMetatronFsHostPath) {
+		return UnmountLazily(podMetatronFsHostPath)
+	}
+	return nil
+}
+
+// cleanupAllPodMounts is a catchall cleanup for anything that might be
+// leftover in the pod mount directly. It will agressivly try to unmount everything.
+func (r *DockerRuntime) cleanupAllPodMounts() error {
+	l := log.WithField("taskID", r.c.TaskID())
+	mountsPath := path.Join(r.cfg.RuntimeDir, "mounts")
+	f := func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() && isDirMounted(path) {
+			l.Infof("Cleanup: unmounting %s", path)
+			_ = UnmountLazily(path)
+		}
+		return nil
+	}
+	return filepath.Walk(mountsPath, f)
+}
+
+func isDirMounted(path string) bool {
+	mounted, _ := mountinfo.Mounted(path)
+	return mounted
 }
 
 func (r *DockerRuntime) getPodMetatronFsHostPath() (string, error) {
@@ -1624,6 +1649,12 @@ func (r *DockerRuntime) Start(parentCtx context.Context, pod *v1.Pod) (string, *
 	}
 
 	tiniConns, err := r.waitForTiniConnections(ctx, listeners)
+	if err != nil {
+		eventCancel()
+		err = fmt.Errorf("container prestart error: %w", err)
+		return "", nil, statusMessageChan, err
+	}
+	err = r.setupTitusInits(tiniConns)
 	if err != nil {
 		eventCancel()
 		err = fmt.Errorf("container prestart error: %w", err)
@@ -2597,6 +2628,52 @@ func (r *DockerRuntime) setupGetLogCredAndRootFromMainTini(parentCtx context.Con
 	rootFile := files[0]
 	r.registerRuntimeCleanup(rootFile.Close)
 	return r.logDir(c), &cred, rootFile, err
+}
+
+func (r *DockerRuntime) setupTitusInits(tiniConns map[string]*net.UnixConn) error {
+	var err error
+	for cName, unixConn := range tiniConns {
+		err = r.setupTitusInit(cName, unixConn)
+		if err != nil {
+			return err
+		}
+	}
+	r.registerRuntimeCleanup(func() error {
+		return os.RemoveAll(getTitusInitsBase(r.c.TaskID()))
+	})
+	return nil
+}
+
+func (r *DockerRuntime) setupTitusInit(cName string, unixConn *net.UnixConn) error {
+	/* Cred here is a ucred. We have a mimic'd type of unix.Ucred, because it's not available
+	 * on darwin. I don't want to stub out this entire method / all of these types on darwin,
+	 * so we have this. These are the containers uid / pid / gid from the perspective of the
+	 * host namespace.
+	 */
+	cred, err := getPeerInfo(unixConn)
+	if err != nil {
+		return fmt.Errorf("Error getting peerinfo for %s: %w", cName, err)
+
+	}
+	target := filepath.Join("/proc/", strconv.FormatInt(int64(cred.pid), 10))
+	link := GetTitusInitsPath(r.c.TaskID(), cName)
+	err = os.MkdirAll(getTitusInitsBase(r.c.TaskID()), 0700)
+	if err != nil {
+		return fmt.Errorf("Error making base titus-inits dir: %w", err)
+	}
+	err = os.Symlink(target, link)
+	if err != nil {
+		return fmt.Errorf("Error making symlink for titus-inits from %s to %s: %w", target, link, err)
+	}
+	return nil
+}
+
+func GetTitusInitsPath(taskID string, cName string) string {
+	return filepath.Join(getTitusInitsBase(taskID), cName)
+}
+
+func getTitusInitsBase(taskID string) string {
+	return filepath.Join("/run/titus-executor/default__"+taskID, "inits")
 }
 
 func (r *DockerRuntime) setupPostStartNetworkingAndIsolate(parentCtx context.Context, c runtimeTypes.Container, cred ucred, rootFile *os.File) error { // nolint: gocyclo

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -87,7 +87,7 @@ func setupScheduler(cred ucred) error {
 
 // This mounts /proc/${PID1}/ to /var/lib/titus-inits for the container
 func (r *DockerRuntime) mountContainerProcPid1InTitusInits(parentCtx context.Context, c runtimeTypes.Container, cred ucred) error {
-	pidpath := filepath.Join("/proc/", strconv.FormatInt(int64(cred.pid), 10))
+	pidpath := filepath.Join("/proc", strconv.FormatInt(int64(cred.pid), 10))
 	path := filepath.Join(titusInits, c.TaskID())
 	if err := os.Mkdir(path, 0755); err != nil { // nolint: gosec
 		return err

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -343,7 +343,7 @@ func setupOOMAdj(c runtimeTypes.Container, cred ucred) error {
 	return err
 }
 
-func mountTmpfs(path string, size string) error {
+func MountTmpfs(path string, size string) error {
 	var flags uintptr
 	flags = syscall.MS_NOATIME | syscall.MS_SILENT
 	flags |= syscall.MS_NODEV | syscall.MS_NOEXEC | syscall.MS_NOSUID
@@ -352,6 +352,6 @@ func mountTmpfs(path string, size string) error {
 	return os.NewSyscallError("mount", err)
 }
 
-func unmountTmpfs(path string) error {
+func UnmountLazily(path string) error {
 	return unix.Unmount(path, unix.MNT_DETACH|umountNoFollow)
 }

--- a/executor/runtime/docker/docker_unsupported.go
+++ b/executor/runtime/docker/docker_unsupported.go
@@ -50,10 +50,10 @@ func stopSystemServices(ctx context.Context, c runtimeTypes.Container) error {
 	return nil
 }
 
-func mountTmpfs(path string, size string) error {
+func MountTmpfs(path string, size string) error {
 	return nil
 }
 
-func unmountTmpfs(path string) error {
+func UnmountLazily(path string) error {
 	return nil
 }

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -193,9 +193,9 @@ func shouldStartLogViewer(cfg *config.Config, c Container) bool {
 }
 
 func shouldStartTitusStorage(cfg *config.Config, c Container) bool {
-	// Currently titus-storage only supports EBS and /ephemeral storage
-	// which is currently only available on GPU instance types.
-	return c.EBSInfo().VolumeID != "" || c.Resources().GPU > 0
+	// Currently titus-storage only supports EBS and /mnt-shared storage
+	// which is currently only available on multi-container workloads
+	return c.EBSInfo().VolumeID != "" || len(c.Pod().Spec.Containers) > 1
 }
 
 func shouldStartContainerTools(cfg *config.Config, c Container) bool {

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -85,6 +85,10 @@ var (
 		name: "titusoss/user-set",
 		tag:  "20210524-1621898423",
 	}
+	fuseImage = testImage{
+		name: "titusoss/titus-test-fuse",
+		tag:  "latest",
+	}
 )
 
 const defaultFailureTimeout = time.Minute
@@ -1279,6 +1283,35 @@ func TestBasicMultiContainerCustomSharedVolumes(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestBasicMultiContainerHasMntShared(t *testing.T) {
+	wrapTestStandalone(t)
+
+	// In the main container, we expect to see a file created by our sentinel
+	testEntrypointOld := "ls -rl /mnt-shared/ && stat /mnt-shared/1/foo"
+	testEntrypointOld = `/bin/sh -vxc "sleep 5;` + testEntrypointOld + `"`
+
+	ji := &JobInput{
+		ImageName: busybox.name,
+		Version:   busybox.tag,
+		// This sentinel container touches a file, and the main container should
+		// see it if volumes are working
+		ExtraContainers: []corev1.Container{
+			{
+				Name:    "fuse-sidecar",
+				Image:   fuseImage.name + `:` + fuseImage.tag,
+				Command: []string{"/bin/sh", "-vxc"},
+				Args:    []string{"touch /mnt-shared/fuse-container-was-here && mkdir /mnt-shared/1 && fuse-zip -f /out.zip /mnt-shared/1"},
+			},
+		},
+		ExtraAnnotations: map[string]string{podCommon.AnnotationKeyPodFuseEnabled: True},
+		EntrypointOld:    testEntrypointOld,
+	}
+	if !RunJobExpectingSuccess(t, ji) {
+		t.Fail()
+	}
+}
+
 func TestOtherUserContaintainerFailsTask(t *testing.T) {
 	wrapTestStandalone(t)
 	testEntrypointOld := `/bin/sh -c "sleep 5"`

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -107,7 +107,7 @@ func skipOnDarwinOrNoRoot(t *testing.T) {
 }
 
 func dockerImageRemove(t *testing.T, imgName string) {
-	cfg, dockerCfg := GenerateTestConfigs(nil)
+	cfg, dockerCfg := GenerateTestConfigs(nil, "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -127,7 +127,7 @@ func dockerImageRemove(t *testing.T, imgName string) {
 }
 
 func dockerPull(t *testing.T, imgName string, imgDigest string) (*dockerTypes.ImageInspect, error) {
-	cfg, dockerCfg := GenerateTestConfigs(nil)
+	cfg, dockerCfg := GenerateTestConfigs(nil, "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/leanovate/gopter v0.0.0-20170420174722-9e6101e5a875
 	github.com/lib/pq v1.3.0
 	github.com/m7shapan/cidr v0.0.0-20200427124835-7eba0889a5d2
+	github.com/moby/sys/mountinfo v0.4.1
 	github.com/mvisonneau/go-ebsnvme v0.0.0-20201026165225-e63797fabc2f
 	github.com/myitcv/gobin v0.0.14
 	github.com/netflix-skunkworks/opencensus-go-exporter-datadog v0.0.0-20190911150647-ef71dde58796

--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -14,6 +14,7 @@ gox -gcflags="${GC_FLAGS:--N -l}" -osarch="linux/amd64 darwin/amd64" \
 make -C mount all
 mv mount/titus-mount-block-device build/bin/linux-amd64/
 mv mount/titus-mount-nfs build/bin/linux-amd64/
+mv mount/titus-mount-bind build/bin/linux-amd64/
 
 # tini
 make build/tini/tini-static

--- a/mount/titus-mount-bind.c
+++ b/mount/titus-mount-bind.c
@@ -11,6 +11,8 @@
 #include <syscall.h> // for __NR_fsopen, __NR_move_mount, __NR_open_tree
 #include <unistd.h> // for syscall, pid_t
 
+#include "common.h"
+
 // Only to make it easier to build on older kernels
 #ifndef AT_RECURSIVE
 #define AT_RECURSIVE 0x8000
@@ -88,6 +90,7 @@ int main(int argc, char *argv[])
 	mfd = open_tree(AT_FDCWD, source,
 			OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC | AT_RECURSIVE);
 	switch_into_mount_namespace(nsfd);
+	mkdir_p(target);
 	E(move_mount(mfd, "", AT_FDCWD, target, MOVE_MOUNT_F_EMPTY_PATH));
 	fprintf(stderr,
 		"titus-mount-bind: All done, bind mount %s mounted on %s\n",

--- a/root/lib/systemd/system/titus-sidecar-storage@.service
+++ b/root/lib/systemd/system/titus-sidecar-storage@.service
@@ -1,6 +1,7 @@
 [Unit]
-Description=Storage mounting for task %s
+Description=Storage mounting for task %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
+ConditionPathExists=/run/titus-executor/default__%i/pod.json
 # PartOf ensures that titus-storage will shutdown as part of the main titus-executor unit
 PartOf=titus-executor@default__%i.service
 
@@ -39,5 +40,4 @@ ExecStop=/apps/titus-executor/bin/titus-storage stop
 ExecStop=/bin/rm -f /var/lib/titus-environments/%i-titus-storage.env
 
 LimitNOFILE=65535
-PrivateTmp=yes
 KillMode=mixed

--- a/root/lib/systemd/system/titus-sidecar-storage@.service
+++ b/root/lib/systemd/system/titus-sidecar-storage@.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Storage mounting for task %i
 ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
-ConditionPathExists=/run/titus-executor/default__%i/pod.json
 # PartOf ensures that titus-storage will shutdown as part of the main titus-executor unit
 PartOf=titus-executor@default__%i.service
 


### PR DESCRIPTION
Now that we have tini on all containers, I would like to slowly offload all storage duties of titus-executor into the `titus-storage` titus-system-service.

This PR does a lot of prerequisite work (pod.json, $task/inits/$cname, etc) to make it so titus-storage has all the data it needs to actually mount stuff.

Then I added code for adding /mnt-shared, which will only be activated on multi-container workloads.

In my testing I found it was a bit racy on shutdown, depending on how the container was killed, so I added a big cleanup function to ensure we never leave behind any mounts.

Lastly, I'm I had to add a `ConditionPathExists` to suppress the running of `titus-storage` during our tests (which only run titus-standalone, and there is no pod.json at all). If you think this is now good, I can spend more time making our standalone_tests actually write out pod files like VK does. Or if you think that our integration tests at another layer are enough, that could be fine too.