### PR TITLE
Add tracing-collector as a Titus System service

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,10 @@ type Config struct {
 	ContainerSpectatord    bool
 	SpectatordServiceImage string
 
+	// Do we enable tracing-collector titus-system-service?
+	ContainerTracingCollector    bool
+	TracingCollectorServiceImage string
+
 	// Do we enable atlas-titus-agent titus-system-service?
 	ContainerAtlasTitusAgent    bool
 	AtlasTitusAgentServiceImage string
@@ -255,6 +259,16 @@ func NewConfig() (*Config, []cli.Flag) {
 			Name:        "container-spectatord-image",
 			EnvVar:      "SPECTATORD_SERVICE_IMAGE",
 			Destination: &cfg.SpectatordServiceImage,
+		},
+		cli.BoolFlag{
+			Name:        "container-tracing-collector",
+			EnvVar:      "CONTAINER_TRACING_COLLECTOR",
+			Destination: &cfg.ContainerTracingCollector,
+		},
+		cli.StringFlag{
+			Name:        "container-tracing-collector-image",
+			EnvVar:      "TRACING_COLLECTOR_SERVICE_IMAGE",
+			Destination: &cfg.TracingCollectorServiceImage,
 		},
 		cli.StringFlag{
 			Name:        "container-tools-image",

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -667,14 +667,15 @@ func (c *PodContainer) SystemServices() ([]*ServiceOpts, error) {
 	}
 
 	imageMap := map[string]string{
-		SidecarServiceAbMetrix:        c.config.AbmetrixServiceImage,
-		SidecarServiceLogViewer:       c.config.LogViewerServiceImage,
-		SidecarServiceMetatron:        c.config.MetatronServiceImage,
-		SidecarServiceServiceMesh:     svcMeshImage,
-		SidecarServiceSshd:            c.config.SSHDServiceImage,
-		SidecarServiceSpectatord:      c.config.SpectatordServiceImage,
-		SidecarServiceAtlasTitusAgent: c.config.AtlasTitusAgentServiceImage,
-		SidecarContainerTools:         c.config.ContainerToolsImage,
+		SidecarServiceAbMetrix:         c.config.AbmetrixServiceImage,
+		SidecarServiceLogViewer:        c.config.LogViewerServiceImage,
+		SidecarServiceMetatron:         c.config.MetatronServiceImage,
+		SidecarServiceServiceMesh:      svcMeshImage,
+		SidecarServiceSshd:             c.config.SSHDServiceImage,
+		SidecarServiceSpectatord:       c.config.SpectatordServiceImage,
+		SidecarServiceTracingCollector: c.config.TracingCollectorServiceImage,
+		SidecarServiceAtlasTitusAgent:  c.config.AtlasTitusAgentServiceImage,
+		SidecarContainerTools:          c.config.ContainerToolsImage,
 	}
 
 	sideCarPtrs := []*ServiceOpts{}

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -455,6 +455,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 			SidecarSeccompAgent,
 			SidecarTitusContainer,
 			SidecarServiceSpectatord,
+			SidecarServiceTracingCollector,
 			SidecarServiceAtlasTitusAgent,
 			SidecarServiceSshd,
 			SidecarServiceMetadataProxy,

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -7,19 +7,20 @@ import (
 )
 
 const (
-	SidecarTitusContainer         = "titus-container"
-	SidecarServiceAbMetrix        = "abmetrix"
-	SidecarServiceLogViewer       = "logviewer"
-	SidecarServiceMetatron        = "metatron"
-	SidecarServiceServiceMesh     = "servicemesh"
-	SidecarServiceSshd            = "sshd"
-	SidecarServiceSpectatord      = "spectatord"
-	SidecarServiceAtlasTitusAgent = "atlas-titus-agent"
-	SidecarTitusStorage           = "titus-storage"
-	SidecarSeccompAgent           = "seccomp-agent"
-	SidecarServiceMetadataProxy   = "metadata-proxy"
-	SidecarContainerTools         = "container-tools"
-	SidecarTrafficSteering        = "traffic-steering"
+	SidecarTitusContainer          = "titus-container"
+	SidecarServiceAbMetrix         = "abmetrix"
+	SidecarServiceLogViewer        = "logviewer"
+	SidecarServiceMetatron         = "metatron"
+	SidecarServiceServiceMesh      = "servicemesh"
+	SidecarServiceSshd             = "sshd"
+	SidecarServiceSpectatord       = "spectatord"
+	SidecarServiceTracingCollector = "tracing-collector"
+	SidecarServiceAtlasTitusAgent  = "atlas-titus-agent"
+	SidecarTitusStorage            = "titus-storage"
+	SidecarSeccompAgent            = "seccomp-agent"
+	SidecarServiceMetadataProxy    = "metadata-proxy"
+	SidecarContainerTools          = "container-tools"
+	SidecarTrafficSteering         = "traffic-steering"
 )
 
 var systemServices = []ServiceOpts{
@@ -46,6 +47,15 @@ var systemServices = []ServiceOpts{
 		Required:     false,
 		Volumes: map[string]struct{}{
 			"/titus/spectatord": {},
+		},
+	},
+	{
+		ServiceName:  SidecarServiceTracingCollector,
+		UnitName:     "titus-sidecar-tracing-collector",
+		EnabledCheck: shouldStartTracingCollector,
+		Required:     false,
+		Volumes: map[string]struct{}{
+			"/titus/tracing-collector": {},
 		},
 	},
 	{
@@ -167,6 +177,18 @@ func shouldStartSpectatord(cfg *config.Config, c Container) bool {
 	}
 
 	if cfg.SpectatordServiceImage == "" {
+		return false
+	}
+	return true
+}
+
+func shouldStartTracingCollector(cfg *config.Config, c Container) bool {
+	enabled := cfg.ContainerTracingCollector
+	if !enabled {
+		return false
+	}
+
+	if cfg.TracingCollectorServiceImage == "" {
 		return false
 	}
 	return true

--- a/root/lib/systemd/system/titus-sidecar-tracing-collector@.service
+++ b/root/lib/systemd/system/titus-sidecar-tracing-collector@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Tracing Collector for container %i
+ConditionPathIsDirectory=/var/lib/titus-inits/%i/ns
+
+StartLimitIntervalSec=30
+StartLimitBurst=5
+CollectMode=inactive-or-failed
+PartOf=titus-container@%i.target
+
+[Service]
+EnvironmentFile=/var/lib/titus-environments/%i.env
+# Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work
+ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/tracing-collector/start
+
+Restart=on-failure
+RestartSec=3
+KillMode=mixed

--- a/root/lib/systemd/system/titus-sidecar-tracing-collector@.service
+++ b/root/lib/systemd/system/titus-sidecar-tracing-collector@.service
@@ -10,7 +10,7 @@ PartOf=titus-container@%i.target
 [Service]
 EnvironmentFile=/var/lib/titus-environments/%i.env
 # Run as root (UID 0, GID 0) and with CAP_DAC_OVERRIDE so that containers with a `USER` instruction work
-ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/tracing-collector/start
+ExecStart=/usr/bin/runc --root /var/run/docker/runtime-${TITUS_OCI_RUNTIME}/moby exec --user 0:0 --cap CAP_DAC_OVERRIDE ${TITUS_CONTAINER_ID} /titus/tracing-collector/start.sh
 
 Restart=on-failure
 RestartSec=3


### PR DESCRIPTION
### Description of the Change

Sets up the tracing-collector as a Titus System Service (follows spectatord's configuration as an example).
