### PR TITLE
docker-runtime: fix cgroup removal

### DIFF
--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -272,7 +272,7 @@ func cleanupCgroups(cgroupPath string) error {
 	}
 	for _, mount := range allCgroupMounts {
 		path := filepath.Join(mount.Mountpoint, cgroupPath)
-		err = os.RemoveAll(path)
+		err = cgroups.RemovePath(path)
 		if err != nil {
 			logrus.Warn("Cannot remove cgroup mount: ", err)
 		}


### PR DESCRIPTION
Both our tests and real containers have some version of the following:

time=2022-07-06T21:45:33Z level=warning msg=Cannot remove cgroup mount: unlinkat /sys/fs/cgroup/systemd/docker/2f5a640a52610860aebb77933d402780e0f133e8a802be1ef7a3deb6a40405a5/cgroup.procs: operation not permitted

Jul 06 14:45:43 titusagent-devtandersencell001-r5metal001-i-038892c08bfa8e581 titus-executor-[3529086]: Cannot remove cgroup mount: unlinkat /sys/fs/cgroup/cpu,cpuacct/containers.slice/titus-executor@default__8bdff8fb-bd97-4b0b-944b-60937a2bbc1e.service/cpu.cfs_burst_us: operation not permitted

This is because cgroupfs doesn't allow removal of the files in
directories, just the directories themselves. runc's libcontainer has a
function that does this correctly, let's use that, vs a recursive
os.RemoveAll().