### PR TITLE
Add a dynamic config to enable getting a random unassigned branch ENI

### DIFF
--- a/vpc/service/assign_addresses_v3.go
+++ b/vpc/service/assign_addresses_v3.go
@@ -89,15 +89,6 @@ func (vpcService *vpcService) getSessionAndTrunkInterface(ctx context.Context, i
 	return instanceSession, instance, trunkENI, nil
 }
 
-type branchENI struct {
-	intid         int64
-	id            string
-	az            string
-	associationID string
-	accountID     string
-	idx           int
-}
-
 func (vpcService *vpcService) getLeastUsedSubnet(ctx context.Context, az, accountID string, subnetIDs []string) (*data.Subnet, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -532,15 +523,15 @@ func (vpcService *vpcService) assignIPsToENI(ctx context.Context, req *vpcapi.As
 	ctx, span := trace.StartSpan(ctx, "assignIPsToENI")
 	defer span.End()
 	span.AddAttributes(
-		trace.StringAttribute("eni", ass.branch.id),
-		trace.Int64Attribute("idx", int64(ass.branch.idx)),
+		trace.StringAttribute("eni", ass.branch.BranchENI),
+		trace.Int64Attribute("idx", int64(ass.branch.Idx)),
 		trace.StringAttribute("trunk", ass.trunk),
-		trace.StringAttribute("branch", ass.branch.id),
+		trace.StringAttribute("branch", ass.branch.BranchENI),
 	)
 	ctx = logger.WithFields(ctx, map[string]interface{}{
-		"eni":    ass.branch.id,
+		"eni":    ass.branch.BranchENI,
 		"trunk":  ass.trunk,
-		"branch": ass.branch.id,
+		"branch": ass.branch.BranchENI,
 	})
 	tx, err := vpcService.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -570,7 +561,7 @@ func (vpcService *vpcService) assignIPsToENI(ctx context.Context, req *vpcapi.As
 	}
 
 	// This locks the branch ENI making this whole process "exclusive"
-	dbSecurityGroups, err := db.GetSecurityGroupsAndLockBranchENI(ctx, tx, ass.branch.id)
+	dbSecurityGroups, err := db.GetSecurityGroupsAndLockBranchENI(ctx, tx, ass.branch.BranchENI)
 	if err != nil {
 		err = errors.Wrap(err, "Cannot get SGs assigned to branch ENI in DB")
 		tracehelpers.SetStatus(err, span)
@@ -583,7 +574,7 @@ func (vpcService *vpcService) assignIPsToENI(ctx context.Context, req *vpcapi.As
 		return nil, err
 	}
 
-	iface, err := ass.branchENISession.GetNetworkInterfaceByID(ctx, ass.branch.id, 100*time.Millisecond)
+	iface, err := ass.branchENISession.GetNetworkInterfaceByID(ctx, ass.branch.BranchENI, 100*time.Millisecond)
 	if err != nil {
 		err = errors.Wrap(err, "Cannot get branch ENI")
 		tracehelpers.SetStatus(err, span)
@@ -719,13 +710,13 @@ func (vpcService *vpcService) assignIPsToENI(ctx context.Context, req *vpcapi.As
 
 	resp.BranchNetworkInterface = &vpcapi.NetworkInterface{
 		SubnetId:           ass.subnet.SubnetID,
-		AvailabilityZone:   ass.branch.az,
+		AvailabilityZone:   ass.branch.AZ,
 		MacAddress:         aws.StringValue(iface.MacAddress),
-		NetworkInterfaceId: ass.branch.id,
-		OwnerAccountId:     ass.branch.accountID,
+		NetworkInterfaceId: ass.branch.BranchENI,
+		OwnerAccountId:     ass.branch.AccountID,
 		VpcId:              ass.subnet.VpcID,
 	}
-	resp.VlanId = uint32(ass.branch.idx)
+	resp.VlanId = uint32(ass.branch.Idx)
 
 	row := tx.QueryRowContext(ctx, `
 UPDATE htb_classid
@@ -895,7 +886,7 @@ func assignArbitraryIPv6AddressV3(ctx context.Context, tx *sql.Tx, branchENI *ec
 	ctx, span := trace.StartSpan(ctx, "assignArbitraryIPv6AddressV3")
 	defer span.End()
 
-	row := tx.QueryRowContext(ctx, "UPDATE subnet_usable_prefix SET last_assigned = last_assigned + 1 WHERE branch_eni_id = $1 RETURNING last_assigned, prefix", ass.branch.intid)
+	row := tx.QueryRowContext(ctx, "UPDATE subnet_usable_prefix SET last_assigned = last_assigned + 1 WHERE branch_eni_id = $1 RETURNING last_assigned, prefix", ass.branch.ID)
 	var lastAssigned int64
 	var prefix string
 	err := row.Scan(&lastAssigned, &prefix)
@@ -924,7 +915,7 @@ func assignArbitraryIPv6AddressV3(ctx context.Context, tx *sql.Tx, branchENI *ec
 	}, nil
 }
 
-func assignArbitraryIPv4AddressV3(ctx context.Context, tx *sql.Tx, branchENI *ec2.NetworkInterface, maxIPAddresses int, cidr string, branch branchENI, branchENISession *ec2wrapper.EC2Session) (*vpcapi.UsableAddress, error) {
+func assignArbitraryIPv4AddressV3(ctx context.Context, tx *sql.Tx, branchENI *ec2.NetworkInterface, maxIPAddresses int, cidr string, branch *data.BranchENI, branchENISession *ec2wrapper.EC2Session) (*vpcapi.UsableAddress, error) {
 	ctx, span := trace.StartSpan(ctx, "assignArbitraryIPv4Address")
 	defer span.End()
 	_, ipnet, err := net.ParseCIDR(cidr)
@@ -935,7 +926,7 @@ func assignArbitraryIPv4AddressV3(ctx context.Context, tx *sql.Tx, branchENI *ec
 	}
 	prefixlength, _ := ipnet.Mask.Size()
 
-	usedIPAddresses, err := db.GetUsedIPv4AddressesByENIAssociation(ctx, tx, branch.associationID)
+	usedIPAddresses, err := db.GetUsedIPv4AddressesByENIAssociation(ctx, tx, branch.AssociationID)
 	if err != nil {
 		err = errors.Wrap(err, "Cannot get ipv4addrs already assigned to interface from DB")
 		tracehelpers.SetStatus(err, span)

--- a/vpc/service/branch_enis.go
+++ b/vpc/service/branch_enis.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Netflix/titus-executor/logger"
+	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
 	"github.com/Netflix/titus-executor/vpc/service/metrics"
 	"github.com/Netflix/titus-executor/vpc/service/vpcerrors"
@@ -162,9 +163,9 @@ func (vpcService *vpcService) finishAssociationAWS(ctx context.Context, slowTx *
 		return nil, err
 	}
 
-	err = vpcService.ensureBranchENIPermissionV3(ctx, slowTx, args.trunkENIAccountID, branchENISession, &branchENI{
-		accountID: args.branchENIAccountID,
-		id:        args.branch,
+	err = vpcService.ensureBranchENIPermissionV3(ctx, slowTx, args.trunkENIAccountID, branchENISession, &data.BranchENI{
+		AccountID: args.branchENIAccountID,
+		BranchENI: args.branch,
 	})
 	if err != nil {
 		err = errors.Wrap(err, "Cannot ensure permission to attach branch ENI")
@@ -560,21 +561,21 @@ VALUES ($1, $2, $3, $4, $5, now(), 'attaching') RETURNING id
 	return id, nil
 }
 
-func (vpcService *vpcService) ensureBranchENIPermissionV3(ctx context.Context, tx *sql.Tx, trunkENIAccountID string, branchENISession *ec2wrapper.EC2Session, eni *branchENI) error {
+func (vpcService *vpcService) ensureBranchENIPermissionV3(ctx context.Context, tx *sql.Tx, trunkENIAccountID string, branchENISession *ec2wrapper.EC2Session, eni *data.BranchENI) error {
 	ctx, span := trace.StartSpan(ctx, "ensureBranchENIPermissionV3")
 	defer span.End()
 
 	span.AddAttributes(
-		trace.StringAttribute("branch", eni.id),
-		trace.StringAttribute("branchAccount", eni.accountID),
+		trace.StringAttribute("branch", eni.BranchENI),
+		trace.StringAttribute("branchAccount", eni.AccountID),
 		trace.StringAttribute("trunkAccount", trunkENIAccountID),
 	)
-	if eni.accountID == trunkENIAccountID {
+	if eni.AccountID == trunkENIAccountID {
 		return nil
 	}
 
 	// This could be collapsed into a join on the above query, but for now, we wont do that
-	row := tx.QueryRowContext(ctx, "SELECT COALESCE(count(*), 0) FROM eni_permissions WHERE branch_eni = $1 AND account_id = $2", eni.id, trunkENIAccountID)
+	row := tx.QueryRowContext(ctx, "SELECT COALESCE(count(*), 0) FROM eni_permissions WHERE branch_eni = $1 AND account_id = $2", eni.BranchENI, trunkENIAccountID)
 	var permissions int
 	err := row.Scan(&permissions)
 	if err != nil {
@@ -586,10 +587,10 @@ func (vpcService *vpcService) ensureBranchENIPermissionV3(ctx context.Context, t
 		return nil
 	}
 
-	logger.G(ctx).Debugf("Creating network interface permission to allow account %s to attach branch ENI in account %s", trunkENIAccountID, eni.accountID)
+	logger.G(ctx).Debugf("Creating network interface permission to allow account %s to attach branch ENI in account %s", trunkENIAccountID, eni.AccountID)
 	_, err = branchENISession.CreateNetworkInterfacePermission(ctx, ec2.CreateNetworkInterfacePermissionInput{
 		AwsAccountId:       aws.String(trunkENIAccountID),
-		NetworkInterfaceId: aws.String(eni.id),
+		NetworkInterfaceId: aws.String(eni.BranchENI),
 		Permission:         aws.String("INSTANCE-ATTACH"),
 	})
 
@@ -598,7 +599,7 @@ func (vpcService *vpcService) ensureBranchENIPermissionV3(ctx context.Context, t
 		return ec2wrapper.HandleEC2Error(err, span)
 	}
 
-	_, err = tx.ExecContext(ctx, "INSERT INTO eni_permissions(branch_eni, account_id) VALUES ($1, $2) ON CONFLICT DO NOTHING ", eni.id, trunkENIAccountID)
+	_, err = tx.ExecContext(ctx, "INSERT INTO eni_permissions(branch_eni, account_id) VALUES ($1, $2) ON CONFLICT DO NOTHING ", eni.BranchENI, trunkENIAccountID)
 	if err != nil {
 		err = errors.Wrap(err, "Cannot insert network interface permission into database")
 		tracehelpers.SetStatus(err, span)

--- a/vpc/service/config.go
+++ b/vpc/service/config.go
@@ -139,7 +139,7 @@ func (dynamicConfig *DynamicConfig) fetchConfigs(ctx context.Context, url string
 	dynamicConfig.Unlock()
 }
 
-func (dynamicConfig *DynamicConfig) GetInt(ctx context.Context, name string, deafult int) int {
+func (dynamicConfig *DynamicConfig) GetInt(ctx context.Context, name string, defaultValue int) int {
 	dynamicConfig.Lock()
 	defer dynamicConfig.Unlock()
 	if value, ok := dynamicConfig.configs[name]; ok {
@@ -150,7 +150,21 @@ func (dynamicConfig *DynamicConfig) GetInt(ctx context.Context, name string, dea
 			return intValue
 		}
 	}
-	return deafult
+	return defaultValue
+}
+
+func (dynamicConfig *DynamicConfig) GetBool(ctx context.Context, name string, defaultValue bool) bool {
+	dynamicConfig.Lock()
+	defer dynamicConfig.Unlock()
+	if value, ok := dynamicConfig.configs[name]; ok {
+		boolValue, err := cast.ToBoolE(value)
+		if err != nil {
+			logger.G(ctx).Errorf("Config %s has an invalid value %s", name, value)
+		} else {
+			return boolValue
+		}
+	}
+	return defaultValue
 }
 
 // Start fetching and updating the configs periodically

--- a/vpc/service/data/branch_eni.go
+++ b/vpc/service/data/branch_eni.go
@@ -1,0 +1,10 @@
+package data
+
+type BranchENI struct {
+	ID            int64
+	BranchENI     string
+	AZ            string
+	AssociationID string
+	AccountID     string
+	Idx           int
+}

--- a/vpc/service/db/query.go
+++ b/vpc/service/db/query.go
@@ -482,3 +482,40 @@ func GetAllBranchENIsByAccountRegion(ctx context.Context, tx *sql.Tx, accountID,
 	}
 	return enis, nil
 }
+
+func GetOldestUnassignedBranchENI(ctx context.Context, tx *sql.Tx, subnet, trunkENI string) (*data.BranchENI, error) {
+	branchENI := &data.BranchENI{}
+	row := tx.QueryRowContext(ctx, `
+SELECT valid_branch_enis.id,
+       valid_branch_enis.branch_eni,
+       valid_branch_enis.association_id,
+       valid_branch_enis.az,
+       valid_branch_enis.account_id,
+       valid_branch_enis.idx
+FROM
+  (SELECT branch_enis.id,
+          branch_enis.branch_eni,
+          branch_enis.az,
+          branch_enis.account_id,
+          branch_eni_attachments.idx,
+          branch_eni_attachments.association_id,
+          branch_eni_attachments.created_at AS branch_eni_attached_at,
+     (SELECT count(*)
+      FROM assignments
+      WHERE assignments.branch_eni_association = branch_eni_attachments.association_id) AS c
+   FROM branch_enis
+   JOIN branch_eni_attachments ON branch_enis.branch_eni = branch_eni_attachments.branch_eni
+   WHERE subnet_id = $1
+     AND trunk_eni = $2
+     AND (SELECT count(*) FROM subnet_usable_prefix WHERE subnet_usable_prefix.branch_eni_id = branch_enis.id) > 0
+     AND state = 'attached') valid_branch_enis
+WHERE c = 0
+ORDER BY c DESC, branch_eni_attached_at ASC
+LIMIT 1`, subnet, trunkENI)
+	err := row.Scan(&branchENI.ID, &branchENI.BranchENI, &branchENI.AssociationID, &branchENI.AZ, &branchENI.AccountID, &branchENI.Idx)
+
+	if err != nil {
+		return nil, err
+	}
+	return branchENI, nil
+}

--- a/vpc/service/db/query.go
+++ b/vpc/service/db/query.go
@@ -483,9 +483,40 @@ func GetAllBranchENIsByAccountRegion(ctx context.Context, tx *sql.Tx, accountID,
 	return enis, nil
 }
 
-func GetOldestUnassignedBranchENI(ctx context.Context, tx *sql.Tx, subnet, trunkENI string) (*data.BranchENI, error) {
+// Get one branch ENI that is not assigned to any container
+// random: If true, select a random unassigned branch ENI. Otherwise, select the oldest one.
+func GetUnassignedBranchENI(ctx context.Context, tx *sql.Tx, subnet, trunkENI string, random bool) (*data.BranchENI, error) {
 	branchENI := &data.BranchENI{}
-	row := tx.QueryRowContext(ctx, `
+	var row *sql.Row
+	if random {
+		row = tx.QueryRowContext(ctx, `
+SELECT valid_branch_enis.id,
+       valid_branch_enis.branch_eni,
+       valid_branch_enis.association_id,
+       valid_branch_enis.az,
+       valid_branch_enis.account_id,
+       valid_branch_enis.idx
+FROM
+  (SELECT branch_enis.id,
+          branch_enis.branch_eni,
+          branch_enis.az,
+          branch_enis.account_id,
+          branch_eni_attachments.idx,
+          branch_eni_attachments.association_id,
+     (SELECT count(*)
+      FROM assignments
+      WHERE assignments.branch_eni_association = branch_eni_attachments.association_id) AS c
+   FROM branch_enis
+   JOIN branch_eni_attachments ON branch_enis.branch_eni = branch_eni_attachments.branch_eni
+   WHERE subnet_id = $1
+     AND trunk_eni = $2
+     AND (SELECT count(*) FROM subnet_usable_prefix WHERE subnet_usable_prefix.branch_eni_id = branch_enis.id) > 0
+     AND state = 'attached') valid_branch_enis
+WHERE c = 0
+ORDER BY RANDOM()
+LIMIT 1`, subnet, trunkENI)
+	} else {
+		row = tx.QueryRowContext(ctx, `
 SELECT valid_branch_enis.id,
        valid_branch_enis.branch_eni,
        valid_branch_enis.association_id,
@@ -512,6 +543,7 @@ FROM
 WHERE c = 0
 ORDER BY c DESC, branch_eni_attached_at ASC
 LIMIT 1`, subnet, trunkENI)
+	}
 	err := row.Scan(&branchENI.ID, &branchENI.BranchENI, &branchENI.AssociationID, &branchENI.AZ, &branchENI.AccountID, &branchENI.Idx)
 
 	if err != nil {

--- a/vpc/service/generate_assignment_id.go
+++ b/vpc/service/generate_assignment_id.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/service/data"
+	"github.com/Netflix/titus-executor/vpc/service/db"
 	"github.com/Netflix/titus-executor/vpc/service/ec2wrapper"
 	"github.com/Netflix/titus-executor/vpc/service/vpcerrors"
 	"github.com/Netflix/titus-executor/vpc/tracehelpers"
@@ -79,7 +80,7 @@ type assignment struct {
 	assignmentChangedSecurityGroups bool
 
 	trunk          string
-	branch         branchENI
+	branch         *data.BranchENI
 	securityGroups []string
 	subnet         *data.Subnet
 	bandwidth      uint64
@@ -93,7 +94,7 @@ type assignment struct {
 }
 
 func (a *assignment) String() string {
-	return fmt.Sprintf("Assignment{Name:%s, ID:%d, branch:%s, assoc:%s, transitionAssignmentID: %d}", a.assignmentName, a.assignmentID, a.branch.id, a.branch.associationID, a.transitionAssignmentID)
+	return fmt.Sprintf("Assignment{Name:%s, ID:%d, branch:%s, assoc:%s, transitionAssignmentID: %d}", a.assignmentName, a.assignmentID, a.branch.BranchENI, a.branch.AssociationID, a.transitionAssignmentID)
 }
 
 // TODO: Consider breaking this into its own module
@@ -164,7 +165,7 @@ func (vpcService *vpcService) generateAssignmentID(ctx context.Context, req getE
 	}
 
 	span.AddAttributes(
-		trace.StringAttribute("branch", ass.branch.id),
+		trace.StringAttribute("branch", ass.branch.BranchENI),
 		trace.StringAttribute("securityGroups", fmt.Sprint(req.securityGroups)),
 	)
 	if ass.assignmentChangedSecurityGroups {
@@ -339,7 +340,7 @@ func (vpcService *vpcService) updateBranchENISecurityGroups(ctx context.Context,
 
 	row := tx.QueryRowContext(ctx, `
 SELECT security_groups, dirty_security_groups FROM branch_enis WHERE branch_enis.branch_eni = $1
-FOR NO KEY UPDATE OF branch_enis`, ass.branch.id)
+FOR NO KEY UPDATE OF branch_enis`, ass.branch.BranchENI)
 
 	// Someone could have undirtied the security groups while we were away
 	var securityGroups []string
@@ -362,7 +363,7 @@ FOR NO KEY UPDATE OF branch_enis`, ass.branch.id)
 	}
 
 	_, err = ass.branchENISession.ModifyNetworkInterfaceAttribute(ctx, ec2.ModifyNetworkInterfaceAttributeInput{
-		NetworkInterfaceId: aws.String(ass.branch.id),
+		NetworkInterfaceId: aws.String(ass.branch.BranchENI),
 		Groups:             aws.StringSlice(ass.securityGroups),
 	})
 	if err != nil {
@@ -370,7 +371,7 @@ FOR NO KEY UPDATE OF branch_enis`, ass.branch.id)
 		return ec2wrapper.HandleEC2Error(err, span)
 	}
 
-	_, err = tx.ExecContext(ctx, "UPDATE branch_enis SET dirty_security_groups = false,  aws_security_groups_updated = transaction_timestamp() WHERE branch_eni = $1", ass.branch.id)
+	_, err = tx.ExecContext(ctx, "UPDATE branch_enis SET dirty_security_groups = false,  aws_security_groups_updated = transaction_timestamp() WHERE branch_eni = $1", ass.branch.BranchENI)
 	if err != nil {
 		err = errors.Wrap(err, "Unable to update database to set security groups to non-dirty")
 		tracehelpers.SetStatus(err, span)
@@ -544,10 +545,10 @@ WHERE c < $4
 ORDER BY c DESC, branch_eni_attached_at ASC
 LIMIT 1`, ass.subnet.SubnetID, ass.trunk, pq.Array(ass.securityGroups), req.maxIPAddresses)
 
-	err := row.Scan(&ass.branch.intid, &ass.branch.id, &ass.branch.associationID, &ass.branch.az, &ass.branch.accountID, &ass.branch.idx, &ass.assignmentChangedSecurityGroups)
+	err := row.Scan(&ass.branch.ID, &ass.branch.BranchENI, &ass.branch.AssociationID, &ass.branch.AZ, &ass.branch.AccountID, &ass.branch.Idx, &ass.assignmentChangedSecurityGroups)
 	if err == nil {
 		logger.WithLogger(ctx, logger.G(ctx).WithFields(map[string]interface{}{
-			"eni": ass.branch.id,
+			"eni": ass.branch.BranchENI,
 		}))
 		logger.G(ctx).Info("Found shared ENI for assignment")
 		return finishPopulateAssignmentUsingAlreadyAttachedENI(ctx, req, ass, fastTx)
@@ -560,52 +561,23 @@ LIMIT 1`, ass.subnet.SubnetID, ass.trunk, pq.Array(ass.securityGroups), req.maxI
 	}
 	logger.G(ctx).Debug("Falling back to trying to find ENI with any security groups")
 
-	row = fastTx.QueryRowContext(ctx, `
-SELECT valid_branch_enis.id,
-       valid_branch_enis.branch_eni,
-       valid_branch_enis.association_id,
-       valid_branch_enis.az,
-       valid_branch_enis.account_id,
-       valid_branch_enis.idx
-FROM
-  (SELECT branch_enis.id,
-          branch_enis.branch_eni,
-          branch_enis.az,
-          branch_enis.account_id,
-          branch_eni_attachments.idx,
-          branch_eni_attachments.association_id,
-          branch_eni_attachments.created_at AS branch_eni_attached_at,
-     (SELECT count(*)
-      FROM assignments
-      WHERE assignments.branch_eni_association = branch_eni_attachments.association_id) AS c
-   FROM branch_enis
-   JOIN branch_eni_attachments ON branch_enis.branch_eni = branch_eni_attachments.branch_eni
-   WHERE subnet_id = $1
-     AND trunk_eni = $2
-     AND (SELECT count(*) FROM subnet_usable_prefix WHERE subnet_usable_prefix.branch_eni_id = branch_enis.id) > 0
-     AND state = 'attached') valid_branch_enis
-WHERE c = 0
-ORDER BY c DESC, branch_eni_attached_at ASC
-LIMIT 1`, req.subnet.SubnetID, req.trunkENI)
-	err = row.Scan(&ass.branch.intid, &ass.branch.id, &ass.branch.associationID, &ass.branch.az, &ass.branch.accountID, &ass.branch.idx)
-	if err == sql.ErrNoRows {
-		err = vpcerrors.NewMethodNotPossibleError("populateAssignmentUsingAlreadyAttachedENI")
-		tracehelpers.SetStatus(err, span)
-		return err
-	}
-
+	ass.branch, err = db.GetOldestUnassignedBranchENI(ctx, fastTx, req.subnet.SubnetID, req.trunkENI)
 	if err != nil {
-		err = errors.Wrap(err, "Cannot scan branch ENIs")
+		if err == sql.ErrNoRows {
+			err = vpcerrors.NewMethodNotPossibleError("populateAssignmentUsingAlreadyAttachedENI")
+		} else {
+			err = errors.Wrap(err, "Cannot scan branch ENIs")
+		}
 		tracehelpers.SetStatus(err, span)
 		return err
 	}
 
 	logger.WithLogger(ctx, logger.G(ctx).WithFields(map[string]interface{}{
-		"eni": ass.branch.id,
+		"eni": ass.branch.BranchENI,
 	}))
 	logger.G(ctx).Info("Found associated ENI for assignment, with different security groups")
 	ass.assignmentChangedSecurityGroups = true
-	_, err = fastTx.ExecContext(ctx, "UPDATE branch_enis SET security_groups = $1, dirty_security_groups = true, modified_at = transaction_timestamp() WHERE branch_eni = $2", pq.Array(req.securityGroups), ass.branch.id)
+	_, err = fastTx.ExecContext(ctx, "UPDATE branch_enis SET security_groups = $1, dirty_security_groups = true, modified_at = transaction_timestamp() WHERE branch_eni = $2", pq.Array(req.securityGroups), ass.branch.BranchENI)
 	if err != nil {
 		err = errors.Wrap(err, "Could not update branch ENI security groups / dirty security groups")
 		tracehelpers.SetStatus(err, span)
@@ -621,8 +593,8 @@ func finishPopulateAssignmentUsingAlreadyAttachedENI(ctx context.Context, req ge
 	span.AddAttributes()
 
 	span.AddAttributes(
-		trace.StringAttribute("eni", ass.branch.id),
-		trace.StringAttribute("associationID", ass.branch.associationID),
+		trace.StringAttribute("eni", ass.branch.BranchENI),
+		trace.StringAttribute("associationID", ass.branch.AssociationID),
 		trace.StringAttribute("assignmentID", req.assignmentID),
 		trace.BoolAttribute("dirtySecurityGroups", ass.assignmentChangedSecurityGroups),
 	)
@@ -633,7 +605,7 @@ func finishPopulateAssignmentUsingAlreadyAttachedENI(ctx context.Context, req ge
 		transitionAssignmentName := fmt.Sprintf("t-%s", uuid.New().String())
 		_, err := fastTx.ExecContext(ctx,
 			"INSERT INTO assignments(branch_eni_association, assignment_id, is_transition_assignment, transition_last_used) VALUES ($1, $2, true, now()) ON CONFLICT (branch_eni_association) WHERE is_transition_assignment DO UPDATE SET transition_last_used = now()",
-			ass.branch.associationID, transitionAssignmentName)
+			ass.branch.AssociationID, transitionAssignmentName)
 		if err != nil {
 			err = errors.Wrap(err, "Cannot insert transition assignment")
 			tracehelpers.SetStatus(err, span)
@@ -641,7 +613,7 @@ func finishPopulateAssignmentUsingAlreadyAttachedENI(ctx context.Context, req ge
 		}
 
 		// This should never error because we just did an insert above that should be a noop.
-		row := fastTx.QueryRowContext(ctx, "SELECT id, ipv4addr FROM assignments WHERE is_transition_assignment = true AND branch_eni_association = $1", ass.branch.associationID)
+		row := fastTx.QueryRowContext(ctx, "SELECT id, ipv4addr FROM assignments WHERE is_transition_assignment = true AND branch_eni_association = $1", ass.branch.AssociationID)
 		err = row.Scan(&ass.transitionAssignmentID, &ipv4addr)
 		if err != nil {
 			err = errors.Wrap(err, "Cannot select ID from transition assignments")
@@ -656,7 +628,7 @@ func finishPopulateAssignmentUsingAlreadyAttachedENI(ctx context.Context, req ge
 	// for A/B tests.
 	row := fastTx.QueryRowContext(ctx,
 		"INSERT INTO assignments(branch_eni_association, assignment_id, jumbo, bandwidth, ceil, transition_assignment) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, jumbo, bandwidth, ceil",
-		ass.branch.associationID, req.assignmentID, req.jumbo, req.bandwidth, req.ceil, tid)
+		ass.branch.AssociationID, req.assignmentID, req.jumbo, req.bandwidth, req.ceil, tid)
 	err := row.Scan(&ass.assignmentID, &req.jumbo, &req.bandwidth, &req.ceil)
 	if err != nil {
 		err = errors.Wrap(err, "Cannot scan row / insert into assignments")
@@ -691,7 +663,7 @@ func (vpcService *vpcService) getENIAndAttach(ctx context.Context, req getENIReq
 	logger.G(ctx).Debug("Attaching new branch ENI")
 
 	var err error
-	var eni *branchENI
+	var eni *data.BranchENI
 	var workItem int
 
 	// 1
@@ -700,7 +672,7 @@ func (vpcService *vpcService) getENIAndAttach(ctx context.Context, req getENIReq
 		tracehelpers.SetStatus(err, span)
 		return err
 	}
-	logger.G(ctx).WithField("eni", eni.id).Debug("Got ENI to attach")
+	logger.G(ctx).WithField("eni", eni.BranchENI).Debug("Got ENI to attach")
 	// 2
 	workItem, err = vpcService.attachENI(ctx, req, eni, fastTx, slowTx)
 	if err != nil {
@@ -733,7 +705,7 @@ func (vpcService *vpcService) getENIAndAttach(ctx context.Context, req getENIReq
 	return nil
 }
 
-func (vpcService *vpcService) attachENI(ctx context.Context, req getENIRequest, eni *branchENI, fastTx, slowTx *sql.Tx) (int, error) {
+func (vpcService *vpcService) attachENI(ctx context.Context, req getENIRequest, eni *data.BranchENI, fastTx, slowTx *sql.Tx) (int, error) {
 	ctx, span := trace.StartSpan(ctx, "attachENI")
 	defer span.End()
 
@@ -795,11 +767,11 @@ func (vpcService *vpcService) attachENI(ctx context.Context, req getENIRequest, 
 	}
 
 	logger.G(ctx).WithFields(map[string]interface{}{
-		"branch": eni.id,
+		"branch": eni.BranchENI,
 		"trunk":  req.trunkENI,
 		"idx":    idx,
 	}).Debug("Trying to associate ENI")
-	workItem, err = vpcService.startAssociation(ctx, fastTx, slowTx, eni.id, req.trunkENI, int(idx))
+	workItem, err = vpcService.startAssociation(ctx, fastTx, slowTx, eni.BranchENI, req.trunkENI, int(idx))
 	if err != nil {
 		err = errors.Wrap(err, "Could not start association")
 		tracehelpers.SetStatus(err, span)
@@ -812,11 +784,11 @@ func (vpcService *vpcService) attachENI(ctx context.Context, req getENIRequest, 
 
 // This function may consume fastTx, and slowTx. Specifically, if it cannot find an ENI in the "warm pool", it will
 // create an ENI, which involves discarding the fastTx, and committing the slowTx
-func (vpcService *vpcService) getUnattachedBranchENIV3(ctx context.Context, fastTx, slowTx *sql.Tx, req getENIRequest, trunkLock *eniLockWrapper) (*branchENI, error) {
+func (vpcService *vpcService) getUnattachedBranchENIV3(ctx context.Context, fastTx, slowTx *sql.Tx, req getENIRequest, trunkLock *eniLockWrapper) (*data.BranchENI, error) {
 	ctx, span := trace.StartSpan(ctx, "getUnattachedBranchENIV3")
 	defer span.End()
 
-	var eni branchENI
+	var eni data.BranchENI
 
 	row := fastTx.QueryRowContext(ctx, `
 SELECT branch_enis.branch_eni,
@@ -841,10 +813,10 @@ WHERE branch_enis.subnet_id = $1
   AND (SELECT count(*) FROM subnet_usable_prefix WHERE subnet_usable_prefix.branch_eni_id = branch_enis.id) > 0
 ORDER BY branch_enis.security_groups = $3::text[] DESC 
 LIMIT 1`, req.subnet.SubnetID, req.trunkENIAccount, pq.Array(req.securityGroups))
-	err := row.Scan(&eni.id, &eni.az, &eni.accountID)
+	err := row.Scan(&eni.BranchENI, &eni.AZ, &eni.AccountID)
 	if err == nil {
 		span.AddAttributes(
-			trace.StringAttribute("eni", eni.id),
+			trace.StringAttribute("eni", eni.BranchENI),
 		)
 		return &eni, nil
 	} else if err != sql.ErrNoRows {

--- a/vpc/service/internal_apis.go
+++ b/vpc/service/internal_apis.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Netflix/titus-executor/api/netflix/titus"
 
+	"github.com/Netflix/titus-executor/vpc/service/data"
 	"github.com/Netflix/titus-executor/vpc/service/vpcerrors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -121,10 +122,10 @@ func (vpcService *vpcService) doAssociateTrunkNetworkInterface(ctx context.Conte
 		return nil, err
 	}
 
-	err = vpcService.ensureBranchENIPermissionV3(ctx, tx, trunkENIAccountID, branchENISession, &branchENI{
-		id:        branch,
-		az:        branchENIAZ,
-		accountID: branchENIAccountID,
+	err = vpcService.ensureBranchENIPermissionV3(ctx, tx, trunkENIAccountID, branchENISession, &data.BranchENI{
+		BranchENI: branch,
+		AZ:        branchENIAZ,
+		AccountID: branchENIAccountID,
 	})
 	if err != nil {
 		tracehelpers.SetStatus(err, span)


### PR DESCRIPTION
# Background

When assigning an IP to a task, the 4th step is to find a branch ENI for the assignment. The logic of this process is,
1) Find all attached branch ENIs that meet the following criteria. Among them, find one with the most number of assignments and earliest creation time. If such a branch ENI is found, use it. Otherwise goto 2).
* In the given subnet.
* Attached to the given trunk ENI.
* Security groups match the given security groups.
* Has at least one corresponding row in the `subnet_usable_prefix` table matching this branch ENI ID.
* The total number of IP addresses assigned to the ENI is less than the maximum allowed value of the given instance type.
2) If failing to find even one branch ENI meeting the above criteria, then try finding one with the same criteria except that a) the security groups can be anything and b) there is currently no IP assigned to this branch ENI yet. If such an ENI is found, update its security groups to the given ones, then use it. Otherwise goto 3).
3) Find an unattached branch ENI. First try finding one in the “warm pool”. That is, a branch ENI meeting the following criteria. If one is found, then use it. Otherwise goto 4)
* In the given subnet.
* In the same account with the trunk ENI OR there exists an ENI permission for the account that the trunk ENI is in.
* The branch ENI doesn’t have a row in the `branch_eni_attachments` table with state “attached”, “attaching” or “unattaching”.
* Security groups match the given security groups.
4) First find a usable IP prefix in the given subnet. Then create a new branch ENI with AWS [CreateNetworkInterface](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html) API with this IPv6 prefix and insert it into the `branch_enis` table. Also update the `subnet_usable_prefix` table to reflect the mapping. Insert the newly created branch ENI to the `branch_enis` table and also add a corresponding row to the `branch_eni_attachments` table.

# Problem

In step 2) above, when trying to find such a branch ENI, VPC service doesn't lock anything. Instead, optimistic locks are used, which means N-1 transactions will abort in the following situation:
1) N `AssignIPV3` requests happen concurrently.
2) All N request checks step 1) above but no branch ENI matching the requested security group found.
3) All N request checks step 2) above and they all found the same branch ENI. This is because the query gets the oldest unassigned branch ENI and there is only one oldest at any time.
4) All N request tries to update the branch ENI's security groups to what they requested.
5) Only the first request to commit the transaction can succeed. All other N-1 transactions must abort and retry.

This can explain why we see a lot of "Could not update branch ENI security groups / dirty security groups: pq: could not serialize access due to read/write dependencies among transactions" errors when there are a lot concurrent requests.

# Mitigation

This PR adds a dynamic config that can change the query in step 2) from finding the oldest unassigned branch ENI to a random branch ENI. This should mitigate the error. However, note that this won't solve the problem completely. It won't help when there is only 1 rather than multiple unassigned branch ENIs. I will first roll out this mitigation and then figure out a long-term solution.