### PR TITLE
Set atlas/spectatord as required

### DIFF
--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -54,7 +54,7 @@ var systemServices = []ServiceOpts{
 		ServiceName:  SidecarServiceSpectatord,
 		UnitName:     "titus-sidecar-spectatord",
 		EnabledCheck: shouldStartSpectatord,
-		Required:     false,
+		Required:     true,
 		Volumes: map[string]struct{}{
 			"/titus/spectatord": {},
 		},
@@ -72,7 +72,7 @@ var systemServices = []ServiceOpts{
 		ServiceName:  SidecarServiceAtlasTitusAgent,
 		UnitName:     "titus-sidecar-atlas-titus-agent",
 		EnabledCheck: shouldStartAtlasTitusAgent,
-		Required:     false,
+		Required:     true,
 		Volumes: map[string]struct{}{
 			"/titus/atlas-titus-agent": {},
 		},


### PR DESCRIPTION
It was nice to have for a while, but now we really do need
metrics to be sure we are routing traffic correctly, not generating
hotspots, etc.
