### PR TITLE
Add support for dynamic configs

### DIFF
--- a/cmd/titus-vpc-service/main.go
+++ b/cmd/titus-vpc-service/main.go
@@ -165,6 +165,7 @@ func main() {
 	rootCmd.Flags().String(config.BranchENIDescriptionFlagName, vpc.DefaultBranchNetworkInterfaceDescription, "The description for branch interfaces")
 	rootCmd.Flags().String(config.SubnetCIDRReservationFlagName, vpc.DefaultSubnetCIDRReservationDescription, "The description of CIDRs to use for SCRs")
 	rootCmd.Flags().String(config.WorkerRoleFlagName, "", "The role which to assume into to do work")
+	rootCmd.Flags().String(config.DynamicConfigURLFlagName, "", "The URL from where to fetch dynamic configs")
 	rootCmd.Flags().Int(config.MaxConcurrentRequestsFlagName, 100, "Maximum concurrent gRPC requests to allow")
 
 	rootCmd.PersistentFlags().String(config.DebugAddressFlagName, ":7003", "Address for zpages, pprof")
@@ -214,6 +215,7 @@ func bindVariables(v *pkgviper.Viper) {
 	bindVariable(v, config.WorkerRoleFlagName, "WORKER_ROLE")
 	bindVariable(v, config.MaxConcurrentRequestsFlagName, "MAX_CONCURRENT_REQUESTS")
 	bindVariable(v, config.TableMetricsIntervalFlagName, "TABLE_METRICS_INTERVAL")
+	bindVariable(v, config.DynamicConfigURLFlagName, "DYNAMIC_CONFIG_URL")
 	// TODO(hli): Consider removing it as it's dangerous. We don't know what env variables are automatically bound by this.
 	v.AutomaticEnv()
 }

--- a/vpc/service/config/constants.go
+++ b/vpc/service/config/constants.go
@@ -1,5 +1,6 @@
 package config
 
+// Config names for static configs, i.e. configs that don't change at runtime
 const (
 	AtlasAddrFlagName             = "atlas-addr"
 	ZipkinURLFlagName             = "zipkin"
@@ -24,4 +25,5 @@ const (
 	SubnetCIDRReservationFlagName = "titus-reserved"
 
 	TableMetricsIntervalFlagName = "table-metrics-interval"
+	DynamicConfigURLFlagName     = "dynamic-config-url"
 )

--- a/vpc/service/config_test.go
+++ b/vpc/service/config_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDynamicConfigServer struct {
+	sync.Mutex
+	configsByName map[string]string
+	srv           *http.Server
+	url           string
+}
+
+func (s *mockDynamicConfigServer) start(wg *sync.WaitGroup, t *testing.T) {
+	s.srv = &http.Server{Addr: "localhost:0"}
+
+	http.HandleFunc("/properties", func(w http.ResponseWriter, r *http.Request) {
+		s.Lock()
+		defer s.Unlock()
+		bytes, err := json.Marshal(s.configsByName)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			_, _ = w.Write(bytes)
+		}
+	})
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	assert.NoError(t, err)
+
+	s.url = fmt.Sprintf("http://localhost:%d/properties", listener.Addr().(*net.TCPAddr).Port)
+
+	go func() {
+		defer wg.Done()
+
+		_ = s.srv.Serve(listener)
+	}()
+}
+
+func TestDynamicConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	// Start a mock dynamic config provider
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	s := mockDynamicConfigServer{
+		configsByName: map[string]string{"TEST_CONFIG": "24"},
+	}
+	s.start(wg, t)
+
+	dynamicConfig := NewDynamicConfig()
+
+	// Before starting fetching configs, the value should be default value
+	assert.Equal(t, 123, dynamicConfig.GetInt(ctx, "TEST_CONFIG", 123))
+
+	interval := time.Second
+	dynamicConfig.Start(ctx, interval, s.url)
+
+	done := make(chan bool)
+	var actualValue int
+	// Keep checking the config value until it changes.
+	go func() {
+		for {
+			actualValue = dynamicConfig.GetInt(ctx, "TEST_CONFIG", 123)
+			if actualValue != 123 {
+				done <- true
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+	select {
+	case <-done:
+		assert.Equal(t, 24, actualValue)
+	case <-time.After(2 * interval):
+		assert.Fail(t, "Failed to fetch latest value after 2 intervals")
+	}
+
+	cancel()
+	_ = s.srv.Shutdown(ctx)
+
+	wg.Wait()
+}


### PR DESCRIPTION
# Summary

Since we are going to have more changes to VPC service coming, it's safer to guard any new changes with killswitches, which can be enabled/disabled at runtime. 

This change adds a framework to add dynamic configs. Periodically, the config values are fetched from a provided dynamic configs URL. For a config, if there is no value is fetched, then the default value is used.

This change doesn't add any dynamic config yet. They'll be added as we add new features.

# Test
Added a new UT
```
$ go test -v -test.run='TestDynamicConfig' ./vpc/service/
=== RUN   TestDynamicConfig
time=2022-06-24T09:13:09-07:00 level=info msg=Dynamic configs updated to {"TEST_CONFIG":"24"}
--- PASS: TestDynamicConfig (0.01s)
PASS
ok      github.com/Netflix/titus-executor/vpc/service
```
