### PR TITLE
Revert "Fix Get GCable ENIs query"

### DIFF
--- a/vpc/service/gc_v3.go
+++ b/vpc/service/gc_v3.go
@@ -293,7 +293,14 @@ JOIN availability_zones ON subnets.account_id = availability_zones.account_id
 AND subnets.az = availability_zones.zone_name
 WHERE (branch_enis.branch_eni NOT IN
          (SELECT branch_eni
-          FROM attached_enis))
+          FROM attached_enis)
+       OR
+         (SELECT generation
+          FROM trunk_enis
+          WHERE trunk_eni =
+              (SELECT trunk_eni
+               FROM attached_enis
+               WHERE branch_eni = branch_enis.branch_eni)) = 3)
   AND branch_enis.account_id = $1
   AND availability_zones.region = $2
 ORDER BY RANDOM()


### PR DESCRIPTION
Reverts Netflix/titus-executor#922

# Reason
Honestly, the more code I read, the more confused I got. In this query, the following condition
```
(branch_enis.branch_eni NOT IN
         (SELECT branch_eni
          FROM attached_enis)
```

seems to mean selecting unattached ENIs. However, as explained in PR #922, the OR condition means select all attached ENIs. As a result, the original query means "select ALL branch ENIs". At first I thought it was a bug and we should only GC unattached ENIs thus PR #922. But later I found in the `doGCENI` function that we distinguish attached and unattached ENIs and try to GC them respectively. For now, though the intention of GC attached ENIs is unclear to me, I'll revert the change until I fully understand the GC logic.