### PR TITLE
runtime: don't start optional service if image pull fails

### DIFF
--- a/executor/runtime/docker/docker_unsupported.go
+++ b/executor/runtime/docker/docker_unsupported.go
@@ -23,7 +23,7 @@ func hasProjectQuotasEnabled(rootDir string) bool {
 	return false
 }
 
-func setupSystemServices(parentCtx context.Context, c runtimeTypes.Container, cfg config.Config) error {
+func setupSystemServices(parentCtx context.Context, systemServices []*runtimeTypes.ServiceOpts, c runtimeTypes.Container, cfg config.Config) error {
 	return nil
 }
 


### PR DESCRIPTION
If a docker image pull fails:

Jul 28 00:58:52 titusagent-main01cell002-m5metal009-i-0e2b0dca2ac46325d titus-executor-[370813]: Pull error message: map[error:received unexpected HTTP status: 500 Internal Server Error errorDetail:map[message:received unexpected HTTP status: 500 Internal Server Error]]
Jul 28 00:59:03 titusagent-main01cell002-m5metal009-i-0e2b0dca2ac46325d titus-executor-[370813]: Error pulling image 'registry.us-west-2.streamingprod.titus.netflix.net:7002/titusoss/titus-sshd@sha256:f50b6cac87b820b08c7783f7db7b4fda88937386d621cfa9ab690f148d2a1d38', due to reason: Error response from daemon: received unexpected HTTP status: 500 Internal Server Error
Jul 28 00:59:16 titusagent-main01cell002-m5metal009-i-0e2b0dca2ac46325d titus-executor-[370813]: Error pulling image 'registry.us-west-2.streamingprod.titus.netflix.net:7002/titusoss/titus-sshd@sha256:f50b6cac87b820b08c7783f7db7b4fda88937386d621cfa9ab690f148d2a1d38', due to reason: Error response from daemon: received unexpected HTTP status: 500 Internal Server Error
Jul 28 00:59:40 titusagent-main01cell002-m5metal009-i-0e2b0dca2ac46325d titus-executor-[370813]: Error pulling image 'registry.us-west-2.streamingprod.titus.netflix.net:7002/titusoss/titus-sshd@sha256:f50b6cac87b820b08c7783f7db7b4fda88937386d621cfa9ab690f148d2a1d38', due to reason: Error response from daemon: received unexpected HTTP status: 500 Internal Server Error
Jul 28 00:59:40 titusagent-main01cell002-m5metal009-i-0e2b0dca2ac46325d titus-executor-[370813]: Unable to setup optional sshd container 'sshd': Error response from daemon: received unexpected HTTP status: 500 Internal Server Error
Jul 28 00:59:40 titusagent-main01cell002-m5metal009-i-0e2b0dca2ac46325d titus-executor-[370813]: SystemD image label set
Jul 28 00:59:40 titusagent-main01cell002-m5metal009-i-0e2b0dca2ac46325d titus-executor-[370813]: Skipping volume container of optional sidecar sshd

then the system service will fail to start, because it's not present, which
is confusing:

Jul 28 00:59:54 titusagent-main01cell002-m5metal009-i-0e2b0dca2ac46325d titus-nsenter[380041]: BUG:do_nsenter:268:No such file or directory Could not execute child

let's just not start it at all.

The calls happen in two different phases of creation, Prepare() and
Start(), so we need to keep a copy of the system services pointers around
because SystemServices() explicitly makes a copy of them. Looks like this
was a TODO, so probably not a big deal.
