### PR TITLE
Move NFS mounting logic to titus-storage from docker runtime

### DIFF
--- a/cmd/titus-storage/main.go
+++ b/cmd/titus-storage/main.go
@@ -64,6 +64,13 @@ func main() {
 				l.WithError(err).Error("Error when reading pod.json file")
 				return err
 			}
+
+			// Setup NFS volume mounts on all containers.
+			if err := setupNFSMounts(ctx, mountConfig.taskID, pod); err != nil {
+				l.WithError(err).Error("Error when mounting NFS volumes")
+				return err
+			}
+
 			mountConfig.pod = pod
 			// Currently only doing mntShared on multi-container workloads
 			if len(pod.Spec.Containers) > 1 {

--- a/cmd/titus-storage/nfs.go
+++ b/cmd/titus-storage/nfs.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	executorDocker "github.com/Netflix/titus-executor/executor/runtime/docker"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	mountCmd     = "/apps/titus-executor/bin/titus-mount-nfs"
+	mountTimeout = 10 * time.Second
+	// MS_RDONLY indicates that mount is read-only
+	MS_RDONLY = 1 // nolint: golint
+)
+
+// setupNFSMount calls out to the titus-mount-nfs command to set up a single
+// EFS mount.
+func setupNFSMount(parentCtx context.Context, taskID, cname string, vol *corev1.Volume, vm *corev1.VolumeMount) error {
+	baseMountOptions := []string{"vers=4.1,rsize=1048576,wsize=1048576,timeo=600,retrans=2"}
+	ctx, cancel := context.WithTimeout(parentCtx, mountTimeout)
+	defer cancel()
+
+	pidDir := executorDocker.GetTitusInitsPath(taskID, cname)
+	cmd := exec.CommandContext(ctx, mountCmd)
+	flags := 0
+
+	if vm.ReadOnly {
+		flags = flags | MS_RDONLY
+	}
+	mountOptions := append(
+		baseMountOptions,
+		fmt.Sprintf("fsc=%s", taskID),
+		fmt.Sprintf("source=[%s]:%s", vol.NFS.Server, filepath.Clean(vol.NFS.Path)),
+	)
+	cmd.Env = []string{
+		fmt.Sprintf("TITUS_PID1_DIR=%s", pidDir),
+		fmt.Sprintf("MOUNT_TARGET=%s", filepath.Clean(vm.MountPath)),
+		fmt.Sprintf("MOUNT_NFS_HOSTNAME=%s", vol.NFS.Server),
+		fmt.Sprintf("MOUNT_FLAGS=%d", flags),
+		fmt.Sprintf("MOUNT_OPTIONS=%s", strings.Join(mountOptions, ",")),
+	}
+
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Mount failure: %+v: %s", cmd, string(stdoutStderr))
+	}
+
+	return nil
+}
+
+// setupNFSMounts sets up all of the mounts across all containers for the given pod.
+func setupNFSMounts(parentCtx context.Context, taskID string, pod *corev1.Pod) error {
+	nameToMount := map[string]corev1.Volume{}
+
+	for _, vol := range pod.Spec.Volumes {
+		if vol.VolumeSource.NFS == nil {
+			continue
+		}
+		nameToMount[vol.Name] = vol
+	}
+
+	for _, container := range pod.Spec.Containers {
+		for i := range container.VolumeMounts {
+			vm := container.VolumeMounts[i]
+			vol, ok := nameToMount[vm.Name]
+			if !ok {
+				continue
+			}
+
+			err := setupNFSMount(parentCtx, taskID, container.Name, &vol, &vm)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -252,9 +252,9 @@ func startSystemdUnit(ctx context.Context, conn *dbus.Conn, taskID string, cID s
 		}
 	case <-time.After(timeout):
 		if opts.Required {
-			return fmt.Errorf("timeout after %d seconds starting %s service (which is required to start)", timeout, opts.UnitName)
+			return fmt.Errorf("timeout after %d seconds starting %s service (which is required to start)", timeout/time.Second, opts.UnitName)
 		}
-		l.Errorf("timeout after %d seconds starting %s service (not required to launch this task)", timeout, opts.UnitName)
+		l.Errorf("timeout after %d seconds starting %s service (not required to launch this task)", timeout/time.Second, opts.UnitName)
 		return nil
 	}
 	return nil

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -215,9 +215,9 @@ func shouldStartLogViewer(cfg *config.Config, c Container) bool {
 }
 
 func shouldStartTitusStorage(cfg *config.Config, c Container) bool {
-	// Currently titus-storage only supports EBS and /mnt-shared storage
+	// Currently titus-storage sets up NFS, EBS, and /mnt-shared storage
 	// which is currently only available on multi-container workloads
-	return c.EBSInfo().VolumeID != "" || len(c.Pod().Spec.Containers) > 1
+	return len(c.NFSMounts()) > 0 || c.EBSInfo().VolumeID != "" || len(c.Pod().Spec.Containers) > 1
 }
 
 func shouldStartContainerTools(cfg *config.Config, c Container) bool {


### PR DESCRIPTION
### Description of the Change

Migrates the logic for mounting NFS volumes from the docker runtime to titus-storage sidecar. Tested with titus-integration-tests:tests/tests_efs.py (went from passing -> failing -> passing). Change should have no functional difference.
