### PR TITLE
High Scale by default means IPv6Only

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -384,11 +384,7 @@ func computeEffectiveNetworkMode(originalNetworkMode string, assignIPv6Address b
 		return titus.NetworkConfiguration_Ipv4Only.String()
 	}
 	if originalNetworkMode == titus.NetworkConfiguration_HighScale.String() {
-		if !enableTransitionNetwork {
-			return titus.NetworkConfiguration_Ipv6Only.String()
-		}
-		// HighScale is really an alias for the Transition Mode today
-		return titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String()
+		return titus.NetworkConfiguration_Ipv6Only.String()
 	}
 	if originalNetworkMode == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() && !enableTransitionNetwork {
 		return titus.NetworkConfiguration_Ipv6AndIpv4.String()

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -385,7 +385,7 @@ func computeEffectiveNetworkMode(originalNetworkMode string, assignIPv6Address b
 	}
 	if originalNetworkMode == titus.NetworkConfiguration_HighScale.String() {
 		if !enableTransitionNetwork {
-			return titus.NetworkConfiguration_Ipv6AndIpv4.String()
+			return titus.NetworkConfiguration_Ipv6Only.String()
 		}
 		// HighScale is really an alias for the Transition Mode today
 		return titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String()


### PR DESCRIPTION
TSA is disabled by default. If a job configured with High Scale mode shows up, the effective mode should be IPv6Only.