### PR TITLE
Removed legacy network annotations

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -429,32 +428,6 @@ type NetworkConfigurationDetails struct {
 	EniID               string
 	ResourceID          string
 	TransitionIPAddress string
-}
-
-// ToLegacyAnnotationMap builds up a map of "legacy" annotations that are a 1:1
-// reflection of the NetworkConfigurationDetails struct, in pod annotation form.
-func (n *NetworkConfigurationDetails) ToLegacyAnnotationMap() map[string]string {
-	m := make(map[string]string)
-	m["IsRoutableIp"] = strconv.FormatBool(n.IsRoutableIP)
-	if n.EniIPv4Address != "" {
-		m["EniIpAddress"] = n.EniIPv4Address
-	}
-	m["EniId"] = n.EniID
-	m["ResourceId"] = n.ResourceID
-	if n.EniIPv6Address != "" {
-		m["EniIPv6Address"] = n.EniIPv6Address
-	}
-	if n.ElasticIPAddress != "" {
-		m["ElasticIPAddress"] = n.ElasticIPAddress
-	}
-	m["NetworkMode"] = n.NetworkMode
-	if n.TransitionIPAddress != "" {
-		m["TransitionIPAddress"] = n.TransitionIPAddress
-	}
-	if p := n.PickPrimaryIP(); p != "" {
-		m["IpAddress"] = p
-	}
-	return m
 }
 
 // ToAnnotationMap builds up a map of annotations that are a computed

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -324,10 +324,6 @@ func (b *Backend) handleUpdate(ctx context.Context, update runner.Update) {
 	b.pod.Status.ContainerStatuses = statuses
 
 	if update.Details != nil && update.Details.NetworkConfiguration != nil {
-		// Backwards compatibility, sets "un-adorned" annotations like "IpAddress" on the pod.
-		for k, v := range update.Details.NetworkConfiguration.ToLegacyAnnotationMap() {
-			b.pod.Annotations[k] = v
-		}
 		// These annotations allow us to get data "back out" from the executor up to the control-plane, without having
 		// to depend on the limitations of the PodStatus structure.
 		for k, v := range update.Details.NetworkConfiguration.ToAnnotationMap() {


### PR DESCRIPTION
This cleans up our pods a little bit, removing "legacy" old style
annotations like `EniId` in favor of the new style that comes from
kube-common.

This can be merged and shipped after
https://github.com/Netflix/titus-control-plane/pull/1257
is fully deployed.
