### PR TITLE
Refactor VPC Service

### DIFF
--- a/cmd/titus-vpc-service/fix_allocations.go
+++ b/cmd/titus-vpc-service/fix_allocations.go
@@ -5,6 +5,8 @@ import (
 
 	// nolint: staticcheck
 	"github.com/Netflix/titus-executor/vpc/service"
+	"github.com/Netflix/titus-executor/vpc/service/config"
+	"github.com/Netflix/titus-executor/vpc/service/db/wrapper"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -15,12 +17,12 @@ func fixAllocations(ctx context.Context, v *pkgviper.Viper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "fix-allocations",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, db, err := newConnection(ctx, v)
+			_, db, err := wrapper.NewConnection(ctx, v.GetString(config.DBURLFlagName), v.GetInt(config.MaxIdleConnectionsFlagName), v.GetInt(config.MaxOpenConnectionsFlagName))
 			if err != nil {
 				return errors.Wrap(err, "Could not connect to database")
 			}
 
-			sessionMgr := ec2wrapper.NewEC2SessionManager(v.GetString(workerRoleFlagName))
+			sessionMgr := ec2wrapper.NewEC2SessionManager(v.GetString(config.WorkerRoleFlagName))
 
 			err = service.FixOldAllocations(ctx, db, sessionMgr)
 			if err != nil {

--- a/cmd/titus-vpc-service/generate_key.go
+++ b/cmd/titus-vpc-service/generate_key.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	vpcapi "github.com/Netflix/titus-executor/vpc/api"
+	"github.com/Netflix/titus-executor/vpc/service/config"
+	"github.com/Netflix/titus-executor/vpc/service/db/wrapper"
 	"github.com/golang/protobuf/jsonpb" // nolint: staticcheck
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -27,7 +29,11 @@ func generateKeyCommand(ctx context.Context, v *pkgviper.Viper) *cobra.Command {
 			}
 			pnow := timestamppb.Now()
 
-			_, db, err := newConnection(ctx, v)
+			_, db, err := wrapper.NewConnection(
+				ctx,
+				v.GetString(config.DBURLFlagName),
+				v.GetInt(config.MaxIdleConnectionsFlagName),
+				v.GetInt(config.MaxOpenConnectionsFlagName))
 			if err != nil {
 				return errors.Wrap(err, "Could not connect to database")
 			}

--- a/cmd/titus-vpc-service/main.go
+++ b/cmd/titus-vpc-service/main.go
@@ -2,11 +2,7 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"expvar"
-	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -18,19 +14,12 @@ import (
 
 	"github.com/Netflix/titus-executor/vpc"
 
-	"contrib.go.opencensus.io/exporter/zipkin"
 	spectator "github.com/Netflix/spectator-go"
 	"github.com/Netflix/titus-executor/cmd/common"
 	"github.com/Netflix/titus-executor/logger"
-	titusTLS "github.com/Netflix/titus-executor/utils/tls"
-	vpcapi "github.com/Netflix/titus-executor/vpc/api"
 	"github.com/Netflix/titus-executor/vpc/service"
-	"github.com/Netflix/titus-executor/vpc/service/db"
-	"github.com/Netflix/titus-executor/vpc/service/metrics"
-	"github.com/golang/protobuf/jsonpb" // nolint: staticcheck
+	"github.com/Netflix/titus-executor/vpc/service/config"
 	datadog "github.com/netflix-skunkworks/opencensus-go-exporter-datadog"
-	openzipkin "github.com/openzipkin/zipkin-go"
-	zipkinHTTP "github.com/openzipkin/zipkin-go/reporter/http"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -39,33 +28,6 @@ import (
 	"go.opencensus.io/trace"
 	"go.opencensus.io/zpages"
 	"golang.org/x/sys/unix"
-)
-
-const (
-	atlasAddrFlagName             = "atlas-addr"
-	zipkinURLFlagName             = "zipkin"
-	debugAddressFlagName          = "debug-address"
-	gcTimeoutFlagName             = "gc-timeout"
-	maxIdleConnectionsFlagName    = "max-idle-connections"
-	refreshIntervalFlagName       = "refresh-interval"
-	maxOpenConnectionsFlagName    = "max-open-connections"
-	maxConcurrentRefreshFlagName  = "max-concurrent-refresh"
-	maxConcurrentRequestsFlagName = "max-concurrent-requests"
-	workerRoleFlagName            = "worker-role"
-	dbURLFlagName                 = "dburl"
-
-	sslCertFlagName       = "ssl-cert"
-	sslPrivateKeyFlagName = "ssl-private-key"
-	sslCAFlagName         = "ssl-ca"
-
-	enabledLongLivedTasksFlagName = "enabled-long-lived-tasks"
-	enabledTaskLoopsFlagName      = "enabled-task-loops"
-
-	trunkENIDescriptionFlagName   = "trunk-eni-description"
-	branchENIDescriptionFlagName  = "branch-eni-description"
-	subnetCIDRReservationFlagName = "titus-reserved"
-
-	tableMetricsIntervalFlagName = "table-metrics-interval"
 )
 
 func setupDebugServer(ctx context.Context, address string) error {
@@ -140,7 +102,7 @@ func main() {
 			}
 			view.SetReportingPeriod(time.Second * 1)
 
-			if atlasAddr := v.GetString(atlasAddrFlagName); atlasAddr != "" {
+			if atlasAddr := v.GetString(config.AtlasAddrFlagName); atlasAddr != "" {
 				config := &spectator.Config{
 					Frequency:  5 * time.Second,
 					Timeout:    1 * time.Second,
@@ -158,33 +120,13 @@ func main() {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := setupDebugServer(ctx, v.GetString("debug-address")); err != nil {
+			if err := setupDebugServer(ctx, v.GetString(config.DebugAddressFlagName)); err != nil {
 				return err
 			}
 
 			if err := v.BindPFlags(cmd.Flags()); err != nil {
 				return err
 			}
-
-			dburl, conn, err := newConnection(ctx, v)
-			if err != nil {
-				return err
-			}
-
-			needsMigration, err := db.NeedsMigration(ctx, conn)
-			if err != nil {
-				return err
-			}
-
-			if needsMigration {
-				logger.G(ctx).Fatal("Cannot startup, need to run database migrations")
-			}
-
-			collector := metrics.NewCollector(ctx, conn, &metrics.CollectorConfig{
-				TableMetricsInterval: v.GetDuration(tableMetricsIntervalFlagName)})
-
-			// Start collecting metrics
-			collector.Start()
 
 			go func() {
 				c := make(chan os.Signal, 1)
@@ -197,69 +139,11 @@ func main() {
 				_ = unix.Kill(0, unix.SIGKILL)
 			}()
 
-			listener, err := net.Listen("tcp", v.GetString("address"))
+			vpcServiceConfig, err := service.NewConfig(ctx, v)
 			if err != nil {
-				return errors.Wrap(err, "Could not setup listener")
+				return errors.Wrap(err, "Failed to create configs for VPC service")
 			}
-			defer listener.Close()
-			logger.G(ctx).WithField("address", listener.Addr().String()).Info("Listening")
-
-			if zipkinURL := v.GetString(zipkinURLFlagName); zipkinURL != "" {
-				reporter := zipkinHTTP.NewReporter(zipkinURL,
-					zipkinHTTP.BatchInterval(time.Second*5),
-					zipkinHTTP.BatchSize(1000),
-					zipkinHTTP.MaxBacklog(100000),
-				)
-				hostname, err := os.Hostname()
-				if err != nil {
-					return errors.Wrap(err, "Unable to fetch hostname")
-				}
-				endpoint, err := openzipkin.NewEndpoint("titus-vpc-service", hostname)
-				if err != nil {
-					return errors.Wrap(err, "Failed to create the local zipkinEndpoint")
-				}
-				logger.G(ctx).WithField("endpoint", endpoint).WithField("url", zipkinURL).Info("Setting up tracing")
-				trace.RegisterExporter(zipkin.NewExporter(reporter, endpoint))
-			}
-
-			var signingKey vpcapi.PrivateKey
-			signingKeyFile, err := os.Open(v.GetString("signingkey"))
-			if err != nil {
-				return errors.Wrap(err, "Failed to open signing key file")
-			}
-
-			err = jsonpb.Unmarshal(signingKeyFile, &signingKey)
-			if err != nil {
-				return errors.Wrap(err, "Could not deserialize key")
-			}
-			signingKeyFile.Close()
-
-			tlsConfig, err := getTLSConfig(ctx, v.GetString(sslCertFlagName), v.GetString(sslPrivateKeyFlagName), v.GetString(sslCAFlagName))
-			if err != nil {
-				return errors.Wrap(err, "Could not generate TLS Config")
-			}
-
-			return service.Run(ctx, &service.Config{
-				Listener:              listener,
-				DB:                    conn,
-				DBURL:                 dburl,
-				Key:                   signingKey, // nolint:govet
-				MaxConcurrentRefresh:  v.GetInt64(maxConcurrentRefreshFlagName),
-				MaxConcurrentRequests: v.GetInt(maxConcurrentRequestsFlagName),
-				GCTimeout:             v.GetDuration(gcTimeoutFlagName),
-				ReconcileInterval:     v.GetDuration("reconcile-interval"),
-				RefreshInterval:       v.GetDuration(refreshIntervalFlagName),
-				TLSConfig:             tlsConfig,
-
-				EnabledLongLivedTasks: v.GetStringSlice(enabledLongLivedTasksFlagName),
-				EnabledTaskLoops:      v.GetStringSlice(enabledTaskLoopsFlagName),
-
-				TrunkNetworkInterfaceDescription:  v.GetString(trunkENIDescriptionFlagName),
-				BranchNetworkInterfaceDescription: v.GetString(branchENIDescriptionFlagName),
-				SubnetCIDRReservationDescription:  v.GetString(subnetCIDRReservationFlagName),
-
-				WorkerRole: v.GetString(workerRoleFlagName),
-			})
+			return service.Run(ctx, vpcServiceConfig, v.GetString("address"))
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
 			if dd != nil {
@@ -270,30 +154,28 @@ func main() {
 
 	rootCmd.Flags().String("address", ":7001", "Listening address")
 	rootCmd.Flags().String("signingkey", "", "The (file) location of the root signing key")
-	rootCmd.Flags().String(sslPrivateKeyFlagName, "", "The SSL Private Key")
-	rootCmd.Flags().String(sslCertFlagName, "", "The SSL Certificate")
-	rootCmd.Flags().String(sslCAFlagName, "", "General SSL CA")
-	rootCmd.Flags().Duration(gcTimeoutFlagName, 2*time.Minute, "How long must an IP be idle before we reclaim it")
-	rootCmd.Flags().Duration("reconcile-interval", 5*time.Minute, "How often to reconcile")
-	rootCmd.Flags().Duration(refreshIntervalFlagName, 60*time.Second, "How often to refresh IPs")
-	rootCmd.Flags().Duration(tableMetricsIntervalFlagName, 5*time.Minute, "How often to collect DB table metrics")
-	rootCmd.Flags().StringSlice(enabledTaskLoopsFlagName, service.GetTaskLoopTaskNames(), "Enabled task loops")
-	rootCmd.Flags().StringSlice(enabledLongLivedTasksFlagName, service.GetLongLivedTaskNames(), "Enabled long lived tasks")
-	rootCmd.Flags().String(trunkENIDescriptionFlagName, vpc.DefaultTrunkNetworkInterfaceDescription, "The description for trunk interfaces")
-	rootCmd.Flags().String(branchENIDescriptionFlagName, vpc.DefaultBranchNetworkInterfaceDescription, "The description for branch interfaces")
-	rootCmd.Flags().String(subnetCIDRReservationFlagName, vpc.DefaultSubnetCIDRReservationDescription, "The description of CIDRs to use for SCRs")
-	rootCmd.Flags().String(workerRoleFlagName, "", "The role which to assume into to do work")
-	rootCmd.Flags().Int(maxConcurrentRequestsFlagName, 100, "Maximum concurrent gRPC requests to allow")
+	rootCmd.Flags().String(config.SslPrivateKeyFlagName, "", "The SSL Private Key")
+	rootCmd.Flags().String(config.SslCertFlagName, "", "The SSL Certificate")
+	rootCmd.Flags().String(config.SslCAFlagName, "", "General SSL CA")
+	rootCmd.Flags().Duration(config.ReconcileIntervalFlagName, 5*time.Minute, "How often to reconcile")
+	rootCmd.Flags().Duration(config.TableMetricsIntervalFlagName, 5*time.Minute, "How often to collect DB table metrics")
+	rootCmd.Flags().StringSlice(config.EnabledTaskLoopsFlagName, service.GetTaskLoopTaskNames(), "Enabled task loops")
+	rootCmd.Flags().StringSlice(config.EnabledLongLivedTasksFlagName, service.GetLongLivedTaskNames(), "Enabled long lived tasks")
+	rootCmd.Flags().String(config.TrunkENIDescriptionFlagName, vpc.DefaultTrunkNetworkInterfaceDescription, "The description for trunk interfaces")
+	rootCmd.Flags().String(config.BranchENIDescriptionFlagName, vpc.DefaultBranchNetworkInterfaceDescription, "The description for branch interfaces")
+	rootCmd.Flags().String(config.SubnetCIDRReservationFlagName, vpc.DefaultSubnetCIDRReservationDescription, "The description of CIDRs to use for SCRs")
+	rootCmd.Flags().String(config.WorkerRoleFlagName, "", "The role which to assume into to do work")
+	rootCmd.Flags().Int(config.MaxConcurrentRequestsFlagName, 100, "Maximum concurrent gRPC requests to allow")
 
-	rootCmd.PersistentFlags().String(debugAddressFlagName, ":7003", "Address for zpages, pprof")
-	rootCmd.PersistentFlags().String(atlasAddrFlagName, "", "Atlas aggregator address")
+	rootCmd.PersistentFlags().String(config.DebugAddressFlagName, ":7003", "Address for zpages, pprof")
+	rootCmd.PersistentFlags().String(config.AtlasAddrFlagName, "", "Atlas aggregator address")
 	rootCmd.PersistentFlags().Bool("debug", false, "Turn on debug logging")
 	rootCmd.PersistentFlags().Bool("journald", true, "Log exclusively to Journald")
-	rootCmd.PersistentFlags().String(zipkinURLFlagName, "", "URL To send Zipkin spans to")
-	rootCmd.PersistentFlags().String(dbURLFlagName, "postgres://localhost/titusvpcservice?sslmode=disable", "Connection String for database")
-	rootCmd.PersistentFlags().Int(maxIdleConnectionsFlagName, 100, "SetMaxIdleConns sets the maximum number of connections in the idle connection pool for the database")
-	rootCmd.PersistentFlags().Int(maxOpenConnectionsFlagName, 200, "Maximum number of open connections allows to open to the database")
-	rootCmd.PersistentFlags().Int64(maxConcurrentRefreshFlagName, 10, "The number of maximum concurrent refreshes to allow")
+	rootCmd.PersistentFlags().String(config.ZipkinURLFlagName, "", "URL To send Zipkin spans to")
+	rootCmd.PersistentFlags().String(config.DBURLFlagName, "postgres://localhost/titusvpcservice?sslmode=disable", "Connection String for database")
+	rootCmd.PersistentFlags().Int(config.MaxIdleConnectionsFlagName, 100, "SetMaxIdleConns sets the maximum number of connections in the idle connection pool for the database")
+	rootCmd.PersistentFlags().Int(config.MaxOpenConnectionsFlagName, 200, "Maximum number of open connections allows to open to the database")
+	rootCmd.PersistentFlags().Int64(config.MaxConcurrentRefreshFlagName, 10, "The number of maximum concurrent refreshes to allow")
 	rootCmd.AddCommand(migrateCommand(ctx, v))
 	rootCmd.AddCommand(generateKeyCommand(ctx, v))
 	rootCmd.AddCommand(fixAllocations(ctx, v))
@@ -303,7 +185,6 @@ func main() {
 	}
 
 	bindVariables(v)
-	v.AutomaticEnv()
 
 	err := rootCmd.Execute()
 	if ctx.Err() != nil {
@@ -320,53 +201,19 @@ func bindVariable(v *pkgviper.Viper, key, env string) {
 }
 
 func bindVariables(v *pkgviper.Viper) {
-	bindVariable(v, dbURLFlagName, "DBURL")
-	bindVariable(v, zipkinURLFlagName, "ZIPKIN")
-	bindVariable(v, debugAddressFlagName, "DEBUG_ADDRESS")
-	bindVariable(v, atlasAddrFlagName, "ATLAS_ADDR")
-	bindVariable(v, gcTimeoutFlagName, "GC_TIMEOUT")
-	bindVariable(v, maxIdleConnectionsFlagName, "DB_MAX_IDLE_CONNECTIONS")
-	bindVariable(v, refreshIntervalFlagName, "REFRESH_INTERVAL")
-	bindVariable(v, sslPrivateKeyFlagName, "SSL_PRIVATE_KEY")
-	bindVariable(v, sslCertFlagName, "SSL_CERT")
-	bindVariable(v, sslCAFlagName, "SSL_CA")
-	bindVariable(v, maxOpenConnectionsFlagName, "MAX_OPEN_CONNECTIONS")
-	bindVariable(v, maxConcurrentRefreshFlagName, "MAX_CONCURRENT_REFRESH")
-	bindVariable(v, workerRoleFlagName, "WORKER_ROLE")
-	bindVariable(v, maxConcurrentRequestsFlagName, "MAX_CONCURRENT_REQUESTS")
-	bindVariable(v, tableMetricsIntervalFlagName, "TABLE_METRICS_INTERVAL")
-}
-
-func getTLSConfig(ctx context.Context, certificateFile, privateKey string, trustedCerts ...string) (*tls.Config, error) {
-	if certificateFile == "" && privateKey == "" {
-		return nil, nil
-	}
-
-	certPool := x509.NewCertPool()
-	for _, cert := range trustedCerts {
-		logger.G(ctx).WithField("cert", cert).Debug("Loading certificate")
-		data, err := ioutil.ReadFile(cert)
-		if err != nil {
-			return nil, err
-		}
-		ok := certPool.AppendCertsFromPEM(data)
-		if !ok {
-			return nil, fmt.Errorf("Cannot load TLS Certificate from %s", cert)
-		}
-	}
-
-	certLoader := &titusTLS.CachedCertificateLoader{
-		CertPath: certificateFile,
-		KeyPath:  privateKey,
-	}
-
-	tlsConfig := &tls.Config{
-		ClientCAs:  certPool,
-		ClientAuth: tls.RequireAndVerifyClientCert,
-		MinVersion: tls.VersionTLS12,
-	}
-	tlsConfig.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-		return certLoader.GetCertificate(tlsConfig.Time)
-	}
-	return tlsConfig, nil
+	bindVariable(v, config.DBURLFlagName, "DBURL")
+	bindVariable(v, config.ZipkinURLFlagName, "ZIPKIN")
+	bindVariable(v, config.DebugAddressFlagName, "DEBUG_ADDRESS")
+	bindVariable(v, config.AtlasAddrFlagName, "ATLAS_ADDR")
+	bindVariable(v, config.MaxIdleConnectionsFlagName, "DB_MAX_IDLE_CONNECTIONS")
+	bindVariable(v, config.SslPrivateKeyFlagName, "SSL_PRIVATE_KEY")
+	bindVariable(v, config.SslCertFlagName, "SSL_CERT")
+	bindVariable(v, config.SslCAFlagName, "SSL_CA")
+	bindVariable(v, config.MaxOpenConnectionsFlagName, "MAX_OPEN_CONNECTIONS")
+	bindVariable(v, config.MaxConcurrentRefreshFlagName, "MAX_CONCURRENT_REFRESH")
+	bindVariable(v, config.WorkerRoleFlagName, "WORKER_ROLE")
+	bindVariable(v, config.MaxConcurrentRequestsFlagName, "MAX_CONCURRENT_REQUESTS")
+	bindVariable(v, config.TableMetricsIntervalFlagName, "TABLE_METRICS_INTERVAL")
+	// TODO(hli): Consider removing it as it's dangerous. We don't know what env variables are automatically bound by this.
+	v.AutomaticEnv()
 }

--- a/vpc/service/branch_enis.go
+++ b/vpc/service/branch_enis.go
@@ -1096,7 +1096,7 @@ UPDATE OF branch_eni_attachments SKIP LOCKED
 func (vpcService *vpcService) associateActionWorker() *actionWorker {
 	return &actionWorker{
 		db:    vpcService.db,
-		dbURL: vpcService.dbURL,
+		dbURL: vpcService.config.DBURL,
 		cb: func(ctx context.Context, tx *sql.Tx, id int) error {
 			_, err := vpcService.finishAssociation(ctx, tx, nil, id)
 			return err
@@ -1116,7 +1116,7 @@ func (vpcService *vpcService) associateActionWorker() *actionWorker {
 func (vpcService *vpcService) disassociateActionWorker() *actionWorker {
 	return &actionWorker{
 		db:    vpcService.db,
-		dbURL: vpcService.dbURL,
+		dbURL: vpcService.config.DBURL,
 		cb: func(ctx context.Context, tx *sql.Tx, id int) error {
 			return vpcService.finishDisassociation(ctx, tx, nil, id)
 		},
@@ -1156,7 +1156,7 @@ WHERE subnets.subnet_id = $1
   FOR
   NO KEY UPDATE OF subnet_usable_prefix SKIP LOCKED
   LIMIT 1
-`, subnetID, vpcService.subnetCIDRReservationDescription)
+`, subnetID, vpcService.config.SubnetCIDRReservationDescription)
 	var prefix string
 	err := row.Scan(&prefix)
 	if err != nil {
@@ -1172,7 +1172,7 @@ WHERE subnets.subnet_id = $1
 	createNetworkInterfaceInput := ec2.CreateNetworkInterfaceInput{
 		// Ipv6AddressCount: aws.Int64(0),
 		SubnetId:    aws.String(subnetID),
-		Description: aws.String(vpcService.branchNetworkInterfaceDescription),
+		Description: aws.String(vpcService.config.BranchNetworkInterfaceDescription),
 		Groups:      aws.StringSlice(securityGroups),
 		Ipv6Prefixes: []*ec2.Ipv6PrefixSpecificationRequest{
 			{

--- a/vpc/service/config.go
+++ b/vpc/service/config.go
@@ -1,0 +1,128 @@
+package service
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/Netflix/titus-executor/logger"
+	titusTLS "github.com/Netflix/titus-executor/utils/tls"
+	vpcapi "github.com/Netflix/titus-executor/vpc/api"
+	"github.com/Netflix/titus-executor/vpc/service/config"
+	"github.com/golang/protobuf/jsonpb" // nolint: staticcheck
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+)
+
+type Config struct {
+	DBURL                 string
+	Key                   vpcapi.PrivateKey
+	MaxConcurrentRefresh  int64
+	MaxConcurrentRequests int
+	MaxIdleConnections    int
+	MaxOpenConnections    int
+	ReconcileInterval     time.Duration
+	// How often to collect DB table metrics
+	TableMetricsInterval time.Duration
+
+	TLSConfig *tls.Config
+
+	EnabledLongLivedTasks []string
+	EnabledTaskLoops      []string
+
+	TrunkNetworkInterfaceDescription  string
+	BranchNetworkInterfaceDescription string
+	SubnetCIDRReservationDescription  string
+
+	WorkerRole string
+
+	ZipkinURL string
+
+	// This is only used for testing.
+	disableRouteCache bool
+}
+
+func NewConfig(ctx context.Context, v *viper.Viper) (*Config, error) {
+	var signingKey vpcapi.PrivateKey
+	signingKeyFile, err := os.Open(v.GetString("signingkey"))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to open signing key file")
+	}
+
+	err = jsonpb.Unmarshal(signingKeyFile, &signingKey)
+	if err != nil {
+		signingKeyFile.Close()
+		return nil, errors.Wrap(err, "Could not deserialize key")
+	}
+	signingKeyFile.Close()
+
+	tlsConfig, err := getTLSConfig(ctx, v)
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not generate TLS Config")
+	}
+
+	return &Config{
+		DBURL:                 v.GetString(config.DBURLFlagName),
+		Key:                   signingKey, // nolint:govet
+		MaxConcurrentRefresh:  v.GetInt64(config.MaxConcurrentRefreshFlagName),
+		MaxConcurrentRequests: v.GetInt(config.MaxConcurrentRequestsFlagName),
+		MaxIdleConnections:    v.GetInt(config.MaxIdleConnectionsFlagName),
+		MaxOpenConnections:    v.GetInt(config.MaxOpenConnectionsFlagName),
+		ReconcileInterval:     v.GetDuration(config.ReconcileIntervalFlagName),
+		TableMetricsInterval:  v.GetDuration(config.TableMetricsIntervalFlagName),
+		TLSConfig:             tlsConfig,
+
+		EnabledLongLivedTasks: v.GetStringSlice(config.EnabledLongLivedTasksFlagName),
+		EnabledTaskLoops:      v.GetStringSlice(config.EnabledTaskLoopsFlagName),
+
+		TrunkNetworkInterfaceDescription:  v.GetString(config.TrunkENIDescriptionFlagName),
+		BranchNetworkInterfaceDescription: v.GetString(config.BranchENIDescriptionFlagName),
+		SubnetCIDRReservationDescription:  v.GetString(config.SubnetCIDRReservationFlagName),
+
+		WorkerRole: v.GetString(config.WorkerRoleFlagName),
+
+		ZipkinURL: v.GetString(config.ZipkinURLFlagName),
+	}, nil
+}
+
+func getTLSConfig(ctx context.Context, v *viper.Viper) (*tls.Config, error) {
+	certificateFile := v.GetString(config.SslCertFlagName)
+	privateKey := v.GetString(config.SslPrivateKeyFlagName)
+	trustedCerts := [1]string{v.GetString(config.SslCAFlagName)}
+
+	if certificateFile == "" && privateKey == "" {
+		return nil, nil
+	}
+
+	certPool := x509.NewCertPool()
+	for _, cert := range trustedCerts {
+		logger.G(ctx).WithField("cert", cert).Debug("Loading certificate")
+		data, err := ioutil.ReadFile(cert)
+		if err != nil {
+			return nil, err
+		}
+		ok := certPool.AppendCertsFromPEM(data)
+		if !ok {
+			return nil, fmt.Errorf("Cannot load TLS Certificate from %s", cert)
+		}
+	}
+
+	certLoader := &titusTLS.CachedCertificateLoader{
+		CertPath: certificateFile,
+		KeyPath:  privateKey,
+	}
+
+	tlsConfig := &tls.Config{
+		ClientCAs:  certPool,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		MinVersion: tls.VersionTLS12,
+	}
+	tlsConfig.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		return certLoader.GetCertificate(tlsConfig.Time)
+	}
+	return tlsConfig, nil
+}

--- a/vpc/service/config/constants.go
+++ b/vpc/service/config/constants.go
@@ -1,0 +1,27 @@
+package config
+
+const (
+	AtlasAddrFlagName             = "atlas-addr"
+	ZipkinURLFlagName             = "zipkin"
+	DebugAddressFlagName          = "debug-address"
+	MaxIdleConnectionsFlagName    = "max-idle-connections"
+	MaxOpenConnectionsFlagName    = "max-open-connections"
+	MaxConcurrentRefreshFlagName  = "max-concurrent-refresh"
+	MaxConcurrentRequestsFlagName = "max-concurrent-requests"
+	WorkerRoleFlagName            = "worker-role"
+	DBURLFlagName                 = "dburl"
+	ReconcileIntervalFlagName     = "reconcile-interval"
+
+	SslCertFlagName       = "ssl-cert"
+	SslPrivateKeyFlagName = "ssl-private-key"
+	SslCAFlagName         = "ssl-ca"
+
+	EnabledLongLivedTasksFlagName = "enabled-long-lived-tasks"
+	EnabledTaskLoopsFlagName      = "enabled-task-loops"
+
+	TrunkENIDescriptionFlagName   = "trunk-eni-description"
+	BranchENIDescriptionFlagName  = "branch-eni-description"
+	SubnetCIDRReservationFlagName = "titus-reserved"
+
+	TableMetricsIntervalFlagName = "table-metrics-interval"
+)

--- a/vpc/service/reconcile_branch_enis.go
+++ b/vpc/service/reconcile_branch_enis.go
@@ -68,7 +68,7 @@ func (vpcService *vpcService) reconcileBranchENIsForRegionAccount(ctx context.Co
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("description"),
-				Values: aws.StringSlice([]string{vpcService.branchNetworkInterfaceDescription}),
+				Values: aws.StringSlice([]string{vpcService.config.BranchNetworkInterfaceDescription}),
 			},
 			{
 				Name:   aws.String("owner-id"),
@@ -183,7 +183,7 @@ func (vpcService *vpcService) reconcileOrphanedBranchENI(ctx context.Context, se
 	ctx, span := trace.StartSpan(ctx, "reconcileOrphanedBranchENI")
 	defer span.End()
 
-	eniExists, err := doesENIExist(ctx, session, eni, vpcService.branchNetworkInterfaceDescription)
+	eniExists, err := doesENIExist(ctx, session, eni, vpcService.config.BranchNetworkInterfaceDescription)
 	if err != nil {
 		err = errors.Wrap(err, "Could not find out if branch ENI exists")
 		return ec2wrapper.HandleEC2Error(err, span)

--- a/vpc/service/reconcile_trunk_enis.go
+++ b/vpc/service/reconcile_trunk_enis.go
@@ -93,7 +93,7 @@ func (vpcService *vpcService) reconcileTrunkENIsForRegionAccount(ctx context.Con
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("description"),
-				Values: aws.StringSlice([]string{vpcService.trunkNetworkInterfaceDescription}),
+				Values: aws.StringSlice([]string{vpcService.config.TrunkNetworkInterfaceDescription}),
 			},
 			{
 				Name:   aws.String("owner-id"),
@@ -201,7 +201,7 @@ func (vpcService *vpcService) reconcileOrphanedTrunkENI(ctx context.Context, ses
 		return err
 	}
 
-	eniExists, err := doesENIExist(ctx, session, eni, vpcService.trunkNetworkInterfaceDescription)
+	eniExists, err := doesENIExist(ctx, session, eni, vpcService.config.TrunkNetworkInterfaceDescription)
 	if err != nil {
 		err = errors.Wrap(err, "Could not find out if branch ENI exists")
 		return ec2wrapper.HandleEC2Error(err, span)

--- a/vpc/service/service.go
+++ b/vpc/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"crypto/tls"
 	"database/sql"
 	"fmt"
 	"net"
@@ -11,19 +10,26 @@ import (
 	"sync"
 	"time"
 
+	"contrib.go.opencensus.io/exporter/zipkin"
 	"github.com/Netflix/titus-executor/services"
+	"github.com/sirupsen/logrus"
 
+	"github.com/Netflix/titus-executor/vpc/service/db/wrapper"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"go.opencensus.io/trace"
 
 	"github.com/Netflix/titus-executor/logger"
 	vpcapi "github.com/Netflix/titus-executor/vpc/api"
+	"github.com/Netflix/titus-executor/vpc/service/db"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	ccache "github.com/karlseguin/ccache/v2"
+	openzipkin "github.com/openzipkin/zipkin-go"
+	zipkinHTTP "github.com/openzipkin/zipkin-go/reporter/http"
 	"github.com/pkg/errors"
 	"github.com/soheilhy/cmux"
 	"go.opencensus.io/plugin/ocgrpc"
@@ -77,30 +83,22 @@ type vpcService struct {
 	hostname string
 	ec2      *ec2wrapper.EC2SessionManager
 
-	db    *sql.DB
-	dbURL string
+	db *sql.DB
 
+	config                 *Config
 	authoritativePublicKey ed25519.PublicKey
 	hostPublicKeySignature []byte
 	hostPrivateKey         ed25519.PrivateKey
 	hostPublicKey          ed25519.PublicKey
 
-	gcTimeout       time.Duration
-	refreshInterval time.Duration
-
 	refreshLock *semaphore.Weighted
 
 	dbRateLimiter *rate.Limiter
 
-	trunkNetworkInterfaceDescription  string
-	branchNetworkInterfaceDescription string
-	subnetCIDRReservationDescription  string
-
 	trunkTracker              *trunkTrackerCache
 	invalidSecurityGroupCache *ccache.Cache
 
-	subnetCacheExpirationTime time.Duration
-	concurrentRequests        *semaphore.Weighted
+	concurrentRequests *semaphore.Weighted
 
 	routesCache sync.Map
 
@@ -165,51 +163,130 @@ func (t *trunkTrackerCache) acquire(ctx context.Context, trunkENI string) (func(
 	}, nil
 }
 
-type Config struct {
-	Listener              net.Listener
-	DB                    *sql.DB
-	DBURL                 string
-	Key                   vpcapi.PrivateKey
-	MaxConcurrentRefresh  int64
-	MaxConcurrentRequests int
-	GCTimeout             time.Duration
-	ReconcileInterval     time.Duration
-	RefreshInterval       time.Duration
-	TLSConfig             *tls.Config
+func (vpcService *vpcService) serve(
+	logrusEntry *logrus.Entry,
+	listener net.Listener,
+	wrapwithAuth bool,
+	hc *healthcheck,
+	addShutdownFunc func(*grpc.Server),
+	options ...grpc.ServerOption) error {
+	grpcServerOptions := []grpc.ServerOption{
+		grpc.StatsHandler(&ocgrpc.ServerHandler{}),
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+			grpc_logrus.UnaryServerInterceptor(logrusEntry),
+			grpc_auth.UnaryServerInterceptor(vpcService.authFunc),
+			services.UnaryMetricsHandler,
+		),
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+			grpc_logrus.StreamServerInterceptor(logrusEntry),
+		),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle: 5 * time.Minute,
+		}),
+	}
+	grpcServer := grpc.NewServer(append(grpcServerOptions, options...)...)
 
-	EnabledLongLivedTasks []string
-	EnabledTaskLoops      []string
+	grpc_health_v1.RegisterHealthServer(grpcServer, hc)
+	if wrapwithAuth {
+		vpcapi.RegisterTitusAgentVPCServiceServer(grpcServer, &titusVPCAgentServiceAuthFuncOverride{vpcService})
+	} else {
+		vpcapi.RegisterTitusAgentVPCServiceServer(grpcServer, vpcService)
+	}
+	titus.RegisterUserIPServiceServer(grpcServer, vpcService)
+	titus.RegisterValidatorIPServiceServer(grpcServer, vpcService)
+	titus.RegisterTitusAgentVPCInformationServiceServer(grpcServer, vpcService)
+	titus.RegisterTitusAgentSecurityGroupServiceServer(grpcServer, vpcService)
 
-	TrunkNetworkInterfaceDescription  string
-	BranchNetworkInterfaceDescription string
-	SubnetCIDRReservationDescription  string
-
-	WorkerRole string
-
-	// This is only used for testing.
-	disableRouteCache bool
+	reflection.Register(grpcServer)
+	addShutdownFunc(grpcServer)
+	return grpcServer.Serve(listener)
 }
 
-func Run(ctx context.Context, config *Config) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	group, ctx := errgroup.WithContext(ctx)
-
-	if config.RefreshInterval == 0 {
-		panic("Refresh interval is 0")
+func newVpcService(ctx context.Context, config *Config) (*vpcService, error) {
+	// Make sure all configs are valid
+	err := validateConfig(config)
+	if err != nil {
+		return nil, err
 	}
-	logrusEntry := logger.G(ctx).WithField("origin", "grpc")
-	grpc_logrus.ReplaceGrpcLogger(logrusEntry)
-
-	if err := view.Register(ocgrpc.DefaultServerViews...); err != nil {
-		return err
-	}
-
 	hostname, err := os.Hostname()
 	if err != nil {
-		return errors.Wrap(err, "Cannot get hostname")
+		return nil, errors.Wrap(err, "Cannot get hostname")
 	}
 
+	var dbConn *sql.DB
+	if config.DBURL != "" {
+		dburl, conn, err := wrapper.NewConnection(ctx, config.DBURL, config.MaxIdleConnections, config.MaxOpenConnections)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to connect to db")
+		}
+		config.DBURL = dburl
+		dbConn = conn
+
+		needsMigration, err := db.NeedsMigration(ctx, dbConn)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to check if the DB needs migration")
+		}
+		if needsMigration {
+			logger.G(ctx).Fatal("Cannot startup, need to run database migrations")
+
+		}
+	}
+
+	// TODO: actually validate this
+	ed25519key := ed25519.NewKeyFromSeed(config.Key.GetEd25519Key().Rfc8032Key)
+	if dbConn != nil {
+		longLivedPublicKey := ed25519key.Public().(ed25519.PublicKey)
+
+		rows, err := dbConn.QueryContext(ctx, "SELECT hostname, created_at FROM trusted_public_keys WHERE keytype='ed25519' AND key = $1", longLivedPublicKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "Could not fetch trusted public keys")
+		}
+		if !rows.Next() {
+			return nil, errors.New("No matching public key to provided private key found")
+		}
+		var keyHostname string
+		var keyCreatedAt time.Time
+		err = rows.Scan(&keyHostname, &keyCreatedAt)
+		if err != nil {
+			return nil, errors.Wrap(err, "Could not read public keys from database")
+		}
+		logger.G(ctx).WithFields(map[string]interface{}{
+			"hostname":  keyHostname,
+			"createdAt": keyCreatedAt,
+		}).Debug("Found matching public key for private key")
+	}
+
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not generate host key")
+	}
+	hostPublicKeySignature := ed25519.Sign(ed25519key, publicKey)
+
+	return &vpcService{
+		hostname: hostname,
+		ec2:      ec2wrapper.NewEC2SessionManager(config.WorkerRole),
+		db:       dbConn,
+
+		config:                 config,
+		authoritativePublicKey: ed25519key.Public().(ed25519.PublicKey),
+		hostPrivateKey:         privateKey,
+		hostPublicKey:          publicKey,
+		hostPublicKeySignature: hostPublicKeySignature,
+
+		refreshLock: semaphore.NewWeighted(config.MaxConcurrentRefresh),
+
+		dbRateLimiter: rate.NewLimiter(1000, 1),
+
+		trunkTracker:              newTrunkTrackerCache(),
+		invalidSecurityGroupCache: ccache.New(ccache.Configure()),
+
+		concurrentRequests: semaphore.NewWeighted(int64(config.MaxConcurrentRequests)),
+	}, nil
+}
+
+func validateConfig(config *Config) error {
 	if config.TrunkNetworkInterfaceDescription == "" {
 		return errors.New("Trunk interface description must be non-empty")
 	}
@@ -221,106 +298,66 @@ func Run(ctx context.Context, config *Config) error {
 	if config.WorkerRole == "" {
 		return errors.New("The worker role must be non-empty")
 	}
+	return nil
+}
 
-	vpc := &vpcService{
-		hostname: hostname,
-		ec2:      ec2wrapper.NewEC2SessionManager(config.WorkerRole),
-		db:       config.DB,
-		dbURL:    config.DBURL,
-
-		gcTimeout:       config.GCTimeout,
-		refreshInterval: config.RefreshInterval,
-
-		refreshLock: semaphore.NewWeighted(config.MaxConcurrentRefresh),
-
-		dbRateLimiter: rate.NewLimiter(1000, 1),
-
-		trunkNetworkInterfaceDescription:  config.TrunkNetworkInterfaceDescription,
-		branchNetworkInterfaceDescription: config.BranchNetworkInterfaceDescription,
-		subnetCIDRReservationDescription:  config.SubnetCIDRReservationDescription,
-
-		trunkTracker:              newTrunkTrackerCache(),
-		invalidSecurityGroupCache: ccache.New(ccache.Configure()),
-
-		// Failures to find subnet (negative result) is never cached. Only positive results are cached.
-		// The reconcile interval drives how often the subnets change in the DB. Although they may be out of phase
-		// they will never be more than in an completely offset phase if we set the expiration time
-		// to the reconcile time.
-		subnetCacheExpirationTime: config.ReconcileInterval / 2.0,
-
-		concurrentRequests: semaphore.NewWeighted(int64(config.MaxConcurrentRequests)),
-	}
-
-	// TODO: actually validate this
-	ed25519key := ed25519.NewKeyFromSeed(config.Key.GetEd25519Key().Rfc8032Key)
-	if config.DB != nil {
-		longLivedPublicKey := ed25519key.Public().(ed25519.PublicKey)
-
-		rows, err := config.DB.QueryContext(ctx, "SELECT hostname, created_at FROM trusted_public_keys WHERE keytype='ed25519' AND key = $1", longLivedPublicKey)
-		if err != nil {
-			return errors.Wrap(err, "Could not fetch trusted public keys")
-		}
-		if !rows.Next() {
-			return errors.New("No matching public key to provided private key found")
-		}
-		var keyHostname string
-		var keyCreatedAt time.Time
-		err = rows.Scan(&keyHostname, &keyCreatedAt)
-		if err != nil {
-			return errors.Wrap(err, "Could not read public keys from database")
-		}
-		logger.G(ctx).WithFields(map[string]interface{}{
-			"hostname":  keyHostname,
-			"createdAt": keyCreatedAt,
-		}).Debug("Found matching public key for private key")
-	}
-
-	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+func Run(ctx context.Context, config *Config, address string) error {
+	vpcService, err := newVpcService(ctx, config)
 	if err != nil {
-		return errors.Wrap(err, "Could not generate host key")
+		return errors.Wrap(err, "Failed to create VPC service")
 	}
-	hostPublicKeySignature := ed25519.Sign(ed25519key, publicKey)
+	return vpcService.run(ctx, address)
+}
 
-	vpc.authoritativePublicKey = ed25519key.Public().(ed25519.PublicKey)
-	vpc.hostPrivateKey = privateKey
-	vpc.hostPublicKey = publicKey
-	vpc.hostPublicKeySignature = hostPublicKeySignature
+func (vpcService *vpcService) run(ctx context.Context, address string) error {
+	if vpcService.db != nil {
+		collector := metrics.NewCollector(ctx, vpcService.db, &metrics.CollectorConfig{
+			TableMetricsInterval: vpcService.config.TableMetricsInterval})
 
-	hc := &healthcheck{}
+		// Start collecting metrics
+		collector.Start()
+	}
 
-	m := cmux.New(config.Listener)
-
-	serve := func(listener net.Listener, wrapwithAuth bool, options ...grpc.ServerOption) error {
-		grpcServerOptions := []grpc.ServerOption{
-			grpc.StatsHandler(&ocgrpc.ServerHandler{}),
-			grpc_middleware.WithUnaryServerChain(
-				grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
-				grpc_logrus.UnaryServerInterceptor(logrusEntry),
-				grpc_auth.UnaryServerInterceptor(vpc.authFunc),
-				services.UnaryMetricsHandler,
-			),
-			grpc_middleware.WithStreamServerChain(
-				grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
-				grpc_logrus.StreamServerInterceptor(logrusEntry),
-			),
-			grpc.KeepaliveParams(keepalive.ServerParameters{
-				MaxConnectionIdle: 5 * time.Minute,
-			}),
+	if vpcService.config.ZipkinURL != "" {
+		reporter := zipkinHTTP.NewReporter(vpcService.config.ZipkinURL,
+			zipkinHTTP.BatchInterval(time.Second*5),
+			zipkinHTTP.BatchSize(1000),
+			zipkinHTTP.MaxBacklog(100000),
+		)
+		endpoint, err := openzipkin.NewEndpoint("titus-vpc-service", vpcService.hostname)
+		if err != nil {
+			return errors.Wrap(err, "Failed to create the local zipkinEndpoint")
 		}
-		grpcServer := grpc.NewServer(append(grpcServerOptions, options...)...)
+		logger.G(ctx).WithField("endpoint", endpoint).WithField("url", vpcService.config.ZipkinURL).Info("Setting up tracing")
+		trace.RegisterExporter(zipkin.NewExporter(reporter, endpoint))
+	}
 
-		grpc_health_v1.RegisterHealthServer(grpcServer, hc)
-		if wrapwithAuth {
-			vpcapi.RegisterTitusAgentVPCServiceServer(grpcServer, &titusVPCAgentServiceAuthFuncOverride{vpc})
-		} else {
-			vpcapi.RegisterTitusAgentVPCServiceServer(grpcServer, vpc)
-		}
-		titus.RegisterUserIPServiceServer(grpcServer, vpc)
-		titus.RegisterValidatorIPServiceServer(grpcServer, vpc)
-		titus.RegisterTitusAgentVPCInformationServiceServer(grpcServer, vpc)
-		titus.RegisterTitusAgentSecurityGroupServiceServer(grpcServer, vpc)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	group, ctx := errgroup.WithContext(ctx)
 
-		reflection.Register(grpcServer)
+	logrusEntry := logger.G(ctx).WithField("origin", "grpc")
+	grpc_logrus.ReplaceGrpcLogger(logrusEntry)
+
+	if err := view.Register(ocgrpc.DefaultServerViews...); err != nil {
+		return err
+	}
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return errors.Wrap(err, "Could not setup listener")
+	}
+	defer listener.Close()
+	logger.G(ctx).WithField("address", listener.Addr().String()).Info("Listening")
+
+	m := cmux.New(listener)
+
+	logger.G(ctx).Info("GRPC Server starting up")
+
+	sslListener := m.Match(cmux.TLS())
+	http1Listener := m.Match(cmux.HTTP1Fast())
+	anyListener := m.Match(cmux.Any())
+
+	addShutdownFunc := func(grpcServer *grpc.Server) {
 		group.Go(func() error {
 			<-ctx.Done()
 			logger.G(ctx).Info("GRPC Server shutting down gracefully")
@@ -332,53 +369,48 @@ func Run(ctx context.Context, config *Config) error {
 			grpcServer.GracefulStop()
 			return nil
 		})
-
-		return grpcServer.Serve(listener)
 	}
 
-	logger.G(ctx).Info("GRPC Server starting up")
-
-	sslListener := m.Match(cmux.TLS())
-	http1Listener := m.Match(cmux.HTTP1Fast())
-	anyListener := m.Match(cmux.Any())
-
-	if config.TLSConfig != nil {
-		c := credentials.NewTLS(config.TLSConfig)
-		group.Go(func() error { return serve(sslListener, true, grpc.Creds(c)) })
+	hc := &healthcheck{}
+	if vpcService.config.TLSConfig != nil {
+		c := credentials.NewTLS(vpcService.config.TLSConfig)
+		group.Go(func() error {
+			return vpcService.serve(logrusEntry, sslListener, true, hc, addShutdownFunc, grpc.Creds(c))
+		})
 	}
 
-	group.Go(func() error { return serve(anyListener, false) })
+	group.Go(func() error { return vpcService.serve(logrusEntry, anyListener, false, hc, addShutdownFunc) })
 	group.Go(func() error { return http.Serve(http1Listener, hc) })
 	group.Go(m.Serve)
-	if !config.disableRouteCache {
+	if !vpcService.config.disableRouteCache {
 		group.Go(func() error {
-			vpc.monitorRouteTableLoop(ctx)
+			vpcService.monitorRouteTableLoop(ctx)
 			return nil
 		})
 	}
 
-	taskLoops := vpc.getTaskLoops()
-	enabledTaskLoops := sets.NewString(config.EnabledTaskLoops...)
+	taskLoops := vpcService.getTaskLoops()
+	enabledTaskLoops := sets.NewString(vpcService.config.EnabledTaskLoops...)
 	for idx := range taskLoops {
 		task := taskLoops[idx]
 		if enabledTaskLoops.Has(task.taskName) {
 			logger.G(ctx).WithField("task", task.taskName).Info("Starting task loop")
 			group.Go(func() error {
-				return vpc.taskLoop(ctx, config.ReconcileInterval, task.taskName, task.itemLister, task.workFunc)
+				return vpcService.taskLoop(ctx, vpcService.config.ReconcileInterval, task.taskName, task.itemLister, task.workFunc)
 			})
 		} else {
 			logger.G(ctx).WithField("task", task.taskName).Info("Task loop disabled")
 		}
 	}
 
-	longLivedTasks := vpc.getLongLivedTasks()
-	enabledLongLivedTasks := sets.NewString(config.EnabledLongLivedTasks...)
+	longLivedTasks := vpcService.getLongLivedTasks()
+	enabledLongLivedTasks := sets.NewString(vpcService.config.EnabledLongLivedTasks...)
 	for idx := range longLivedTasks {
 		task := longLivedTasks[idx]
 		if enabledLongLivedTasks.Has(task.taskName) {
 			logger.G(ctx).WithField("task", task.taskName).Info("Starting task")
 			group.Go(func() error {
-				return vpc.runFunctionUnderLongLivedLock(ctx, task.taskName, task.itemLister, task.workFunc)
+				return vpcService.runFunctionUnderLongLivedLock(ctx, task.taskName, task.itemLister, task.workFunc)
 			})
 		} else {
 			logger.G(ctx).WithField("task", task.taskName).Info("Task disabled")
@@ -432,7 +464,7 @@ func (vpcService *vpcService) getLongLivedTasks() []longLivedTask {
 }
 
 func GetLongLivedTaskNames() []string {
-	s := &vpcService{}
+	s := &vpcService{config: &Config{}}
 	tasks := s.getLongLivedTasks()
 	ret := make([]string, len(tasks))
 	for idx := range tasks {
@@ -468,7 +500,7 @@ func (vpcService *vpcService) getTaskLoops() []taskLoop {
 }
 
 func GetTaskLoopTaskNames() []string {
-	s := &vpcService{}
+	s := &vpcService{config: &Config{}}
 	tasks := s.getTaskLoops()
 	ret := make([]string, len(tasks))
 	for idx := range tasks {

--- a/vpc/service/trunk_enis.go
+++ b/vpc/service/trunk_enis.go
@@ -256,7 +256,7 @@ func (vpcService *vpcService) createNewTrunkENI(ctx context.Context, session *ec
 	defer span.End()
 
 	createNetworkInterfaceInput := ec2.CreateNetworkInterfaceInput{
-		Description:      aws.String(vpcService.trunkNetworkInterfaceDescription),
+		Description:      aws.String(vpcService.config.TrunkNetworkInterfaceDescription),
 		InterfaceType:    aws.String("trunk"),
 		Ipv6AddressCount: aws.Int64(0),
 		SubnetId:         subnetID,


### PR DESCRIPTION
# Summary

I’ve found the following issues when reading VPC service code:
* When starting VPC service, some operations are done in `main.go`  and some are done in `Run` function. It's unclear what operations are needed only for running VPC service and what are needed only by the command itself.
* `vpcService` struct members is a mix of configs and data structures. Some of the configs are duplicates of the `Config` struct.

This refactoring tries to achieve the following to make the code clearer:
* Separate configs and members for `VpcService` struct. Make sure all configs are in `Config` struct. Configs are what we passed at start-up time (e.g. DB URL). Members are the dependencies of `VpcService` (e.g. a `*sql.DB` struct). `VpcService` also depends on `Config` as one member to get configs at runtime.
* `cmd/titus-vpc-service/main.go` mainly does the following things. It knows nothing about operations needed in order to run VPC service. For example, it doesn't know how to connect to the DB needed for VPC service. That is done by `Run` function.
  1) Get the configs from user input (flags, env vars, etc).
  2) Construct the `Config` struct for `VpcService`. 
  3) Construct a `VpcService` struct using the config.
  4) Start running the `VpcService` by calling `Run` function. 
* `VpcService.Run` function is responsible for performing all the actions needed for running VPC service. For example, connecting to DB, setting up monitoring, starting grpc server, etc. It takes config as an input and knows nothing about where the configs are from.
* Put all config names into one file `vpc/service/config/constants.go`.

I also removed some configs that are not used anywhere to reduce confusion, including
* RefreshInterval
* GcTimeout
* subnetCacheExpirationTime

# Test
```
make test-local
```
