### PR TITLE
Fix Get GCable ENIs query

### DIFF
--- a/vpc/service/gc_v3.go
+++ b/vpc/service/gc_v3.go
@@ -293,14 +293,7 @@ JOIN availability_zones ON subnets.account_id = availability_zones.account_id
 AND subnets.az = availability_zones.zone_name
 WHERE (branch_enis.branch_eni NOT IN
          (SELECT branch_eni
-          FROM attached_enis)
-       OR
-         (SELECT generation
-          FROM trunk_enis
-          WHERE trunk_eni =
-              (SELECT trunk_eni
-               FROM attached_enis
-               WHERE branch_eni = branch_enis.branch_eni)) = 3)
+          FROM attached_enis))
   AND branch_enis.account_id = $1
   AND availability_zones.region = $2
 ORDER BY RANDOM()


### PR DESCRIPTION
# Summary

I believe this is a bug. The following condition 

```
(SELECT generation
          FROM trunk_enis
          WHERE trunk_eni =
              (SELECT trunk_eni
               FROM attached_enis
               WHERE branch_eni = branch_enis.branch_eni)) = 3)
```

will always be true because all rows in `trunk_enis` has `generation` column to be 3. My guess is that it should be `!=3` to GC ENIs in old generation. I checked that all DBs only have 3 in `generation` column in `trunk_enis` table. 

E.g. in us-east-1 prod:

```
titusvpcservice=> select generation, count(*) from trunk_enis group by generation;
 generation | count 
------------+-------
          3 |  6676
(1 row)
```

As a result, this query will get ALL branch ENIs of a <region, account> instead of only the unattached ones. Though later the GC process will eliminate the attached ones, it should be better if we don't get them as "GCable" in the first place.

# Test

## Before the change

Run the query with a <region, account>
```
titusvpcservice=> WITH attached_enis AS
  (SELECT branch_eni,
          trunk_eni
   FROM branch_eni_attachments
   WHERE state = 'attaching'
     OR state = 'attached'
     OR state = 'unattaching')
SELECT COUNT(branch_enis.branch_eni)
FROM branch_enis
JOIN subnets ON branch_enis.subnet_id = subnets.subnet_id
JOIN availability_zones ON subnets.account_id = availability_zones.account_id
AND subnets.az = availability_zones.zone_name
WHERE (branch_enis.branch_eni NOT IN
         (SELECT branch_eni
          FROM attached_enis)
       OR                  
         (SELECT generation
          FROM trunk_enis
          WHERE trunk_eni =                                    
              (SELECT trunk_eni
               FROM attached_enis
               WHERE branch_eni = branch_enis.branch_eni)) = 3)
  AND branch_enis.account_id = '453078116140'
  AND availability_zones.region = 'us-east-1'
ORDER BY RANDOM()
;
 count 
-------
   117
(1 row)
```
 
The content is same as the following query
```
titusvpcservice=> SELECT COUNT(branch_enis.branch_eni)
FROM branch_enis
JOIN subnets ON branch_enis.subnet_id = subnets.subnet_id
JOIN availability_zones ON subnets.account_id = availability_zones.account_id
AND subnets.az = availability_zones.zone_name
WHERE branch_enis.account_id = '453078116140'
  AND availability_zones.region = 'us-east-1';
 count 
-------
   117
(1 row)
```

which means we are trying to GC ALL ENIs of this account rather than only the unattached ones.

## After the change

```
titusvpcservice=> WITH attached_enis AS
  (SELECT branch_eni,
          trunk_eni
   FROM branch_eni_attachments
   WHERE state = 'attaching'
     OR state = 'attached'
     OR state = 'unattaching')
SELECT COUNT(branch_enis.branch_eni)
FROM branch_enis
JOIN subnets ON branch_enis.subnet_id = subnets.subnet_id
JOIN availability_zones ON subnets.account_id = availability_zones.account_id
AND subnets.az = availability_zones.zone_name
WHERE (branch_enis.branch_eni NOT IN
         (SELECT branch_eni
          FROM attached_enis))
  AND branch_enis.account_id = '453078116140'
  AND availability_zones.region = 'us-east-1'
ORDER BY RANDOM()
;
 count 
-------
   106
(1 row)
```