### PR TITLE
Allow standalone tests to run in linux as non-root

### DIFF
--- a/executor/runtime/docker/capabilities_linux.go
+++ b/executor/runtime/docker/capabilities_linux.go
@@ -1,3 +1,6 @@
+//go:build linux && !noroot
+// +build linux,!noroot
+
 package docker
 
 import (

--- a/executor/runtime/docker/capabilities_unsupported.go
+++ b/executor/runtime/docker/capabilities_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux || noroot
+// +build !linux noroot
+
+package docker
+
+import (
+	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
+	"github.com/docker/docker/api/types/container"
+)
+
+func setupAdditionalCapabilities(c runtimeTypes.Container, hostCfg *container.HostConfig) error {
+	return nil
+}


### PR DESCRIPTION
This teases out the capabilties stuff, which I would rather not run
under root (doesn't work without additional apparmor or seccomp stuff
installed)

This allows (some) of the standalone tests to run under linux as
non-root, just as they do in darwin.
