### PR TITLE
runner: always delegate all cgroups

### DIFF
--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -282,10 +282,6 @@ func cleanupCgroups(cgroupPath string) error {
 }
 
 func setCgroupOwnership(parentCtx context.Context, c runtimeTypes.Container, cred ucred) error {
-	if !c.IsSystemD() {
-		return nil
-	}
-
 	cgroupPath := filepath.Join("/proc/", strconv.Itoa(int(cred.pid)), "cgroup")
 	cgroups, err := ioutil.ReadFile(cgroupPath) // nolint: gosec
 	if err != nil {
@@ -303,19 +299,18 @@ func setCgroupOwnership(parentCtx context.Context, c runtimeTypes.Container, cre
 		}
 		// This is to handle the name=systemd cgroup, we should probably parse /proc/mounts, but this is a little bit easier
 		controllerType = strings.TrimPrefix(controllerType, "name=")
-		if controllerType != "systemd" {
-			continue
-		}
 
-		// systemd needs to be the owner of its systemd cgroup in order to start up
+		// systemd needs to be the owner of its systemd cgroup in order
+		// to start up, and needs to be the owner of e.g. its memory
+		// controller path to do memory accounting.
 		controllerPath := cgroupInfo[2]
 		fsPath := filepath.Join(sysFsCgroup, controllerType, controllerPath)
-		logrus.Infof("chowning systemd cgroup path: %s", fsPath)
+		logrus.Infof("chowning cgroup path: %s to %d %d", fsPath, cred.uid, cred.gid)
 		err = os.Chown(fsPath, int(cred.uid), int(cred.gid))
 		if err != nil {
 			logrus.WithError(err).Error("Could not chown systemd cgroup path")
+			return err
 		}
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
This patch makes two changes:

1. delegate all cgroups. this is necessary for systemd to do resource
   accounting for its services, since it wants to be able to create subdirs
   and put tasks in there in order to do this accounting

2. always delegate cgroups instead of just in the systemd case. there's
   nothing really special about systemd here, it is conceivable that some
   other application (or more realistically, application runtime) may want
   to do its own sort of accounting using cgroups. let's not force people
   to run systemd in this case.
