### PR TITLE
vpctool: don't run bpfloader test if it will fail

### DIFF
--- a/vpc/tool/bpfloader/bpfloader_linux_test.go
+++ b/vpc/tool/bpfloader/bpfloader_linux_test.go
@@ -4,7 +4,11 @@
 package bpfloader
 
 import (
+	"io/ioutil"
 	"os"
+	"os/user"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +18,23 @@ func TestLoad(t *testing.T) {
 	if os.Getenv("CIRCLECI") == "true" {
 		t.Skip("Test does not work on Travis")
 	}
+
+	disabledStr, err := ioutil.ReadFile("/proc/sys/kernel/unprivileged_bpf_disabled")
+	assert.NoError(t, err)
+
+	disabled, err := strconv.Atoi(strings.TrimSpace(string(disabledStr)))
+	assert.NoError(t, err)
+
+	u, err := user.Current()
+	assert.NoError(t, err)
+
+	uid, err := strconv.Atoi(u.Uid)
+	assert.NoError(t, err)
+
+	if disabled != 0 && uid != 0 {
+		t.Skip("unprivileged bpf is not allowed and not root")
+	}
+
 	reader, err := os.Open("testdata/filter.o")
 	assert.NoError(t, err)
 	_, err = GetProgram(reader, "classifier_ingress")


### PR DESCRIPTION
Most linux distros disallow unprivlieged bpf by default, so
`make test-local` in this configuration fails as an unprivleged user:

=== RUN   TestLoad

    bpfloader_linux_test.go:20:
        	Error Trace:	bpfloader_linux_test.go:20
        	Error:      	Received unexpected error:
        	            	operation not permitted
        	Test:       	TestLoad
--- FAIL: TestLoad (0.01s)

Let's detect this case and skip it.