### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,10 +5,13 @@
 /vpc/ @DonavanFritz
 /vpc/ @MyUmmaGumma
 /vpc/ @hechaoli
-/vpc/ @aloktiagi
+
+/cmd/titus-vpc-service/ @aloktiagi
+/cmd/titus-vpc-service/ @DonavanFritz
+/cmd/titus-vpc-service/ @MyUmmaGumma
+/cmd/titus-vpc-service/ @hechaoli
 
 executor/runtime/docker/networking* @aloktiagi
 executor/runtime/docker/networking* @DonavanFritz
 executor/runtime/docker/networking* @MyUmmaGumma
 executor/runtime/docker/networking* @hechaoli
-executor/runtime/docker/networking* @aloktiagi


### PR DESCRIPTION
Our CODEOWNERS should be correct. My only guess of why PR #905 didn't work is that I modified files under both "vpc/" and "cmd/titus-vpc-service". 

According to the example [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), 

> When someone opens a pull request that only modifies JS files, only @js-owner and not the global owner(s) will be requested for a review.

I can only guess that "that only modifies JS files" is the key because my PR didn't "only modify vpc/".

This diff adds a matching rule for `/cmd/titus-vpc-service/`. Hope it would work.