### PR TITLE
Install sigquit handler on all binaries

### DIFF
--- a/cmd/titus-executor-backend/main.go
+++ b/cmd/titus-executor-backend/main.go
@@ -12,6 +12,7 @@ import (
 
 	"contrib.go.opencensus.io/exporter/zipkin"
 	"github.com/Netflix/metrics-client-go/metrics"
+	"github.com/Netflix/titus-executor/cmd/common"
 	"github.com/Netflix/titus-executor/config"
 	"github.com/Netflix/titus-executor/executor/runner"
 	"github.com/Netflix/titus-executor/executor/runtime/docker"
@@ -38,6 +39,7 @@ type commandConfig struct {
 }
 
 func main() {
+	go common.HandleQuitSignal()
 	mainCfg := commandConfig{}
 	var flags = []cli.Flag{
 		cli.StringFlag{

--- a/cmd/titus-inject-metadataproxy/main.go
+++ b/cmd/titus-inject-metadataproxy/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Netflix/titus-executor/cmd/common"
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/metadataserver/inject"
 	log2 "github.com/Netflix/titus-executor/utils/log"
@@ -14,6 +15,7 @@ import (
 
 func main() {
 	log2.MaybeSetupLoggerIfOnJournaldAvailable()
+	go common.HandleQuitSignal()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/titus-logviewer/main.go
+++ b/cmd/titus-logviewer/main.go
@@ -7,6 +7,7 @@ import (
 	log2 "github.com/Netflix/titus-executor/utils/log"
 	titusTLS "github.com/Netflix/titus-executor/utils/tls"
 
+	"github.com/Netflix/titus-executor/cmd/common"
 	"github.com/Netflix/titus-executor/logviewer/api"
 	"github.com/Netflix/titus-executor/logviewer/conf"
 	log "github.com/sirupsen/logrus"
@@ -53,6 +54,7 @@ func getTLSConfig(certificateFile string, privateKey string) (*tls.Config, error
 
 func main() {
 	log2.MaybeSetupLoggerIfOnJournaldAvailable()
+	go common.HandleQuitSignal()
 	log.Println("Titus logviewer is starting")
 	r := newMux()
 	go listenOnHTTPSOptionally(r)

--- a/cmd/titus-reaper/main.go
+++ b/cmd/titus-reaper/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"time"
 
+	"github.com/Netflix/titus-executor/cmd/common"
 	"github.com/Netflix/titus-executor/reaper"
 	log "github.com/Netflix/titus-executor/utils/log"
 	"github.com/sirupsen/logrus"
@@ -14,6 +15,7 @@ var dockerHost string
 var debug bool
 
 func main() {
+	go common.HandleQuitSignal()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	flag.StringVar(&dockerHost, "docker-host", "unix:///var/run/docker.sock", "Docker Daemon URI")

--- a/cmd/titus-standalone/main.go
+++ b/cmd/titus-standalone/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Netflix/metrics-client-go/metrics"
+	"github.com/Netflix/titus-executor/cmd/common"
 	"github.com/Netflix/titus-executor/config"
 	"github.com/Netflix/titus-executor/executor/runtime/docker"
 	"github.com/Netflix/titus-executor/tag"
@@ -27,6 +28,7 @@ type cliOptions struct {
 }
 
 func main() {
+	go common.HandleQuitSignal()
 	var options cliOptions
 	app := cli.NewApp()
 	app.Name = "titus-standalone"

--- a/cmd/titus-storage/main.go
+++ b/cmd/titus-storage/main.go
@@ -39,6 +39,7 @@ type MountConfig struct {
 }
 
 func main() {
+	go common.HandleQuitSignal()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	log.MaybeSetupLoggerIfOnJournaldAvailable()

--- a/cmd/titus-vpc-service/main.go
+++ b/cmd/titus-vpc-service/main.go
@@ -20,6 +20,7 @@ import (
 
 	"contrib.go.opencensus.io/exporter/zipkin"
 	spectator "github.com/Netflix/spectator-go"
+	"github.com/Netflix/titus-executor/cmd/common"
 	"github.com/Netflix/titus-executor/logger"
 	titusTLS "github.com/Netflix/titus-executor/utils/tls"
 	vpcapi "github.com/Netflix/titus-executor/vpc/api"
@@ -114,6 +115,7 @@ func getCommonTags() map[string]string {
 }
 
 func main() {
+	go common.HandleQuitSignal()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/cmd/titus-vpc-tool/main.go
+++ b/cmd/titus-vpc-tool/main.go
@@ -7,6 +7,7 @@ import (
 
 	"contrib.go.opencensus.io/exporter/zipkin"
 	datadog "github.com/Datadog/opencensus-go-exporter-datadog"
+	"github.com/Netflix/titus-executor/cmd/common"
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/tool/identity"
 	openzipkin "github.com/openzipkin/zipkin-go"
@@ -56,6 +57,7 @@ type instanceIdentityProviderGetter func() identity.InstanceIdentityProvider
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func main() {
+	go common.HandleQuitSignal()
 	var cfgFile string
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
It kinda sucks that in go you can get a dump of goroutines, but wouldn't
it be great if it was like java and you could get that snapshot, without
terminating the app!?

Aparently it is this easy:
https://stackoverflow.com/a/27398062/2056003

With this change, if we have a stuck process for any reason, we can get
a dump of goroutines, without killing it, and without pprof.

----

I can't think of any badness from this?
We were not doing anything fancy with sigquit before anyway.