### PR TITLE
Prepended "Error while pulling Docker image" to image pull failures

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -633,7 +633,7 @@ func (r *DockerRuntime) DockerPull(ctx context.Context, c runtimeTypes.Container
 				return nil, &runtimeTypes.RegistryImageNotFoundError{Reason: err}
 			}
 			tracehelpers.SetStatus(err, span)
-			return nil, err
+			return nil, fmt.Errorf("Error checking if image %s exists: %w", imgName, err)
 		}
 
 		if imgInfo != nil {
@@ -1724,7 +1724,7 @@ func (r *DockerRuntime) pullAllExtraContainers(ctx context.Context, pod *v1.Pod)
 			l.Debugf("pulling other container image %s", image)
 			err := pullWithRetries(ctx, r.cfg, r.metrics, r.client, image, doDockerPull)
 			if err != nil {
-				return err
+				return fmt.Errorf("Error while pulling Docker image %s: %w", image, err)
 			}
 			imageInspect, err2 := imageExists(ctx, r.client, image)
 			if err2 != nil {

--- a/executor/runtime/docker/docker_image_pull.go
+++ b/executor/runtime/docker/docker_image_pull.go
@@ -32,6 +32,7 @@ func pullWithRetries(ctx context.Context, cfg config.Config, metrics metrics.Rep
 		if err == nil {
 			return nil
 		} else if isBadImageErr(err) {
+			err = fmt.Errorf("Error while pulling Docker image %s: %w", qualifiedImageName, err)
 			return &runtimeTypes.RegistryImageNotFoundError{Reason: err}
 		}
 	}


### PR DESCRIPTION
We depend on this error so that we treat them as "localsystemerrors" (by
the control plane).

Also it is just lame to see docker's "500" error unadorned.
