### PR TITLE
Move inserting into htb_class to insertTrunkENIIntoDB

### DIFF
--- a/vpc/service/reconcile_trunk_enis.go
+++ b/vpc/service/reconcile_trunk_enis.go
@@ -302,7 +302,7 @@ func (vpcService *vpcService) reconcileAttachedTrunkENI(ctx context.Context, ses
 	}()
 
 	// Generation is only set at ENI creation time, not updated
-	_, err = insertTrunkENIIntoDB(ctx, tx, networkInterface, 0)
+	err = insertTrunkENIIntoDB(ctx, tx, networkInterface, 0)
 	if err != nil {
 		err = errors.Wrap(err, "Cannot update trunk enis")
 		tracehelpers.SetStatus(err, span)


### PR DESCRIPTION
# Background 

When `ProvisionInstanceV3` is called in a VPC Service, it creates a trunk ENI, inserts it into the `trunk_enis` table and also inserts rows into `htb_classid` table. However, when reconciling trunk ENIs, it doesn't insert into `htb_classid` table.

# Problem
If a trunk ENI is inserted by reconciliation, then it will miss rows in `htb_classid` table. Later, an assignment using that trunk ENI will get a "Could not assign IPs to ENI: Unable to update / set class id for allocation: sql: no rows in result set" error. 

After we set up staging, it's possible that an instance is not provisioned by the staging instance so that it only gets the corresponding trunk ENI by reconciliation. Later, an assignment would fail because of the missing `htb_classid` rows.

# Fix

This PR moves inserting to `htb_classid` to `insertTrunkENIIntoDB` function so that it covers both `ProvisionInstanceV3` case and trunk ENI reconciliation case.