### PR TITLE
Fix gauge TTL in titus.containers.status and platform.sidecars.instan…

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1773,8 +1773,8 @@ func (r *DockerRuntime) generateContainerStatusSpectatordMetrics() []string {
 		}
 		metricTags["titus.state"] = state
 		// 3. Create the metric line using the spectatord protocol.
-		// The metric is a gauge with a value of 1 and a TTL of 2m.
-		statusGauge := fmt.Sprintf("g,2:titus.containers.status,%s:1", spectatordTags(metricTags))
+		// The metric is a gauge with a value of 1 and a TTL of 120s.
+		statusGauge := fmt.Sprintf("g,120:titus.containers.status,%s:1", spectatordTags(metricTags))
 		metricLines = append(metricLines, statusGauge)
 	}
 	return metricLines
@@ -1829,8 +1829,8 @@ func (r *DockerRuntime) generatePlatformSidecarSpectatordMetrics() []string {
 			"platform.sidecar.channel":     release[0],
 			"platform.sidecar.channel.def": release[1],
 		}
-		// The metric is a gauge with a value of 1 and a TTL of 2m.
-		psGauge := fmt.Sprintf("g,2:platform.sidecars.instance,%s:1", spectatordTags(metricTags))
+		// The metric is a gauge with a value of 1 and a TTL of 120s.
+		psGauge := fmt.Sprintf("g,120:platform.sidecars.instance,%s:1", spectatordTags(metricTags))
 		metricLines = append(metricLines, psGauge)
 	}
 	return metricLines

--- a/executor/runtime/docker/docker_test.go
+++ b/executor/runtime/docker/docker_test.go
@@ -313,8 +313,8 @@ func TestGenerateContainerStatusSpectatordMetrics(t *testing.T) {
 	}
 	actual := runtime.generateContainerStatusSpectatordMetrics()
 	expected := []string{
-		"g,2:titus.containers.status,nf.container=main,titus.image.name=titusops_echoservice_latest,titus.image.version=sha256_60d5cdeea0de265fe7b5fe40fe23a90e1001181312d226d0e688b0f75045109e,titus.state=healthy:1",
-		"g,2:titus.containers.status,nf.container=fuse,nf.process=foo,titus.image.name=titusops_titus-test-fuse,titus.image.version=sha256_f6ac1d3f204660792aef47b482fb43a34de23768727512868f428d18a90d4c48,titus.state=healthy:1",
+		"g,120:titus.containers.status,nf.container=main,titus.image.name=titusops_echoservice_latest,titus.image.version=sha256_60d5cdeea0de265fe7b5fe40fe23a90e1001181312d226d0e688b0f75045109e,titus.state=healthy:1",
+		"g,120:titus.containers.status,nf.container=fuse,nf.process=foo,titus.image.name=titusops_titus-test-fuse,titus.image.version=sha256_f6ac1d3f204660792aef47b482fb43a34de23768727512868f428d18a90d4c48,titus.state=healthy:1",
 	}
 	assert.Equal(t, expected, actual)
 }
@@ -352,8 +352,8 @@ func TestGeneratePlatformSidecarSpectatordMetrics(t *testing.T) {
 	}
 	actual := runtime.generatePlatformSidecarSpectatordMetrics()
 	expected := []string{
-		"g,2:platform.sidecars.instance,platform.sidecar.channel.def=1,platform.sidecar.channel=dev,platform.sidecar=sidecar1:1",
-		"g,2:platform.sidecars.instance,platform.sidecar.channel.def=32,platform.sidecar.channel=stable,platform.sidecar=sidecar2:1",
+		"g,120:platform.sidecars.instance,platform.sidecar.channel.def=1,platform.sidecar.channel=dev,platform.sidecar=sidecar1:1",
+		"g,120:platform.sidecars.instance,platform.sidecar.channel.def=32,platform.sidecar.channel=stable,platform.sidecar=sidecar2:1",
 	}
 	assert.ElementsMatch(t, expected, actual) // Ignore order of the metric strings.
 }


### PR DESCRIPTION
…ce metrics

Gauge TTL is specified in seconds, not minutes, with a minimum duration of 5 seconds.