### PR TITLE
Add a counter for scan ENI error

### DIFF
--- a/vpc/service/detach_unused_branch_eni.go
+++ b/vpc/service/detach_unused_branch_eni.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 )
 
@@ -105,6 +108,8 @@ LIMIT 1
 	}
 	if err != nil {
 		err = errors.Wrap(err, "Cannot scan branch ENI to delete")
+		mutators := []tag.Mutator{tag.Upsert(tag.MustNewKey("msg"), err.Error())}
+		_ = stats.RecordWithTags(ctx, mutators, metrics.ErrorScanBranchEniCount.M(1))
 		span.SetStatus(traceStatusFromError(err))
 		return timeBetweenErrors, err
 	}

--- a/vpc/service/metrics/metrics.go
+++ b/vpc/service/metrics/metrics.go
@@ -17,10 +17,11 @@ var (
 	connectionsIdle    = stats.Int64("db.connectionsIdle", "The number of idle connections", "connections")
 
 	// Counter measures
-	waitCount         = stats.Int64("db.waitCount", "The total number of connections waited for", "connections")
-	waitDuration      = stats.Int64("db.waitDuration", "The total time blocked waiting for a new connection", "ns")
-	maxIdleClosed     = stats.Int64("db.maxIdleClosed", "The total number of connections closed due to SetMaxIdleConns", "connections")
-	maxLifetimeClosed = stats.Int64("db.maxLifetimeClosed", "The total number of connections closed due to SetConnMaxLifetime", "connections")
+	waitCount               = stats.Int64("db.waitCount", "The total number of connections waited for", "connections")
+	waitDuration            = stats.Int64("db.waitDuration", "The total time blocked waiting for a new connection", "ns")
+	maxIdleClosed           = stats.Int64("db.maxIdleClosed", "The total number of connections closed due to SetMaxIdleConns", "connections")
+	maxLifetimeClosed       = stats.Int64("db.maxLifetimeClosed", "The total number of connections closed due to SetConnMaxLifetime", "connections")
+	ErrorScanBranchEniCount = stats.Int64("error.scanBranchEni", "ENIs that could not be cleaned up due to error in query", stats.UnitNone)
 )
 
 func init() {
@@ -38,7 +39,10 @@ func init() {
 		}
 	}
 
-	counterMeasures := []stats.Measure{waitCount, waitDuration, maxIdleClosed, maxLifetimeClosed}
+	counterMeasures := []stats.Measure{
+		waitCount, waitDuration, maxIdleClosed, maxLifetimeClosed,
+		ErrorScanBranchEniCount,
+	}
 	for idx := range counterMeasures {
 		if err := view.Register(
 			&view.View{


### PR DESCRIPTION
# Summary

Add a counter for scan ENI errors.

# Test

No local test. In theory this should work as it works for other stats like `db.waitCount`. Will query Atlas after the code is deployed.
