### PR TITLE
VPC Service Refactor

### DIFF
--- a/cmd/titus-vpc-service/main.go
+++ b/cmd/titus-vpc-service/main.go
@@ -26,6 +26,7 @@ import (
 	vpcapi "github.com/Netflix/titus-executor/vpc/api"
 	"github.com/Netflix/titus-executor/vpc/service"
 	"github.com/Netflix/titus-executor/vpc/service/db"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/golang/protobuf/jsonpb" // nolint: staticcheck
 	datadog "github.com/netflix-skunkworks/opencensus-go-exporter-datadog"
 	openzipkin "github.com/openzipkin/zipkin-go"
@@ -176,7 +177,9 @@ func main() {
 				logger.G(ctx).Fatal("Cannot startup, need to run database migrations")
 			}
 
-			go collectDBMetrics(ctx, conn)
+			collector := metrics.NewCollector(ctx, conn)
+			// Start collecting metrics
+			collector.Start()
 
 			go func() {
 				c := make(chan os.Signal, 1)

--- a/cmd/titus-vpc-service/migrate.go
+++ b/cmd/titus-vpc-service/migrate.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"time"
 
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/db"
@@ -16,51 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	pkgviper "github.com/spf13/viper"
-	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
 )
-
-var (
-	maxOpenConnections = stats.Int64("db.maxOpenConnections", "Maximum number of open connections to the database", "connections")
-	openConnections    = stats.Int64("db.openConnections", "The number of established connections both in use and idle", "connections")
-	connectionsInUse   = stats.Int64("db.connectionsInUse", "The number of connections currently in use", "connections")
-	connectionsIdle    = stats.Int64("db.connectionsIdle", "The number of idle connections", "connections")
-
-	waitCount         = stats.Int64("db.waitCount", "The total number of connections waited for", "connections")
-	waitDuration      = stats.Int64("db.waitDuration", "The total time blocked waiting for a new connection", "ns")
-	maxIdleClosed     = stats.Int64("db.maxIdleClosed", "The total number of connections closed due to SetMaxIdleConns", "connections")
-	maxLifetimeClosed = stats.Int64("db.maxLifetimeClosed", "The total number of connections closed due to SetConnMaxLifetime", "connections")
-)
-
-func init() {
-	gaugeMeasures := []stats.Measure{maxOpenConnections, openConnections, connectionsInUse, connectionsIdle}
-	for idx := range gaugeMeasures {
-		if err := view.Register(
-			&view.View{
-				Name:        gaugeMeasures[idx].Name(),
-				Description: gaugeMeasures[idx].Description(),
-				Measure:     gaugeMeasures[idx],
-				Aggregation: view.LastValue(),
-			},
-		); err != nil {
-			panic(err)
-		}
-	}
-
-	counterMeasures := []stats.Measure{waitCount, waitDuration, maxIdleClosed, maxLifetimeClosed}
-	for idx := range counterMeasures {
-		if err := view.Register(
-			&view.View{
-				Name:        counterMeasures[idx].Name(),
-				Description: counterMeasures[idx].Description(),
-				Measure:     counterMeasures[idx],
-				Aggregation: view.Count(),
-			},
-		); err != nil {
-			panic(err)
-		}
-	}
-}
 
 func migrateCommand(ctx context.Context, v *pkgviper.Viper) *cobra.Command {
 	cmd := &cobra.Command{
@@ -136,44 +91,4 @@ func newConnection(ctx context.Context, v *pkgviper.Viper) (string, *sql.DB, err
 	db.SetMaxOpenConns(v.GetInt(maxOpenConnectionsFlagName))
 
 	return fullDBURL, db, nil
-}
-
-func collectDBMetrics(ctx context.Context, db *sql.DB) {
-	var (
-		lastWaitCount         int64
-		lastMaxIdleClosed     int64
-		lastMaxLifetimeClosed int64
-		lastWaitDuration      = time.Duration(0)
-	)
-
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			dbStats := db.Stats()
-
-			incrementalWaitCount := dbStats.WaitCount - lastWaitCount
-			lastWaitCount = dbStats.WaitCount
-			incrementalLastWaitDuration := dbStats.WaitDuration - lastWaitDuration
-			lastWaitDuration = dbStats.WaitDuration
-			incrementalMaxIdleClosed := dbStats.MaxIdleClosed - lastMaxIdleClosed
-			lastMaxIdleClosed = dbStats.MaxIdleClosed
-			incrementalMaxLifetimeClosed := dbStats.MaxLifetimeClosed - lastMaxLifetimeClosed
-			lastMaxLifetimeClosed = dbStats.MaxLifetimeClosed
-
-			stats.Record(ctx,
-				maxOpenConnections.M(int64(dbStats.MaxOpenConnections)),
-				openConnections.M(int64(dbStats.OpenConnections)),
-				connectionsInUse.M(int64(dbStats.InUse)),
-				connectionsIdle.M(int64(dbStats.Idle)),
-				waitCount.M(incrementalWaitCount),
-				waitDuration.M(incrementalLastWaitDuration.Nanoseconds()),
-				maxIdleClosed.M(incrementalMaxIdleClosed),
-				maxLifetimeClosed.M(incrementalMaxLifetimeClosed),
-			)
-		}
-	}
 }

--- a/vpc/service/metrics/metrics.go
+++ b/vpc/service/metrics/metrics.go
@@ -1,0 +1,107 @@
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	// Gauge measures
+	maxOpenConnections = stats.Int64("db.maxOpenConnections", "Maximum number of open connections to the database", "connections")
+	openConnections    = stats.Int64("db.openConnections", "The number of established connections both in use and idle", "connections")
+	connectionsInUse   = stats.Int64("db.connectionsInUse", "The number of connections currently in use", "connections")
+	connectionsIdle    = stats.Int64("db.connectionsIdle", "The number of idle connections", "connections")
+
+	// Counter measures
+	waitCount         = stats.Int64("db.waitCount", "The total number of connections waited for", "connections")
+	waitDuration      = stats.Int64("db.waitDuration", "The total time blocked waiting for a new connection", "ns")
+	maxIdleClosed     = stats.Int64("db.maxIdleClosed", "The total number of connections closed due to SetMaxIdleConns", "connections")
+	maxLifetimeClosed = stats.Int64("db.maxLifetimeClosed", "The total number of connections closed due to SetConnMaxLifetime", "connections")
+)
+
+func init() {
+	gaugeMeasures := []stats.Measure{maxOpenConnections, openConnections, connectionsInUse, connectionsIdle}
+	for idx := range gaugeMeasures {
+		if err := view.Register(
+			&view.View{
+				Name:        gaugeMeasures[idx].Name(),
+				Description: gaugeMeasures[idx].Description(),
+				Measure:     gaugeMeasures[idx],
+				Aggregation: view.LastValue(),
+			},
+		); err != nil {
+			panic(err)
+		}
+	}
+
+	counterMeasures := []stats.Measure{waitCount, waitDuration, maxIdleClosed, maxLifetimeClosed}
+	for idx := range counterMeasures {
+		if err := view.Register(
+			&view.View{
+				Name:        counterMeasures[idx].Name(),
+				Description: counterMeasures[idx].Description(),
+				Measure:     counterMeasures[idx],
+				Aggregation: view.Count(),
+			},
+		); err != nil {
+			panic(err)
+		}
+	}
+}
+
+type Collector struct {
+	db  *sql.DB
+	ctx context.Context
+}
+
+func NewCollector(ctx context.Context, db *sql.DB) *Collector {
+	return &Collector{ctx: ctx, db: db}
+}
+
+func (c *Collector) Start() {
+	go c.collectDbMetrics(c.ctx)
+}
+
+func (c *Collector) collectDbMetrics(ctx context.Context) {
+	var (
+		lastWaitCount         int64
+		lastMaxIdleClosed     int64
+		lastMaxLifetimeClosed int64
+		lastWaitDuration      = time.Duration(0)
+	)
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			dbStats := c.db.Stats()
+
+			incrementalWaitCount := dbStats.WaitCount - lastWaitCount
+			lastWaitCount = dbStats.WaitCount
+			incrementalLastWaitDuration := dbStats.WaitDuration - lastWaitDuration
+			lastWaitDuration = dbStats.WaitDuration
+			incrementalMaxIdleClosed := dbStats.MaxIdleClosed - lastMaxIdleClosed
+			lastMaxIdleClosed = dbStats.MaxIdleClosed
+			incrementalMaxLifetimeClosed := dbStats.MaxLifetimeClosed - lastMaxLifetimeClosed
+			lastMaxLifetimeClosed = dbStats.MaxLifetimeClosed
+
+			stats.Record(ctx,
+				maxOpenConnections.M(int64(dbStats.MaxOpenConnections)),
+				openConnections.M(int64(dbStats.OpenConnections)),
+				connectionsInUse.M(int64(dbStats.InUse)),
+				connectionsIdle.M(int64(dbStats.Idle)),
+				waitCount.M(incrementalWaitCount),
+				waitDuration.M(incrementalLastWaitDuration.Nanoseconds()),
+				maxIdleClosed.M(incrementalMaxIdleClosed),
+				maxLifetimeClosed.M(incrementalMaxLifetimeClosed),
+			)
+		}
+	}
+}


### PR DESCRIPTION
# Summary
This PR contains the following changes:
* Remove statsd-related code from VPC service and VPC tool since it never works due to bugs.
  * In VPC service, the bug is that `STATSD_ADDR` environment variable is never set.
  * In VPC tool, the bug is that the variable bound to the environment variable is wrong. Should be `statsdAddrFlagName` but is `zipkinURLFlagName`.
* Move the function of exporting DB metrics from `migrate.go` to `metrics.go`. It is confusing to put metrics collecting code in `migrate.go`, which was used for migrating DB schema.
# Test
```
$ make test-local 
```
