### PR TITLE
Add error logs to APIs and Long-running Tasks

### DIFF
--- a/vpc/service/action_worker.go
+++ b/vpc/service/action_worker.go
@@ -99,7 +99,7 @@ func (actionWorker *actionWorker) loop(ctx context.Context, item data.KeyedItem)
 		case <-ctx.Done():
 			return ctx.Err()
 		case err = <-errCh:
-			logger.G(ctx).WithError(err).Error("Worker exiting")
+			logger.G(ctx).WithError(err).Error("Worker failed")
 			return err
 		case <-pingTimer.C:
 			go func() {

--- a/vpc/service/gc_v3.go
+++ b/vpc/service/gc_v3.go
@@ -211,9 +211,13 @@ AND gc_tombstone < now() - INTERVAL '30 minutes'
 func (vpcService *vpcService) doGCAttachedENIsLoop(ctx context.Context, protoItem data.KeyedItem) error {
 	item := protoItem.(*regionAccount)
 	for {
+		ctx = logger.WithFields(ctx, map[string]interface{}{
+			"region":    item.region,
+			"accountID": item.accountID,
+		})
 		err := vpcService.doGCENIs(ctx, item)
 		if err != nil {
-			logger.G(ctx).WithField("region", item.region).WithField("accountID", item.accountID).WithError(err).Error("Failed to adequately GC interfaces")
+			logger.G(ctx).WithError(err).Error("Failed to adequately GC interfaces")
 		}
 		err = waitFor(ctx, timeBetweenGCs)
 		if err != nil {
@@ -238,10 +242,6 @@ func (vpcService *vpcService) doGCENIs(ctx context.Context, item *regionAccount)
 		trace.StringAttribute("region", item.region),
 		trace.StringAttribute("accountID", item.accountID),
 	)
-	ctx = logger.WithFields(ctx, map[string]interface{}{
-		"region":    item.region,
-		"accountID": item.accountID,
-	})
 	logger.G(ctx).Info("Beginning GC of ENIs")
 
 	session, err := vpcService.ec2.GetSessionFromAccountAndRegion(ctx, ec2wrapper.Key{AccountID: item.accountID, Region: item.region})

--- a/vpc/service/gc_v3.go
+++ b/vpc/service/gc_v3.go
@@ -94,7 +94,24 @@ func (vpcService *vpcService) GCV3(ctx context.Context, req *vpcapi.GCRequestV3)
 	ctx = logger.WithLogger(ctx, log)
 	ctx = logger.WithFields(ctx, map[string]interface{}{
 		"instance": req.InstanceIdentity.InstanceID,
+		"taskIds":  req.RunningTaskIDs,
 	})
+
+	resp, err := vpcService.doGCV3(ctx, req)
+	if err != nil {
+		logger.G(ctx).WithError(err).Error("Failed to get assignments to GC")
+		tracehelpers.SetStatus(err, span)
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (vpcService *vpcService) doGCV3(ctx context.Context, req *vpcapi.GCRequestV3) (*vpcapi.GCResponseV3, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	ctx, span := trace.StartSpan(ctx, "doGCV3")
+	defer span.End()
+
 	span.AddAttributes(
 		trace.StringAttribute("instance", req.InstanceIdentity.InstanceID),
 	)

--- a/vpc/service/provision_instance.go
+++ b/vpc/service/provision_instance.go
@@ -24,9 +24,11 @@ func (vpcService *vpcService) ProvisionInstanceV3(ctx context.Context, req *vpca
 	log := ctxlogrus.Extract(ctx)
 	ctx = logger.WithLogger(ctx, log)
 
+	ctx = logger.WithField(ctx, "instance", req.InstanceIdentity.InstanceID)
 	networkInterface, err := vpcService.provisionInstanceShared(ctx, req.InstanceIdentity, 3)
 	if err != nil {
 		tracehelpers.SetStatus(err, span)
+		logger.G(ctx).WithError(err).Error("Failed to provision instance")
 		return nil, err
 	}
 

--- a/vpc/service/prune_unused_ips.go
+++ b/vpc/service/prune_unused_ips.go
@@ -23,6 +23,19 @@ func (vpcService *vpcService) pruneLastUsedIPAddresses(ctx context.Context, null
 	ctx, span := trace.StartSpan(ctx, "pruneLastUsedIPAddresses")
 	defer span.End()
 
+	err := vpcService.doPruneLastUsedIPAddresses(ctx, tx)
+	if err != nil {
+		logger.G(ctx).WithError(err).Error("Failed to prune laste used IPs")
+		tracehelpers.SetStatus(err, span)
+		return err
+	}
+	return nil
+}
+
+func (vpcService *vpcService) doPruneLastUsedIPAddresses(ctx context.Context, tx *sql.Tx) (retErr error) {
+	ctx, span := trace.StartSpan(ctx, "pruneLastUsedIPAddresses")
+	defer span.End()
+
 	logger.G(ctx).Debug("Beginning purge of last used ip addresses")
 	result, err := tx.ExecContext(ctx,
 		`WITH addresses_by_family AS

--- a/vpc/service/reconcile_branch_eni_attachments.go
+++ b/vpc/service/reconcile_branch_eni_attachments.go
@@ -35,7 +35,7 @@ func (vpcService *vpcService) reconcileBranchENIAttachmentLoop(ctx context.Conte
 	for {
 		err := vpcService.reconcileBranchAttachmentsENIsForRegionAccount(ctx, item)
 		if err != nil {
-			logger.G(ctx).WithError(err).Error("Failed to reconcile branch ENIs")
+			logger.G(ctx).WithError(err).Error("Failed to reconcile branch ENI attachments")
 		}
 		err = waitFor(ctx, timeBetweenBranchENIAttachmentReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_subnets.go
+++ b/vpc/service/reconcile_subnets.go
@@ -58,9 +58,13 @@ func (vpcService *vpcService) getRegionAccounts(ctx context.Context) ([]data.Key
 func (vpcService *vpcService) doReconcileSubnetsForRegionAccountLoop(ctx context.Context, protoItem data.KeyedItem) error {
 	item := protoItem.(*regionAccount)
 	for {
+		ctx = logger.WithFields(ctx, map[string]interface{}{
+			"region":    item.region,
+			"accountID": item.accountID,
+		})
 		err := vpcService.doReconcileSubnetsForRegionAccount(ctx, item)
 		if err != nil {
-			logger.G(ctx).WithField("region", item.region).WithField("accountID", item.accountID).WithError(err).Error("Failed to reconcile subnets")
+			logger.G(ctx).WithError(err).Error("Failed to reconcile subnets")
 		}
 		err = waitFor(ctx, timeBetweenSubnetReconcilation)
 		if err != nil {
@@ -86,10 +90,7 @@ func (vpcService *vpcService) doReconcileSubnetsForRegionAccount(ctx context.Con
 		return err
 	}
 
-	logger.G(ctx).WithFields(map[string]interface{}{
-		"region":    account.region,
-		"accountID": account.accountID,
-	}).Info("Beginning reconcilation of subnets")
+	logger.G(ctx).Info("Beginning reconcilation of subnets")
 
 	ec2client := vpcService.ec2.NewEC2(session.Session)
 


### PR DESCRIPTION
# Problem

In RPC service, some of the errors are written in logs but some are only in the trace. This makes it hard to debug as we need to switch between log and trace.

# Fix

This PR makes sure the errors of all frequently called APIs and all long-running tasks are written into logs.