### PR TITLE
Remove some unit manipulation on Bandwidth

### DIFF
--- a/executor/runtime/docker/networking.go
+++ b/executor/runtime/docker/networking.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	defaultNetworkBandwidth = 128 * MB
-	vpctoolTimeout          = 45 * time.Second
+	defaultNetworkBandwidthBps = 128 * MB
+	vpctoolTimeout             = 45 * time.Second
 )
 
 // This will setup c.Allocation
@@ -54,9 +54,9 @@ func prepareNetworkDriver(ctx context.Context, cfg Config, c runtimeTypes.Contai
 		return nil, err
 	}
 
-	bw := int64(defaultNetworkBandwidth)
-	if bwLim := c.BandwidthLimitMbps(); bwLim != nil && *bwLim != 0 {
-		bw = *bwLim * 1000 * 1000
+	bandwidthBps := int64(defaultNetworkBandwidthBps)
+	if bwLim := c.IngressBandwidthLimitBps(); bwLim != nil && *bwLim != 0 {
+		bandwidthBps = *bwLim
 	}
 
 	args := []string{
@@ -64,7 +64,7 @@ func prepareNetworkDriver(ctx context.Context, cfg Config, c runtimeTypes.Contai
 		"--device-idx", strconv.Itoa(*eniIdx),
 		"--security-groups", strings.Join(*sgIDs, ","),
 		"--task-id", c.TaskID(),
-		"--bandwidth", strconv.FormatInt(bw, 10),
+		"--bandwidth", strconv.FormatInt(bandwidthBps, 10),
 		"--network-mode", c.EffectiveNetworkMode(), // TODO: Deal with HighScale mode either here, or use the effective mode (which is fallback)
 	}
 

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -200,12 +200,12 @@ func (c *PodContainer) AssignIPv6Address() bool {
 	return false
 }
 
-func (c *PodContainer) BandwidthLimitMbps() *int64 {
+func (c *PodContainer) IngressBandwidthLimitBps() *int64 {
 	bw := c.podConfig.IngressBandwidth
 	if bw == nil {
 		return nil
 	}
-	return ptr.Int64Ptr(bw.Value() / units.MB)
+	return ptr.Int64Ptr(bw.Value())
 }
 
 func (c *PodContainer) BatchPriority() *string {

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Netflix/titus-executor/uploader"
 	vpcapi "github.com/Netflix/titus-executor/vpc/api"
 	podCommon "github.com/Netflix/titus-kube-common/pod" // nolint: staticcheck
+	units "github.com/docker/go-units"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 	"gotest.tools/assert"
@@ -132,7 +133,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 	imgName := "titusoss/alpine"
 	imgDigest := "sha256:58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4"
 	expectedImage := "docker.io/" + imgName + "@" + imgDigest
-	expBwLimitMbs := int64(128)
+	expBwLimitBps := int64(42 * units.MB)
 	expCapabilities := &corev1.Capabilities{
 		Add:  []corev1.Capability{"NET_ADMIN"},
 		Drop: []corev1.Capability{"SYS_TIME"},
@@ -164,7 +165,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 		GPU:     1,
 		Mem:     512,
 		Disk:    10000,
-		Network: 128,
+		Network: 42,
 	}
 	expSGs := []string{"sg-1", "sg-2"}
 	expShmSize := uint32(256)
@@ -313,7 +314,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 	assert.Equal(t, c.AppName(), "appName")
 	assert.Equal(t, c.AssignIPv6Address(), true)
 	assert.Equal(t, c.EffectiveNetworkMode(), titus.NetworkConfiguration_Ipv6AndIpv4.String())
-	assert.DeepEqual(t, c.BandwidthLimitMbps(), &expBwLimitMbs)
+	assert.DeepEqual(t, c.IngressBandwidthLimitBps(), &expBwLimitBps)
 	assert.DeepEqual(t, c.BatchPriority(), ptr.StringPtr("idle"))
 	assert.DeepEqual(t, c.Capabilities(), expCapabilities)
 	assert.Equal(t, c.CombinedAppStackDetails(), "appName-appStack-appDetail")
@@ -350,7 +351,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 		"TITUS_NUM_DISK":                    "10000",
 		"TITUS_NUM_GPU":                     "1",
 		"TITUS_NUM_MEM":                     "512",
-		"TITUS_NUM_NETWORK_BANDWIDTH":       "128",
+		"TITUS_NUM_NETWORK_BANDWIDTH":       "42",
 		"TITUS_OCI_RUNTIME":                 DefaultOciRuntime,
 		"USER_SET_ENV1":                     "var1",
 		"USER_SET_ENV2":                     "var2",

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -152,7 +152,7 @@ type Container interface {
 	AllowNetworkBursting() bool
 	AppArmorProfile() *string
 	AppName() string
-	BandwidthLimitMbps() *int64
+	IngressBandwidthLimitBps() *int64
 	BatchPriority() *string
 	Capabilities() *corev1.Capabilities
 	CombinedAppStackDetails() string
@@ -400,7 +400,7 @@ func ContainerTestArgs() (*corev1.Pod, *config.Config) {
 		CPU:     2,
 		GPU:     1,
 		Disk:    10000,
-		Network: 128,
+		Network: 42,
 	}
 	taskID := "taskid"
 	pod := GenerateV1TestPod(taskID, resources, cfg)


### PR DESCRIPTION
`BandwidthLimitMbs` was the containerInfo function, we no longer need to
be bound to it.

This PR renames that to be more explicit about what it is extracting
from the pod.
