### PR TITLE
Add error counters and latency measures for long-running tasks

### DIFF
--- a/vpc/service/branch_enis.go
+++ b/vpc/service/branch_enis.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/service/vpcerrors"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/aws/aws-sdk-go/aws"
@@ -1106,6 +1107,7 @@ func (vpcService *vpcService) associateActionWorker() *actionWorker {
 		name:            "associateWorker2",
 		table:           "branch_eni_attachments",
 		maxWorkTime:     30 * time.Second,
+		errorCounter:    metrics.ErrorAssociateBranchENICount,
 
 		pendingState: attaching,
 
@@ -1124,8 +1126,8 @@ func (vpcService *vpcService) disassociateActionWorker() *actionWorker {
 		finishedChanel:  "branch_eni_unattachments_finished",
 		name:            "disassociateWorker2",
 		table:           "branch_eni_attachments",
-
-		maxWorkTime: 30 * time.Second,
+		maxWorkTime:     30 * time.Second,
+		errorCounter:    metrics.ErrorDisassociateBranchENICount,
 
 		pendingState: unattaching,
 

--- a/vpc/service/branch_enis.go
+++ b/vpc/service/branch_enis.go
@@ -1107,7 +1107,8 @@ func (vpcService *vpcService) associateActionWorker() *actionWorker {
 		name:            "associateWorker2",
 		table:           "branch_eni_attachments",
 		maxWorkTime:     30 * time.Second,
-		errorCounter:    metrics.ErrorAssociateBranchENICount,
+		errorMeasure:    metrics.ErrorAssociateBranchENICount,
+		latencyMeasure:  metrics.AssociateBranchENILatency,
 
 		pendingState: attaching,
 
@@ -1127,7 +1128,8 @@ func (vpcService *vpcService) disassociateActionWorker() *actionWorker {
 		name:            "disassociateWorker2",
 		table:           "branch_eni_attachments",
 		maxWorkTime:     30 * time.Second,
-		errorCounter:    metrics.ErrorDisassociateBranchENICount,
+		errorMeasure:    metrics.ErrorDisassociateBranchENICount,
+		latencyMeasure:  metrics.DisassociateBranchENILatency,
 
 		pendingState: unattaching,
 

--- a/vpc/service/db/query_metrics.go
+++ b/vpc/service/db/query_metrics.go
@@ -26,7 +26,7 @@ func init() {
 				Name:        measure.Name(),
 				Description: measure.Description(),
 				Measure:     measure,
-				Aggregation: view.Count(),
+				Aggregation: view.Distribution(),
 			},
 		); err != nil {
 			panic(err)

--- a/vpc/service/delete_failed_assignments.go
+++ b/vpc/service/delete_failed_assignments.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 )
 
@@ -23,7 +25,8 @@ func (vpcService *vpcService) deleteFailedAssignments(ctx context.Context, proto
 	for {
 		err := vpcService.doDeleteFailedAssignments(ctx)
 		if err != nil {
-			logger.G(ctx).WithError(err).Error("Unable to delete failed assignments")
+			logger.G(ctx).WithError(err).Error("Failed to delete failed assignments")
+			stats.Record(ctx, metrics.ErrorDeleteFailedAssignmentsCount.M(1))
 		}
 		err = waitFor(ctx, timeBetweenDeleteFailedAssignments)
 		if err != nil {

--- a/vpc/service/delete_failed_assignments.go
+++ b/vpc/service/delete_failed_assignments.go
@@ -23,10 +23,13 @@ func (vpcService *vpcService) deleteFailedAssignments(ctx context.Context, proto
 	defer cancel()
 
 	for {
+		start := time.Now()
 		err := vpcService.doDeleteFailedAssignments(ctx)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to delete failed assignments")
 			stats.Record(ctx, metrics.ErrorDeleteFailedAssignmentsCount.M(1))
+		} else {
+			stats.Record(ctx, metrics.DeleteFailedAssignmentsLatency.M(time.Since(start).Milliseconds()))
 		}
 		err = waitFor(ctx, timeBetweenDeleteFailedAssignments)
 		if err != nil {

--- a/vpc/service/detach_unused_branch_eni.go
+++ b/vpc/service/detach_unused_branch_eni.go
@@ -40,12 +40,14 @@ func (vpcService *vpcService) detatchUnusedBranchENILoop(ctx context.Context, pr
 		"az":        item.Az,
 	})
 	for {
+		start := time.Now()
 		resetTime, err := vpcService.doDetatchUnusedBranchENI(ctx, item)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to detach unused branch ENIs")
 			stats.Record(ctx, metrics.ErrorDetachUnusedBranchENIsCount.M(1))
 		} else {
 			logger.G(ctx).WithField("resetTime", resetTime).Debug("Waiting to recheck")
+			stats.Record(ctx, metrics.DetachUnusedBranchENIsLatency.M(time.Since(start).Milliseconds()))
 		}
 		err = waitFor(ctx, resetTime)
 		if err != nil {

--- a/vpc/service/detach_unused_branch_eni.go
+++ b/vpc/service/detach_unused_branch_eni.go
@@ -6,15 +6,14 @@ import (
 	"time"
 
 	"github.com/Netflix/titus-executor/vpc/service/data"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/service/vpcerrors"
 
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
-	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/pkg/errors"
 	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 )
 
@@ -43,7 +42,8 @@ func (vpcService *vpcService) detatchUnusedBranchENILoop(ctx context.Context, pr
 	for {
 		resetTime, err := vpcService.doDetatchUnusedBranchENI(ctx, item)
 		if err != nil {
-			logger.G(ctx).WithError(err).Error("Unable to detach ENI")
+			logger.G(ctx).WithError(err).Error("Failed to detach unused branch ENIs")
+			stats.Record(ctx, metrics.ErrorDetachUnusedBranchENIsCount.M(1))
 		} else {
 			logger.G(ctx).WithField("resetTime", resetTime).Debug("Waiting to recheck")
 		}
@@ -98,8 +98,6 @@ LIMIT 1
 	}
 	if err != nil {
 		err = errors.Wrap(err, "Cannot scan branch ENI to delete")
-		mutators := []tag.Mutator{tag.Upsert(tag.MustNewKey("msg"), err.Error())}
-		_ = stats.RecordWithTags(ctx, mutators, metrics.ErrorScanBranchEniCount.M(1))
 		tracehelpers.SetStatus(err, span)
 		return timeBetweenErrors, err
 	}

--- a/vpc/service/gc_v3.go
+++ b/vpc/service/gc_v3.go
@@ -418,9 +418,12 @@ func (vpcService *vpcService) gcWorker(ctx context.Context, session *ec2wrapper.
 			if !ok {
 				return
 			}
+			start := time.Now()
 			if err := vpcService.doGCENI(ctx, session, eni, vpcService.dbRateLimiter); err != nil {
 				logger.G(ctx).WithField("eni", eni).WithError(err).Error("Failed to GC ENI")
 				stats.Record(ctx, metrics.ErrorGCBranchENIsCount.M(1))
+			} else {
+				stats.Record(ctx, metrics.GCBranchENIsLatency.M(time.Since(start).Milliseconds()))
 			}
 		}
 	}

--- a/vpc/service/metrics/metrics.go
+++ b/vpc/service/metrics/metrics.go
@@ -46,6 +46,25 @@ var (
 	ErrorReconcileSGsCount                    = stats.Int64("error.reconcileSGs", "The number of time failing to reconcile security groups", stats.UnitNone)
 	ErrorReconcileSubnetCIDRReservationsCount = stats.Int64("error.reconcileSubnetCIDRReservations", "The number of time failing to reconcile subnet CIDR reservations", stats.UnitNone)
 	ErrorMonitorRouteTableCount               = stats.Int64("error.monitorRouteTable", "The number of time failing to monitor route table", stats.UnitNone)
+
+	// Distribution measures
+
+	ReconcileEIPsLatency                   = stats.Int64("loop.reconcileEIPs.latency", "The latency to reconcile elastic IPs", stats.UnitMilliseconds)
+	ReconcileAZsLatency                    = stats.Int64("loop.reconcileAZs.latency", "The latency to reconcile availability zones", stats.UnitMilliseconds)
+	PruneLastUsedIPsLatency                = stats.Int64("loop.pruneLastUsedIPs.latency", "The latency to prune last used IPs", stats.UnitMilliseconds)
+	ReconcileBranchENIAttachmentsLatency   = stats.Int64("loop.reconcileBranchENIAttachments.latency", "The latency to reconcile branch ENI attachments", stats.UnitMilliseconds)
+	GCBranchENIsLatency                    = stats.Int64("loop.gcBranchENIs.latency", "The latency to GC branch ENIs", stats.UnitMilliseconds)
+	DeleteExcessBranchENIsLatency          = stats.Int64("loop.deleteExcessBranchENIs.latency", "The latency to delete excess branch ENIs", stats.UnitMilliseconds)
+	DetachUnusedBranchENIsLatency          = stats.Int64("loop.detachUnusedBranchENIs.latency", "The latency to detach unused branch ENIs", stats.UnitMilliseconds)
+	DeleteFailedAssignmentsLatency         = stats.Int64("loop.deleteFailedAssignments.latency", "The latency to delete failed assignments", stats.UnitMilliseconds)
+	ReconcileSubnetsLatency                = stats.Int64("loop.reconcileSubnets.latency", "The latency to reconcile subnets", stats.UnitMilliseconds)
+	ReconcileBranchENIsLatency             = stats.Int64("loop.reconcileBranchENIs.latency", "The latency to reconcile branch ENIs", stats.UnitMilliseconds)
+	ReconcileTrunkENIsLatency              = stats.Int64("loop.reconcileTrunkENIs.latency", "The latency to reconcile trunk ENIs", stats.UnitMilliseconds)
+	AssociateBranchENILatency              = stats.Int64("loop.associateBranchENI.latency", "The latency to associate branch ENI", stats.UnitMilliseconds)
+	DisassociateBranchENILatency           = stats.Int64("loop.disassociateBranchENI.latency", "The latency to disassociate branch ENI", stats.UnitMilliseconds)
+	ReconcileSGsLatency                    = stats.Int64("loop.reconcileSGs.latency", "The latency to reconcile security groups", stats.UnitMilliseconds)
+	ReconcileSubnetCIDRReservationsLatency = stats.Int64("loop.reconcileSubnetCIDRReservations.latency", "The latency to reconcile subnet CIDR reservations", stats.UnitMilliseconds)
+	MonitorRouteTableLatency               = stats.Int64("loop.monitorRouteTable.latency", "The latency to monitor route table", stats.UnitMilliseconds)
 )
 
 func init() {
@@ -92,6 +111,38 @@ func init() {
 				Description: counterMeasures[idx].Description(),
 				Measure:     counterMeasures[idx],
 				Aggregation: view.Count(),
+			},
+		); err != nil {
+			panic(err)
+		}
+	}
+
+	distributionMeasures := []stats.Measure{
+		ReconcileEIPsLatency,
+		ReconcileAZsLatency,
+		PruneLastUsedIPsLatency,
+		ReconcileBranchENIAttachmentsLatency,
+		GCBranchENIsLatency,
+		DeleteExcessBranchENIsLatency,
+		DetachUnusedBranchENIsLatency,
+		DeleteFailedAssignmentsLatency,
+		ReconcileSubnetsLatency,
+		ReconcileBranchENIsLatency,
+		ReconcileTrunkENIsLatency,
+		AssociateBranchENILatency,
+		DisassociateBranchENILatency,
+		ReconcileSGsLatency,
+		ReconcileSubnetCIDRReservationsLatency,
+		MonitorRouteTableLatency,
+	}
+
+	for idx := range distributionMeasures {
+		if err := view.Register(
+			&view.View{
+				Name:        distributionMeasures[idx].Name(),
+				Description: distributionMeasures[idx].Description(),
+				Measure:     distributionMeasures[idx],
+				Aggregation: view.Distribution(),
 			},
 		); err != nil {
 			panic(err)

--- a/vpc/service/metrics/metrics.go
+++ b/vpc/service/metrics/metrics.go
@@ -25,11 +25,27 @@ var (
 	unattachedEnisCount       = stats.Int64("unattached_enis.count", "The number of rows in branch_enis table that don't have an attachment", stats.UnitNone)
 
 	// Counter measures
-	waitCount               = stats.Int64("db.waitCount", "The total number of connections waited for", "connections")
-	waitDuration            = stats.Int64("db.waitDuration", "The total time blocked waiting for a new connection", "ns")
-	maxIdleClosed           = stats.Int64("db.maxIdleClosed", "The total number of connections closed due to SetMaxIdleConns", "connections")
-	maxLifetimeClosed       = stats.Int64("db.maxLifetimeClosed", "The total number of connections closed due to SetConnMaxLifetime", "connections")
-	ErrorScanBranchEniCount = stats.Int64("error.scanBranchEni", "ENIs that could not be cleaned up due to error in query", stats.UnitNone)
+	waitCount         = stats.Int64("db.waitCount", "The total number of connections waited for", "connections")
+	waitDuration      = stats.Int64("db.waitDuration", "The total time blocked waiting for a new connection", "ns")
+	maxIdleClosed     = stats.Int64("db.maxIdleClosed", "The total number of connections closed due to SetMaxIdleConns", "connections")
+	maxLifetimeClosed = stats.Int64("db.maxLifetimeClosed", "The total number of connections closed due to SetConnMaxLifetime", "connections")
+
+	ErrorReconcileEIPsCount                   = stats.Int64("error.reconcileEIPs", "The number of time failing to reconcile elastic IPs", stats.UnitNone)
+	ErrorReconcileAZsCount                    = stats.Int64("error.reconcileAZs", "The number of time failing to reconcile availability zones", stats.UnitNone)
+	ErrorPruneLastUsedIPsCount                = stats.Int64("error.pruneLastUsedIPs", "The number of time failing to prune last used IP addreses", stats.UnitNone)
+	ErrorReconcileBranchENIAttachmentsCount   = stats.Int64("error.reconcileBranchENIAttachments", "The number of time failing to reconcile branch ENI attachments", stats.UnitNone)
+	ErrorGCBranchENIsCount                    = stats.Int64("error.gcBranchENIs", "The number of time failing to GC branch ENIs", stats.UnitNone)
+	ErrorDeleteExcessBranchENIsCount          = stats.Int64("error.deleteExcessBranchENIs", "The number of time failing to delete excess branch ENIs", stats.UnitNone)
+	ErrorDetachUnusedBranchENIsCount          = stats.Int64("error.detachUnusedBranchENIs", "The number of time failing to detach unused branch ENIs", stats.UnitNone)
+	ErrorDeleteFailedAssignmentsCount         = stats.Int64("error.deleteFailedAssignments", "The number of time failing to delete failed assignments", stats.UnitNone)
+	ErrorReconcileSubnetsCount                = stats.Int64("error.reconcileSubnets", "The number of time failing to reconcile subnets", stats.UnitNone)
+	ErrorReconcileBranchENIsCount             = stats.Int64("error.reconcileBranchENIs", "The number of time failing to reconcile branch ENIs", stats.UnitNone)
+	ErrorReconcileTrunkENIsCount              = stats.Int64("error.reconcileTrunkENIs", "The number of time failing to reconcile trunk ENIs", stats.UnitNone)
+	ErrorAssociateBranchENICount              = stats.Int64("error.associateBranchENI", "The number of time failing to finish branch ENI association", stats.UnitNone)
+	ErrorDisassociateBranchENICount           = stats.Int64("error.disassociateBranchENI", "The number of time failing to finish branch ENI disassociation", stats.UnitNone)
+	ErrorReconcileSGsCount                    = stats.Int64("error.reconcileSGs", "The number of time failing to reconcile security groups", stats.UnitNone)
+	ErrorReconcileSubnetCIDRReservationsCount = stats.Int64("error.reconcileSubnetCIDRReservations", "The number of time failing to reconcile subnet CIDR reservations", stats.UnitNone)
+	ErrorMonitorRouteTableCount               = stats.Int64("error.monitorRouteTable", "The number of time failing to monitor route table", stats.UnitNone)
 )
 
 func init() {
@@ -52,7 +68,22 @@ func init() {
 
 	counterMeasures := []stats.Measure{
 		waitCount, waitDuration, maxIdleClosed, maxLifetimeClosed,
-		ErrorScanBranchEniCount,
+		ErrorReconcileEIPsCount,
+		ErrorReconcileAZsCount,
+		ErrorPruneLastUsedIPsCount,
+		ErrorReconcileBranchENIAttachmentsCount,
+		ErrorGCBranchENIsCount,
+		ErrorDeleteExcessBranchENIsCount,
+		ErrorDetachUnusedBranchENIsCount,
+		ErrorDeleteFailedAssignmentsCount,
+		ErrorReconcileSubnetsCount,
+		ErrorReconcileBranchENIsCount,
+		ErrorReconcileTrunkENIsCount,
+		ErrorAssociateBranchENICount,
+		ErrorDisassociateBranchENICount,
+		ErrorReconcileSGsCount,
+		ErrorReconcileSubnetCIDRReservationsCount,
+		ErrorMonitorRouteTableCount,
 	}
 	for idx := range counterMeasures {
 		if err := view.Register(

--- a/vpc/service/prune_unused_ips.go
+++ b/vpc/service/prune_unused_ips.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
@@ -25,6 +26,7 @@ func (vpcService *vpcService) pruneLastUsedIPAddresses(ctx context.Context, null
 	ctx, span := trace.StartSpan(ctx, "pruneLastUsedIPAddresses")
 	defer span.End()
 
+	start := time.Now()
 	err := vpcService.doPruneLastUsedIPAddresses(ctx, tx)
 	if err != nil {
 		logger.G(ctx).WithError(err).Error("Failed to prune laste used IPs")
@@ -32,6 +34,7 @@ func (vpcService *vpcService) pruneLastUsedIPAddresses(ctx context.Context, null
 		tracehelpers.SetStatus(err, span)
 		return err
 	}
+	stats.Record(ctx, metrics.PruneLastUsedIPsLatency.M(time.Since(start).Milliseconds()))
 	return nil
 }
 

--- a/vpc/service/prune_unused_ips.go
+++ b/vpc/service/prune_unused_ips.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 )
 
@@ -26,6 +28,7 @@ func (vpcService *vpcService) pruneLastUsedIPAddresses(ctx context.Context, null
 	err := vpcService.doPruneLastUsedIPAddresses(ctx, tx)
 	if err != nil {
 		logger.G(ctx).WithError(err).Error("Failed to prune laste used IPs")
+		stats.Record(ctx, metrics.ErrorPruneLastUsedIPsCount.M(1))
 		tracehelpers.SetStatus(err, span)
 		return err
 	}

--- a/vpc/service/reconcile_availability_zones.go
+++ b/vpc/service/reconcile_availability_zones.go
@@ -9,9 +9,11 @@ import (
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 )
 
@@ -29,6 +31,7 @@ func (vpcService *vpcService) reconcileAvailabilityZonesRegionAccount(ctx contex
 	err := vpcService.doReconcileAvailabilityZonesRegionAccount(ctx, account, tx)
 	if err != nil {
 		logger.G(ctx).WithError(err).Error("Failed to reconcile availability zones")
+		stats.Record(ctx, metrics.ErrorReconcileAZsCount.M(1))
 		tracehelpers.SetStatus(err, span)
 		return err
 	}

--- a/vpc/service/reconcile_availability_zones.go
+++ b/vpc/service/reconcile_availability_zones.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 
@@ -28,6 +29,7 @@ func (vpcService *vpcService) reconcileAvailabilityZonesRegionAccount(ctx contex
 		"region":    account.region,
 		"accountID": account.accountID,
 	})
+	start := time.Now()
 	err := vpcService.doReconcileAvailabilityZonesRegionAccount(ctx, account, tx)
 	if err != nil {
 		logger.G(ctx).WithError(err).Error("Failed to reconcile availability zones")
@@ -35,6 +37,7 @@ func (vpcService *vpcService) reconcileAvailabilityZonesRegionAccount(ctx contex
 		tracehelpers.SetStatus(err, span)
 		return err
 	}
+	stats.Record(ctx, metrics.ReconcileAZsLatency.M(time.Since(start).Milliseconds()))
 	return nil
 }
 

--- a/vpc/service/reconcile_branch_eni_attachments.go
+++ b/vpc/service/reconcile_branch_eni_attachments.go
@@ -35,10 +35,13 @@ func (vpcService *vpcService) reconcileBranchENIAttachmentLoop(ctx context.Conte
 		"accountID": item.accountID,
 	})
 	for {
+		start := time.Now()
 		err := vpcService.reconcileBranchAttachmentsENIsForRegionAccount(ctx, item)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile branch ENI attachments")
 			stats.Record(ctx, metrics.ErrorReconcileBranchENIAttachmentsCount.M(1))
+		} else {
+			stats.Record(ctx, metrics.ReconcileBranchENIAttachmentsLatency.M(time.Since(start).Milliseconds()))
 		}
 		err = waitFor(ctx, timeBetweenBranchENIAttachmentReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_branch_eni_attachments.go
+++ b/vpc/service/reconcile_branch_eni_attachments.go
@@ -13,9 +13,11 @@ import (
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 )
 
@@ -36,6 +38,7 @@ func (vpcService *vpcService) reconcileBranchENIAttachmentLoop(ctx context.Conte
 		err := vpcService.reconcileBranchAttachmentsENIsForRegionAccount(ctx, item)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile branch ENI attachments")
+			stats.Record(ctx, metrics.ErrorReconcileBranchENIAttachmentsCount.M(1))
 		}
 		err = waitFor(ctx, timeBetweenBranchENIAttachmentReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_branch_enis.go
+++ b/vpc/service/reconcile_branch_enis.go
@@ -39,10 +39,13 @@ func (vpcService *vpcService) reconcileBranchENILoop(ctx context.Context, protoI
 		"accountID": item.accountID,
 	})
 	for {
+		start := time.Now()
 		err := vpcService.reconcileBranchENIsForRegionAccount(ctx, item)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile branch ENIs")
 			stats.Record(ctx, metrics.ErrorReconcileBranchENIsCount.M(1))
+		} else {
+			stats.Record(ctx, metrics.ReconcileBranchENIsLatency.M(time.Since(start).Milliseconds()))
 		}
 		err = waitFor(ctx, timeBetweenBranchENIReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_branch_enis.go
+++ b/vpc/service/reconcile_branch_enis.go
@@ -13,12 +13,14 @@ import (
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/service/vpcerrors"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -40,6 +42,7 @@ func (vpcService *vpcService) reconcileBranchENILoop(ctx context.Context, protoI
 		err := vpcService.reconcileBranchENIsForRegionAccount(ctx, item)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile branch ENIs")
+			stats.Record(ctx, metrics.ErrorReconcileBranchENIsCount.M(1))
 		}
 		err = waitFor(ctx, timeBetweenBranchENIReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_elastic_ips.go
+++ b/vpc/service/reconcile_elastic_ips.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"time"
 
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
@@ -36,6 +37,7 @@ func (vpcService *vpcService) reconcileEIPsForRegionAccount(ctx context.Context,
 		"region":    account.region,
 		"accountID": account.accountID,
 	})
+	start := time.Now()
 	err := vpcService.doReconcileEIPsForRegionAccount(ctx, account, tx)
 	if err != nil {
 		logger.G(ctx).WithError(err).Error("Failed to reconcile EIPs")
@@ -43,6 +45,7 @@ func (vpcService *vpcService) reconcileEIPsForRegionAccount(ctx context.Context,
 		tracehelpers.SetStatus(err, span)
 		return err
 	}
+	stats.Record(ctx, metrics.ReconcileEIPsLatency.M(time.Since(start).Milliseconds()))
 	return nil
 }
 

--- a/vpc/service/reconcile_elastic_ips.go
+++ b/vpc/service/reconcile_elastic_ips.go
@@ -9,10 +9,12 @@ import (
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 )
 
@@ -37,6 +39,7 @@ func (vpcService *vpcService) reconcileEIPsForRegionAccount(ctx context.Context,
 	err := vpcService.doReconcileEIPsForRegionAccount(ctx, account, tx)
 	if err != nil {
 		logger.G(ctx).WithError(err).Error("Failed to reconcile EIPs")
+		stats.Record(ctx, metrics.ErrorReconcileEIPsCount.M(1))
 		tracehelpers.SetStatus(err, span)
 		return err
 	}

--- a/vpc/service/reconcile_security_groups.go
+++ b/vpc/service/reconcile_security_groups.go
@@ -34,10 +34,13 @@ func (vpcService *vpcService) reconcileSecurityGroupsForRegionAccountLoop(ctx co
 		"accountID": account.accountID,
 	})
 	for {
+		start := time.Now()
 		err := vpcService.reconcileSecurityGroupsForRegionAccount(ctx, account)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile security groups")
 			stats.Record(ctx, metrics.ErrorReconcileSGsCount.M(1))
+		} else {
+			stats.Record(ctx, metrics.ReconcileSGsLatency.M(time.Since(start).Milliseconds()))
 		}
 		err = waitFor(ctx, timeBetweenSecurityGroupReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_security_groups.go
+++ b/vpc/service/reconcile_security_groups.go
@@ -9,10 +9,12 @@ import (
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/lib/pq"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -35,6 +37,7 @@ func (vpcService *vpcService) reconcileSecurityGroupsForRegionAccountLoop(ctx co
 		err := vpcService.reconcileSecurityGroupsForRegionAccount(ctx, account)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile security groups")
+			stats.Record(ctx, metrics.ErrorReconcileSGsCount.M(1))
 		}
 		err = waitFor(ctx, timeBetweenSecurityGroupReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_subnet_cidr_reservations.go
+++ b/vpc/service/reconcile_subnet_cidr_reservations.go
@@ -45,12 +45,14 @@ func (vpcService *vpcService) reconcileSubnetCIDRReservationsLoop(ctx context.Co
 			"accountID": subnet.AccountID,
 			"az":        subnet.Az,
 		})
+		start := time.Now()
 		err := vpcService.doReconcileSubnetCIDRReservations(ctx, subnet)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile subnet CIDR Reservations")
 			stats.Record(ctx, metrics.ErrorReconcileSubnetCIDRReservationsCount.M(1))
 			resetTime = timeBetweenErrors
 		} else {
+			stats.Record(ctx, metrics.ReconcileSubnetCIDRReservationsLatency.M(time.Since(start).Milliseconds()))
 			resetTime = timeBetweenSubnetCIDRReservationReconcilation
 		}
 		err = waitFor(ctx, resetTime)

--- a/vpc/service/reconcile_subnet_cidr_reservations.go
+++ b/vpc/service/reconcile_subnet_cidr_reservations.go
@@ -10,11 +10,13 @@ import (
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -46,6 +48,7 @@ func (vpcService *vpcService) reconcileSubnetCIDRReservationsLoop(ctx context.Co
 		err := vpcService.doReconcileSubnetCIDRReservations(ctx, subnet)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile subnet CIDR Reservations")
+			stats.Record(ctx, metrics.ErrorReconcileSubnetCIDRReservationsCount.M(1))
 			resetTime = timeBetweenErrors
 		} else {
 			resetTime = timeBetweenSubnetCIDRReservationReconcilation

--- a/vpc/service/reconcile_subnets.go
+++ b/vpc/service/reconcile_subnets.go
@@ -64,10 +64,13 @@ func (vpcService *vpcService) doReconcileSubnetsForRegionAccountLoop(ctx context
 			"region":    item.region,
 			"accountID": item.accountID,
 		})
+		start := time.Now()
 		err := vpcService.doReconcileSubnetsForRegionAccount(ctx, item)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile subnets")
 			stats.Record(ctx, metrics.ErrorReconcileSubnetsCount.M(1))
+		} else {
+			stats.Record(ctx, metrics.ReconcileSubnetsLatency.M(time.Since(start).Milliseconds()))
 		}
 		err = waitFor(ctx, timeBetweenSubnetReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_subnets.go
+++ b/vpc/service/reconcile_subnets.go
@@ -11,12 +11,14 @@ import (
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/go-multierror"
 	"github.com/lib/pq"
 	"github.com/m7shapan/cidr"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -65,6 +67,7 @@ func (vpcService *vpcService) doReconcileSubnetsForRegionAccountLoop(ctx context
 		err := vpcService.doReconcileSubnetsForRegionAccount(ctx, item)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile subnets")
+			stats.Record(ctx, metrics.ErrorReconcileSubnetsCount.M(1))
 		}
 		err = waitFor(ctx, timeBetweenSubnetReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_trunk_enis.go
+++ b/vpc/service/reconcile_trunk_enis.go
@@ -9,11 +9,13 @@ import (
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -36,6 +38,7 @@ func (vpcService *vpcService) reconcileTrunkENIsForRegionAccountLoop(ctx context
 		err := vpcService.reconcileTrunkENIsForRegionAccount(ctx, item)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile trunk ENIs")
+			stats.Record(ctx, metrics.ErrorReconcileTrunkENIsCount.M(1))
 		}
 		err = waitFor(ctx, timeBetweenTrunkENIReconcilation)
 		if err != nil {

--- a/vpc/service/reconcile_trunk_enis.go
+++ b/vpc/service/reconcile_trunk_enis.go
@@ -35,10 +35,13 @@ func (vpcService *vpcService) reconcileTrunkENIsForRegionAccountLoop(ctx context
 	})
 
 	for {
+		start := time.Now()
 		err := vpcService.reconcileTrunkENIsForRegionAccount(ctx, item)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Failed to reconcile trunk ENIs")
 			stats.Record(ctx, metrics.ErrorReconcileTrunkENIsCount.M(1))
+		} else {
+			stats.Record(ctx, metrics.ReconcileTrunkENIsLatency.M(time.Since(start).Milliseconds()))
 		}
 		err = waitFor(ctx, timeBetweenTrunkENIReconcilation)
 		if err != nil {

--- a/vpc/service/route_table.go
+++ b/vpc/service/route_table.go
@@ -13,10 +13,12 @@ import (
 	vpcapi "github.com/Netflix/titus-executor/vpc/api"
 	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
+	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/go-multierror"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 )
 
@@ -42,6 +44,7 @@ func (vpcService *vpcService) monitorRouteTableLoop(ctx context.Context) {
 		err = vpcService.monitorRouteTables(ctx)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Route table monitoring attempt failed!")
+			stats.Record(ctx, metrics.ErrorMonitorRouteTableCount.M(1))
 		}
 	}
 }

--- a/vpc/service/route_table.go
+++ b/vpc/service/route_table.go
@@ -41,10 +41,13 @@ func (vpcService *vpcService) monitorRouteTableLoop(ctx context.Context) {
 			return
 		}
 
+		start := time.Now()
 		err = vpcService.monitorRouteTables(ctx)
 		if err != nil {
 			logger.G(ctx).WithError(err).Error("Route table monitoring attempt failed!")
 			stats.Record(ctx, metrics.ErrorMonitorRouteTableCount.M(1))
+		} else {
+			stats.Record(ctx, metrics.MonitorRouteTableLatency.M(time.Since(start).Milliseconds()))
 		}
 	}
 }

--- a/vpc/service/service.go
+++ b/vpc/service/service.go
@@ -449,7 +449,7 @@ func (vpcService *vpcService) getLongLivedTasks() []longLivedTask {
 		{
 			taskName:   "gc_enis2",
 			itemLister: vpcService.getBranchENIRegionAccounts,
-			workFunc:   vpcService.doGCAttachedENIsLoop,
+			workFunc:   vpcService.doGCENIsLoop,
 		},
 		vpcService.deleteExcessBranchesLongLivedTask(),
 		{


### PR DESCRIPTION
# Problem

For APIs, we have gRPC stats provided by [opencensus](https://github.com/danielkhan/openconsensus/tree/master/schemas/opencensus). However, no stats/metrics exist for long-running tasks in VPC Service. 

# Fix
This PR adds an error counter and a latency measure for all long-running tasks. With this change, we ensure that for each failed execution, we count the error whereas for each successful execution, we measure its latency. Alerts will be set up based for these two metrics so that we will catch it early when certain tasks keep failing or have an increased execution time.