### PR TITLE
vpctool: set default quantum for htb class

### DIFF
--- a/vpc/tool/container2/setup_container_linux.go
+++ b/vpc/tool/container2/setup_container_linux.go
@@ -662,6 +662,7 @@ func setupClass(ctx context.Context, assignmentBandwidth *vpcapi.AssignIPRespons
 		Ceil:    ceil,
 		Buffer:  uint32(math.Ceil(bytespersecond/netlink.Hz()+float64(mtu)) + 1),
 		Cbuffer: uint32(math.Ceil(ceilbytespersecond/netlink.Hz()+10*float64(mtu)) + 1),
+		Quantum: uint32(mtu) + framingOverhead,
 	}
 	class := netlink.NewHtbClass(classattrs, htbclassattrs)
 	logger.G(ctx).Debug("Setting up HTB class: ", class)


### PR DESCRIPTION
I see a bunch of:

HTB: quantum of class 1277B is big. Consider r2q change.

in my kernel logs when I start a container. This is because we don't set a
default quantum, so the kernel computes one that's too big and warns us
about it. After every setupClass(), we immediately call setupSubqdisc()
with an explicit quantum, so I don't think this makes any difference other
than silencing the warnings.
