### PR TITLE
Fix network setup return error

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -920,7 +920,10 @@ func (r *DockerRuntime) Prepare(ctx context.Context, pod *v1.Pod) (err error) { 
 				r.registerRuntimeCleanup(cf)
 			}
 			tracehelpers.SetStatus(netErr, span)
-			return fmt.Errorf("network setup error: %w", netErr)
+			if netErr != nil {
+				return fmt.Errorf("network setup error: %w", netErr)
+			}
+			return nil
 		})
 	} else {
 		// Don't call out to network driver for local development


### PR DESCRIPTION
By wrapping the network error, I thought I was making things cleaner,
but in practice I was making something that was nil => something non
nil.

Fixes the `network setup error: %!w(<nil>)` error.
