### PR TITLE
TITUS-6124: don't concurrently access pod annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ test-local: | $(clean)
 	CGO_ENABLED=0 go test -short $(TEST_FLAGS) -covermode=count -coverprofile=coverage-local.out -coverpkg=github.com/Netflix/... ./... \
 	| tee /dev/stderr > test-local.log
 
+.PHONY: test-local-race
+test-local-race: | $(clean)
+	CGO_ENABLED=0 go test -short $(TEST_FLAGS) ./... | tee /dev/stderr >& test-local-race.log
+
 # run standalone tests against the docker container runtime
 .PHONY: test-standalone
 test-standalone: titus-agent | $(clean) $(builder)

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -29,11 +29,6 @@ import (
 type Task struct {
 	TaskID  string
 	Pod     *corev1.Pod
-	Mem     int64
-	CPU     int64
-	Gpu     int64
-	Disk    int64
-	Network int64
 }
 
 // Runner maintains in memory state for the Task runner

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -43,7 +43,6 @@ type Runner struct {
 	metricsTagger tagger // the presence of tagger indicates extra Atlas tag is enabled
 	runtime       runtimeTypes.Runtime
 	config        config.Config
-	pod           *corev1.Pod
 
 	container runtimeTypes.Container
 	watcher   *filesystems.Watcher
@@ -72,7 +71,6 @@ func StartTaskWithRuntime(ctx context.Context, task Task, m metrics.Reporter, rp
 		UpdatesChan:   make(chan Update, 10),
 		StoppedChan:   make(chan struct{}),
 		container:     container,
-		pod:           task.Pod,
 	}
 
 	rt, err := rp(ctx, runner.container, startTime)
@@ -187,7 +185,7 @@ func (r *Runner) runMainContainerAndStartSidecars(ctx context.Context, startTime
 	default:
 	}
 	r.maybeSetDefaultTags(ctx) // initialize metrics.Reporter default tags
-	containerNames := getContainerNames(r.pod)
+	containerNames := getContainerNames(r.container.Pod())
 	startingMsg := fmt.Sprintf("starting %d container(s): %s", len(containerNames), containerNames)
 	updateChan <- update{status: titusdriver.Starting, msg: startingMsg}
 

--- a/executor/runner/runner.go
+++ b/executor/runner/runner.go
@@ -149,7 +149,7 @@ func (r *Runner) prepareContainer(ctx context.Context) update {
 	}()
 	// When Create() returns the host may have been modified to create storage and pull the image.
 	// These steps may or may not have completed depending on if/where a failure occurred.
-	if err := r.runtime.Prepare(prepareCtx, r.pod); err != nil {
+	if err := r.runtime.Prepare(prepareCtx); err != nil {
 		r.metrics.Counter("titus.executor.launchTaskFailed", 1, nil)
 		logger.G(ctx).WithError(err).Error("Task failed to create main container")
 		// Treat registry pull errors as LOST and non-existent images as FAILED.
@@ -199,7 +199,7 @@ func (r *Runner) runMainContainerAndStartSidecars(ctx context.Context, startTime
 	}
 
 	logger.G(ctx).Info(startingMsg)
-	logDir, details, statusMessageChan, err := r.runtime.Start(ctx, r.pod)
+	logDir, details, statusMessageChan, err := r.runtime.Start(ctx)
 	if err != nil { // nolint: vetshadow
 		r.metrics.Counter("titus.executor.launchTaskFailed", 1, nil)
 		logger.G(ctx).WithError(err).Error("error starting container")

--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -145,6 +145,7 @@ func TestSendTerminalStatusUntilCleanup(t *testing.T) {
 	task := Task{
 		TaskID:  taskID,
 		Pod:     pod,
+		PodLock: &sync.Mutex{},
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
 		r.c = c
@@ -215,6 +216,7 @@ func TestCancelDuringPrepare(t *testing.T) { // nolint: gocyclo
 	task := Task{
 		TaskID:  taskID,
 		Pod:     pod,
+		PodLock: &sync.Mutex{},
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
 		r.c = c
@@ -297,6 +299,7 @@ func TestSendRedundantStatusMessage(t *testing.T) { // nolint: gocyclo
 	task := Task{
 		TaskID:  taskID,
 		Pod:     pod,
+		PodLock: &sync.Mutex{},
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
 		r.c = c

--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -46,7 +45,7 @@ type runtimeMock struct {
 	killCallback    func(c runtimeTypes.Container) error
 }
 
-func (r *runtimeMock) Prepare(ctx context.Context, pod *v1.Pod) error {
+func (r *runtimeMock) Prepare(ctx context.Context) error {
 	if r.c == nil {
 		panic("Container is nil")
 	}
@@ -57,7 +56,7 @@ func (r *runtimeMock) Prepare(ctx context.Context, pod *v1.Pod) error {
 	return nil
 }
 
-func (r *runtimeMock) Start(ctx context.Context, pod *v1.Pod) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
+func (r *runtimeMock) Start(ctx context.Context) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
 	r.t.Log("runtimeMock.Start", r.c.TaskID())
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/executor/runner/runner_test.go
+++ b/executor/runner/runner_test.go
@@ -144,11 +144,6 @@ func TestSendTerminalStatusUntilCleanup(t *testing.T) {
 	pod, _ := runtimeTypes.ContainerTestArgs()
 	task := Task{
 		TaskID:  taskID,
-		Mem:     1,
-		CPU:     1,
-		Gpu:     0,
-		Disk:    1,
-		Network: 1,
 		Pod:     pod,
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
@@ -219,11 +214,6 @@ func TestCancelDuringPrepare(t *testing.T) { // nolint: gocyclo
 	pod, _ := runtimeTypes.ContainerTestArgs()
 	task := Task{
 		TaskID:  taskID,
-		Mem:     1,
-		CPU:     1,
-		Gpu:     0,
-		Disk:    1,
-		Network: 1,
 		Pod:     pod,
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {
@@ -306,11 +296,6 @@ func TestSendRedundantStatusMessage(t *testing.T) { // nolint: gocyclo
 	pod, _ := runtimeTypes.ContainerTestArgs()
 	task := Task{
 		TaskID:  taskID,
-		Mem:     1,
-		CPU:     1,
-		Gpu:     0,
-		Disk:    1,
-		Network: 1,
 		Pod:     pod,
 	}
 	executor, err := StartTaskWithRuntime(ctx, task, metrics.Discard, func(ctx context.Context, c runtimeTypes.Container, startTime time.Time) (runtimeTypes.Runtime, error) {

--- a/executor/runtime/docker/capabilities_test.go
+++ b/executor/runtime/docker/capabilities_test.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"sync"
 	"testing"
 
 	runtimeTypes "github.com/Netflix/titus-executor/executor/runtime/types"
@@ -16,7 +17,7 @@ const (
 func TestDefaultProfile(t *testing.T) {
 	pod, conf, err := runtimeTypes.PodContainerTestArgs()
 	assert.NoError(t, err)
-	c, err := runtimeTypes.NewPodContainer(pod, *conf)
+	c, err := runtimeTypes.NewPodContainer(pod, &sync.Mutex{}, *conf)
 	assert.NoError(t, err)
 	hostConfig := container.HostConfig{}
 
@@ -32,7 +33,7 @@ func TestFuseProfile(t *testing.T) {
 	pod, conf, err := runtimeTypes.PodContainerTestArgs()
 	assert.NoError(t, err)
 	pod.Annotations[podCommon.AnnotationKeyPodFuseEnabled] = True
-	c, err := runtimeTypes.NewPodContainer(pod, *conf)
+	c, err := runtimeTypes.NewPodContainer(pod, &sync.Mutex{}, *conf)
 	assert.NoError(t, err)
 	hostConfig := container.HostConfig{}
 
@@ -53,7 +54,7 @@ func TestOverrideFuseProfile(t *testing.T) {
 	// Using the full pod spec, the apparmor profile is specified in an annotation
 	pod.Annotations[podCommon.AnnotationKeyPrefixAppArmor+"/"+runtimeTypes.MainContainerName] = "docker_foo"
 	pod.Annotations[podCommon.AnnotationKeyPodFuseEnabled] = True
-	c, err := runtimeTypes.NewPodContainer(pod, *conf)
+	c, err := runtimeTypes.NewPodContainer(pod, &sync.Mutex{}, *conf)
 	assert.NoError(t, err)
 	hostConfig := container.HostConfig{}
 

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1019,7 +1019,11 @@ func (r *DockerRuntime) Prepare(ctx context.Context) (err error) { // nolint: go
 	ctx = logger.WithField(ctx, "containerID", r.c.ID())
 	logger.G(ctx).Info("Main Container successfully created")
 
-	if len(r.c.Pod().Spec.Containers) > 1 {
+	pod, podLock := r.c.Pod()
+	hasExtraContainers := len(pod.Spec.Containers) > 1
+	podLock.Unlock()
+	if hasExtraContainers {
+
 		mainContainerRoot, err = r.inspectAndGetMainContainerRoot(ctx)
 		if err != nil {
 			return err
@@ -1033,7 +1037,7 @@ func (r *DockerRuntime) Prepare(ctx context.Context) (err error) { // nolint: go
 		if err != nil {
 			return err
 		}
-		err = r.createAllExtraContainers(ctx, r.c.Pod(), r.c.ID(), mainContainerRoot)
+		err = r.createAllExtraContainers(ctx, pod, r.c.ID(), mainContainerRoot)
 		if err != nil {
 			return err
 		}
@@ -1354,7 +1358,9 @@ func (r *DockerRuntime) Start(parentCtx context.Context) (string, *runtimeTypes.
 	}
 
 	// This sets up the tini listeners and pauses the workload
-	listeners, err := r.setupTiniListeners(ctx, r.c.Pod())
+	pod, podLock := r.c.Pod()
+	listeners, err := r.setupTiniListeners(ctx, pod)
+	podLock.Unlock()
 	if err != nil {
 		tracehelpers.SetStatus(err, span)
 		return "", nil, statusMessageChan, err
@@ -1537,18 +1543,21 @@ func connectToSpectatord(spectatordSocket string, attemptsLeft int) (net.Conn, e
 func (r *DockerRuntime) generateContainerStatusSpectatordMetrics() []string {
 	l := log.WithField("taskID", r.c.TaskID())
 	var metricLines []string
+	thePod, podLock := r.c.Pod()
+	defer podLock.Unlock()
+
 	// 1. Loop through all containers.
-	for _, c := range r.c.Pod().Status.ContainerStatuses {
+	for _, c := range thePod.Status.ContainerStatuses {
 		// 2. Get container metadata and state.
 		metricTags := make(map[string]string)
 		metricTags["nf.container"] = c.Name
-		metricTags["nf.process"] = processNameForContainer(c.Name, r.c.Pod())
+		metricTags["nf.process"] = processNameForContainer(c.Name, thePod)
 		imageName, imageVersion, err := imageNameAndDigest(c.Image, c.Name)
 		if err != nil {
 			l.WithError(err).Warn("Error getting image metric tags, skipping sending container status metric")
 			continue
 		}
-		if imageTag := pod.GetImageTagForContainer(c.Name, r.c.Pod()); imageTag != "" && imageName != "" {
+		if imageTag := pod.GetImageTagForContainer(c.Name, thePod); imageTag != "" && imageName != "" {
 			imageName = fmt.Sprintf("%s:%s", imageName, imageTag)
 		}
 		metricTags["titus.image.name"] = imageName
@@ -1599,7 +1608,10 @@ func imageNameAndDigest(image, containerName string) (name, digest string, err e
 func (r *DockerRuntime) generatePlatformSidecarSpectatordMetrics() []string {
 	l := log.WithField("taskID", r.c.TaskID())
 	var metricLines []string
-	for k, v := range r.c.Pod().Annotations {
+
+	thePod, podLock := r.c.Pod()
+	defer podLock.Unlock()
+	for k, v := range thePod.Annotations {
 		releaseSuffix := fmt.Sprintf(".%s/%s", pod.AnnotationKeySuffixSidecars, pod.AnnotationKeySuffixSidecarsRelease)
 		if !strings.HasSuffix(k, releaseSuffix) {
 			continue
@@ -2654,7 +2666,9 @@ func (r *DockerRuntime) runAllPreStopHooks(ctx context.Context) *multierror.Erro
 		errs = multierror.Append(errs, err)
 
 	}
-	err := r.runPreStopHookIfDefined(ctx, &r.c.Pod().Spec.Containers[0], r.c.ID())
+	pod, podLock := r.c.Pod()
+	defer podLock.Unlock()
+	err := r.runPreStopHookIfDefined(ctx, &pod.Spec.Containers[0], r.c.ID())
 	errs = multierror.Append(errs, err)
 	return errs
 }

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -872,7 +872,7 @@ func (r *DockerRuntime) Prepare(ctx context.Context, pod *v1.Pod) (err error) { 
 	if totalExtraContainerCount > 0 {
 		group.Go(func(ctx context.Context) error {
 			logger.G(ctx).Infof("Pulling %d other user/platform containers", totalExtraContainerCount)
-			return r.pullAllExtraContainers(ctx, pod)
+			return r.pullAllExtraContainers(ctx)
 		})
 	}
 
@@ -1713,7 +1713,7 @@ func (r *DockerRuntime) statusMonitor(cancel context.CancelFunc, containerID str
 	}
 }
 
-func (r *DockerRuntime) pullAllExtraContainers(ctx context.Context, pod *v1.Pod) error {
+func (r *DockerRuntime) pullAllExtraContainers(ctx context.Context) error {
 	l := log.WithField("taskID", r.c.TaskID())
 	// In this design, the first container has already been pulled, so we only look
 	// at the other containers here.

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -797,7 +797,7 @@ func (r *DockerRuntime) createVolumeContainer(ctx context.Context, containerName
 }
 
 // Prepare host state (pull images, create fs, create container, etc...)
-func (r *DockerRuntime) Prepare(ctx context.Context, pod *v1.Pod) (err error) { // nolint: gocyclo
+func (r *DockerRuntime) Prepare(ctx context.Context) (err error) { // nolint: gocyclo
 	var volumeContainers []string
 
 	ctx, cancel := context.WithTimeout(ctx, r.dockerCfg.prepareTimeout)
@@ -1019,7 +1019,7 @@ func (r *DockerRuntime) Prepare(ctx context.Context, pod *v1.Pod) (err error) { 
 	ctx = logger.WithField(ctx, "containerID", r.c.ID())
 	logger.G(ctx).Info("Main Container successfully created")
 
-	if len(pod.Spec.Containers) > 1 {
+	if len(r.c.Pod().Spec.Containers) > 1 {
 		mainContainerRoot, err = r.inspectAndGetMainContainerRoot(ctx)
 		if err != nil {
 			return err
@@ -1033,7 +1033,7 @@ func (r *DockerRuntime) Prepare(ctx context.Context, pod *v1.Pod) (err error) { 
 		if err != nil {
 			return err
 		}
-		err = r.createAllExtraContainers(ctx, pod, r.c.ID(), mainContainerRoot)
+		err = r.createAllExtraContainers(ctx, r.c.Pod(), r.c.ID(), mainContainerRoot)
 		if err != nil {
 			return err
 		}
@@ -1336,7 +1336,7 @@ func (r *DockerRuntime) setupLogsAndMisc(ctx context.Context, typedConn *net.Uni
 
 // Start runs an already created container. A watcher is created that monitors container state. The Status Message Channel is ONLY
 // valid if err == nil, otherwise it will block indefinitely.
-func (r *DockerRuntime) Start(parentCtx context.Context, pod *v1.Pod) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
+func (r *DockerRuntime) Start(parentCtx context.Context) (string, *runtimeTypes.Details, <-chan runtimeTypes.StatusMessage, error) {
 	ctx, cancel := context.WithTimeout(parentCtx, r.dockerCfg.startTimeout)
 	defer cancel()
 	ctx, span := trace.StartSpan(ctx, "Start")

--- a/executor/runtime/docker/docker_test.go
+++ b/executor/runtime/docker/docker_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
@@ -306,7 +307,7 @@ func TestGenerateContainerStatusSpectatordMetrics(t *testing.T) {
 			},
 		},
 	}
-	container, err := runtimeTypes.NewPodContainer(pod, config.Config{})
+	container, err := runtimeTypes.NewPodContainer(pod, &sync.Mutex{}, config.Config{})
 	assert.NoError(t, err)
 	runtime := &DockerRuntime{
 		c: container,
@@ -345,7 +346,7 @@ func TestGeneratePlatformSidecarSpectatordMetrics(t *testing.T) {
 			},
 		},
 	}
-	container, err := runtimeTypes.NewPodContainer(pod, config.Config{})
+	container, err := runtimeTypes.NewPodContainer(pod, &sync.Mutex{}, config.Config{})
 	assert.NoError(t, err)
 	runtime := &DockerRuntime{
 		c: container,

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -245,7 +245,9 @@ func shouldStartLogViewer(cfg *config.Config, c Container) bool {
 func shouldStartTitusStorage(cfg *config.Config, c Container) bool {
 	// Currently titus-storage sets up NFS, EBS, and /mnt-shared storage
 	// which is currently only available on multi-container workloads
-	return len(c.NFSMounts()) > 0 || c.EBSInfo().VolumeID != "" || len(c.Pod().Spec.Containers) > 1
+	pod, podLock := c.Pod()
+	defer podLock.Unlock()
+	return len(c.NFSMounts()) > 0 || c.EBSInfo().VolumeID != "" || len(pod.Spec.Containers) > 1
 }
 
 func shouldStartContainerTools(cfg *config.Config, c Container) bool {

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Netflix/titus-executor/config"
@@ -196,7 +197,7 @@ type Container interface {
 	NFSMounts() []NFSMount
 	OomScoreAdj() *int32
 	OwnerEmail() *string
-	Pod() *v1.Pod
+	Pod() (*v1.Pod, *sync.Mutex)
 	Process() ([]string, []string)
 	QualifiedImageName() string
 	Resources() *Resources

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -507,9 +507,9 @@ type Runtime interface {
 	// TODO(fabio): better (non-Docker specific) abstraction for binds
 	// The context passed to the Prepare, and Start function is valid over the lifetime of the container,
 	// NOT per-operation
-	Prepare(containerCtx context.Context, pod *corev1.Pod) error
+	Prepare(containerCtx context.Context) error
 	// Start a container -- Returns an optional Log Directory if an external Logger is desired
-	Start(containerCtx context.Context, pod *corev1.Pod) (string, *Details, <-chan StatusMessage, error)
+	Start(containerCtx context.Context) (string, *Details, <-chan StatusMessage, error)
 	// Kill a container. MUST be idempotent.
 	Kill(ctx context.Context, wasKilled bool) error
 	// Cleanup can be called to tear down resources after a container has been Killed or has naturally

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -525,11 +525,6 @@ func StartTestTask(t *testing.T, ctx context.Context, jobInput *JobInput) (*JobR
 	}
 
 	task := runner.Task{
-		Mem:     memMiB,
-		CPU:     cpu,
-		Gpu:     gpu,
-		Disk:    diskMiB,
-		Network: network,
 		TaskID:  taskID,
 	}
 

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -526,6 +527,7 @@ func StartTestTask(t *testing.T, ctx context.Context, jobInput *JobInput) (*JobR
 
 	task := runner.Task{
 		TaskID:  taskID,
+		PodLock: &sync.Mutex{},
 	}
 
 	tErr := createPodTask(jobInput, jobID, &task, env, resources, cfg)

--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -148,7 +149,7 @@ func dockerPull(t *testing.T, imgName string, imgDigest string) (*dockerTypes.Im
 	assert.NoError(t, err)
 	pod.Spec.Containers[0].Image = imgName + "@" + imgDigest
 
-	c, err := runtimeTypes.NewPodContainer(pod, *conf)
+	c, err := runtimeTypes.NewPodContainer(pod, &sync.Mutex{}, *conf)
 	assert.NoError(t, err)
 
 	res, err := drt.DockerPull(ctx, c)

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -171,11 +171,6 @@ func (b *Backend) run(ctx context.Context) (*runner.Runner, error) {
 	r, err := runner.StartTaskWithRuntime(ctx, runner.Task{
 		TaskID:  b.pod.GetName(),
 		Pod:     b.pod,
-		Mem:     b.memory.Value(),
-		CPU:     b.cpu.Value(),
-		Gpu:     b.gpu.Value(),
-		Disk:    b.disk.Value(),
-		Network: b.network.Value(),
 	}, b.m, b.rp, *b.cfg)
 	b.readyErr = err
 


### PR DESCRIPTION
We have the following reports from titus-executor version
9f4c02f81575ec31915c3fb0be5ebfeaffec7e8c (with a bit of an ordering issue
in the stack trace because I am unsure how to sort kibana logs exactly):

...
started 1 container(s): [main], now monitoring for container status
Starting external logger
uploading using writer role
starting watchLoop
Processing msg from a container: '\x01' - main container is now running
Updating Task status
fatal error: concurrent map iteration and map write
Updated pod dir
goroutine 382 [running]:
runtime.throw({0x1222ead, 0xc000d17740})
	/usr/local/go/src/runtime/panic.go:1198 +0x71 fp=0xc000d176e0 sp=0xc000d176b0 pc=0x433891
runtime.mapiternext(0x11f1d9c)
	/usr/local/go/src/runtime/map.go:858 +0x4eb fp=0xc000d17750 sp=0xc000d176e0 pc=0x40f8eb
github.com/Netflix/titus-executor/executor/runtime/docker.(*DockerRuntime).generatePlatformSidecarSpectatordMetrics(0xc000968380)
	/var/lib/buildkite-agent/builds/ip-192-168-1-90-1/netflix/titus-executor/executor/runtime/docker/docker.go:1598 +0x10e fp=0xc000d17a18 sp=0xc000d17750 pc=0xf3e8ae
github.com/Netflix/titus-executor/executor/runtime/docker.(*DockerRuntime).periodicallyReportTaskMetrics(0xc000968380, {0x145a290, 0xc000912000})
	/var/lib/buildkite-agent/builds/ip-192-168-1-90-1/netflix/titus-executor/executor/runtime/docker/docker.go:1505 +0x21d fp=0xc000d17fb8 sp=0xc000d17a18 pc=0xf3d2bd
github.com/Netflix/titus-executor/executor/runtime/docker.(*DockerRuntime).Start·dwrap·14()
	/var/lib/buildkite-agent/builds/ip-192-168-1-90-1/netflix/titus-executor/executor/runtime/docker/docker.go:1476 +0x2e fp=0xc000d17fe0 sp=0xc000d17fb8 pc=0xf3ce8e
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc000d17fe8 sp=0xc000d17fe0 pc=0x463fc1
created by github.com/Netflix/titus-executor/executor/runtime/docker.(*DockerRuntime).Start
	/var/lib/buildkite-agent/builds/ip-192-168-1-90-1/netflix/titus-executor/executor/runtime/docker/docker.go:1476 +0x16b6
goroutine 1 [select]:
github.com/Netflix/titus-executor/vk/backend.(*Backend).RunWithOutputDir(0xc000a46000, {0x145a338, 0xc000311440}, {0x7ffc2d1ac6ee, 0x41})
	/var/lib/buildkite-agent/builds/ip-192-168-1-90-1/netflix/titus-executor/vk/backend/backend.go:246 +0x565
main.mainWithError({0x145a338, 0xc000311440}, 0xc000564480, 0xc0003b38c0, 0xc0003113e0, {0x145a488, 0xc0001b2108})
	/var/lib/buildkite-agent/builds/ip-192-168-1-90-1/netflix/titus-executor/cmd/titus-executor-backend/main.go:184 +0x14c5
main.main.func1(0xc00091a000)
	/var/lib/buildkite-agent/builds/ip-192-168-1-90-1/netflix/titus-executor/cmd/titus-executor-backend/main.go:103 +0x209
github.com/urfave/cli.HandleAction({0x101b100, 0xc000178870}, 0xc0002da540)
	/tmp/gopath/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:524 +0xa8
github.com/urfave/cli.(*App).Run(0xc0002da540, {0xc0001be000, 0x2, 0x2})
	/tmp/gopath/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:286 +0x625
main.main()
	/var/lib/buildkite-agent/builds/ip-192-168-1-90-1/netflix/titus-executor/cmd/titus-executor-backend/main.go:109 +0xc69
goroutine 18 [chan receive]:
k8s.io/klog/v2.(*loggingT).flushDaemon(0x0)
	/tmp/gopath/pkg/mod/k8s.io/klog/v2@v2.30.0/klog.go:1181 +0x6a
created by k8s.io/klog/v2.init.0
	/tmp/gopath/pkg/mod/k8s.io/klog/v2@v2.30.0/klog.go:420 +0xfb
goroutine 19 [select]:
github.com/Netflix/metrics-client-go/metrics.(*reporter).readLoop(0xc0001bac60, 0x0, 0x0)
	/tmp/gopath/pkg/mod/github.com/!netflix/metrics-client-go@v0.0.0-20171019173821-bb173f41fc07/metrics/reporter.go:150 +0x1ee
created by github.com/Netflix/metrics-client-go/metrics.WithURLInterval
	/tmp/gopath/pkg/mod/github.com/!netflix/metrics-client-go@v0.0.0-20171019173821-bb173f41fc07/metrics/reporter.go:70 +0x24f

this corresponds to an iteration over the pod annotations:

    for k, v := range r.c.Pod().Annotations

which it seems like we can concurrently modify in vk:

    // These annotations allow us to get data "back out" from the executor up to the control-plane, without having
    // to depend on the limitations of the PodStatus structure.
    b.podLock.Lock()
    defer b.podLock.Unlock()
    for k, v := range update.Details.NetworkConfiguration.ToAnnotationMap() {
	    b.pod.Annotations[k] = v
    }

Passing this lock around is a bit of a hack, but that seems (?) easier than
trying to fix whatever that comment is referencing, which I don't quite
understand.

Seems like this race has existed for a while, but has probably been more easily
triggerable since I added my log parsing code, which probably delays container
setup a few ms or something.
