### PR TITLE
Increase context timeout for detach_unused_branch_eni

### DIFF
--- a/vpc/service/detach_unused_branch_eni.go
+++ b/vpc/service/detach_unused_branch_eni.go
@@ -61,7 +61,7 @@ func (vpcService *vpcService) detatchUnusedBranchENILoop(ctx context.Context, pr
 }
 
 func (vpcService *vpcService) doDetatchUnusedBranchENI(ctx context.Context, subnet *subnet) (time.Duration, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute * 10)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*10)
 	defer cancel()
 
 	ctx, span := trace.StartSpan(ctx, "doDetatchUnusedBranchENI")

--- a/vpc/service/detach_unused_branch_eni.go
+++ b/vpc/service/detach_unused_branch_eni.go
@@ -19,7 +19,7 @@ const (
 	timeBetweenNoDetatches = time.Minute
 	minTimeUnused          = time.Hour
 	minTimeAttached        = assignTimeout
-	contextTimeout 			= 10 * time.Minute
+	contextTimeout         = 10 * time.Minute
 )
 
 type nilItem struct {

--- a/vpc/service/detach_unused_branch_eni.go
+++ b/vpc/service/detach_unused_branch_eni.go
@@ -61,7 +61,7 @@ func (vpcService *vpcService) detatchUnusedBranchENILoop(ctx context.Context, pr
 }
 
 func (vpcService *vpcService) doDetatchUnusedBranchENI(ctx context.Context, subnet *subnet) (time.Duration, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute * 10)
 	defer cancel()
 
 	ctx, span := trace.StartSpan(ctx, "doDetatchUnusedBranchENI")

--- a/vpc/service/detach_unused_branch_eni.go
+++ b/vpc/service/detach_unused_branch_eni.go
@@ -19,6 +19,7 @@ const (
 	timeBetweenNoDetatches = time.Minute
 	minTimeUnused          = time.Hour
 	minTimeAttached        = assignTimeout
+	contextTimeout 			= 10 * time.Minute
 )
 
 type nilItem struct {
@@ -61,7 +62,7 @@ func (vpcService *vpcService) detatchUnusedBranchENILoop(ctx context.Context, pr
 }
 
 func (vpcService *vpcService) doDetatchUnusedBranchENI(ctx context.Context, subnet *subnet) (time.Duration, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*10)
+	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
 	defer cancel()
 
 	ctx, span := trace.StartSpan(ctx, "doDetatchUnusedBranchENI")


### PR DESCRIPTION
Large table sizes prevents the SQL query from completing in a meaningful time. Increase the context deadline timeout to help.
