### PR TITLE
networking: waitpid() on titus-vpc-tool setup-container

### DIFF
--- a/executor/runtime/docker/networking.go
+++ b/executor/runtime/docker/networking.go
@@ -218,6 +218,7 @@ func setupNetworking(ctx context.Context, burst bool, c runtimeTypes.Container, 
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not start setup command")
 	}
+	defer setupCommand.Wait() // nolint: errcheck
 
 	allocation := c.VPCAllocation()
 	marshaler := protojson.MarshalOptions{


### PR DESCRIPTION
It looks like we are leaking vpc tool invocations on successful container
network setup:

root      549470  0.1  0.0 734360 35044 ?        Ssl  Jul26  23:40 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__364844c1-300f-4875-98ce-caa03e6b0dea
root      554607  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549475  0.1  0.0 735384 34508 ?        Ssl  Jul26  23:04 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__6081f90e-e9a1-4eba-bc70-42011aaeac39
root      554471  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549493  0.1  0.0 735640 37460 ?        Ssl  Jul26  23:36 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__325de4f7-da94-468c-942c-7d5b35659e81
root      554606  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549505  0.1  0.0 734872 34848 ?        Ssl  Jul26  23:58 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__ff33448e-a67e-48d2-b19c-0631930ea46f
root      554601  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549527  0.1  0.0 735896 35300 ?        Ssl  Jul26  23:17 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__36d5be56-a260-480f-ae46-75f7dc05e362
root      554472  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549563  0.1  0.0 734872 35044 ?        Ssl  Jul26  23:01 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__3f574ed0-8142-4fba-ad78-4136f61e03a9
root      554473  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549596  0.1  0.0 734360 34336 ?        Ssl  Jul26  25:00 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__ff0a5c8c-7cd8-425d-8f09-c7ed99010eaa
root      554686  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549624  0.1  0.0 735128 36136 ?        Ssl  Jul26  24:38 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__5bce4d05-9065-49f4-9f81-bd7811602e8c
root      554902  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549674  0.1  0.0 735384 36012 ?        Ssl  Jul26  22:05 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__df4f29d5-b188-4d4c-8c9a-b542a5378256
root      555720  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549718  0.1  0.0 802780 44060 ?        Ssl  Jul26  22:50 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__3a25de2d-4084-4952-a4c9-8dfc61349b4c
root      555027  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549777  0.1  0.0 735128 35420 ?        Ssl  Jul26  22:43 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__942fc7c5-2868-4b4d-ba6e-c8fffae8740f
root      555459  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549826  0.1  0.0 734616 34632 ?        Ssl  Jul26  22:42 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__31150f90-2ccd-4e7b-a3d1-520342151a5d
root      555550  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      549931  0.1  0.0 735640 35172 ?        Ssl  Jul26  24:02 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__ea980c7e-9aa0-4bcd-b52b-8751c6403549
root      556204  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      550049  0.1  0.0 734872 35332 ?        Ssl  Jul26  23:52 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__c9b1a465-f67b-4ce3-b363-bf67f5a3a49f
root      555904  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      550143  0.1  0.0 733848 43432 ?        Ssl  Jul26  24:11 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__c7ecb60b-29e7-4a41-8ed7-e7011b9f6d66
root      556551  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      550339  0.1  0.0 734872 35408 ?        Ssl  Jul26  22:05 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__aea5f317-79fc-4293-b93a-447e1075d5c7
root      557373  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      550402  0.1  0.0 734616 42992 ?        Ssl  Jul26  22:37 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__19be092a-28ca-476d-9539-e8b5bb1b2d76
root      557533  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      550549  0.1  0.0 733848 34992 ?        Ssl  Jul26  22:32 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__16bde7ad-bde2-47d9-916c-1a6bff682f40
root      557704  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      550620  0.1  0.0 734616 36536 ?        Ssl  Jul26  24:25 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__bf803224-a79b-4f82-aeeb-03113a95c7e2
root      558961  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      550663  0.1  0.0 735640 35112 ?        Ssl  Jul26  22:50 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__38ef50cf-ef95-4050-b5e5-3b41645b559c
root      557849  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      550785  0.1  0.0 802780 33600 ?        Ssl  Jul26  22:50 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__6a30ac6f-8ef2-4bf6-9958-a4d7efac3b45
root      559764  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      551068  0.1  0.0 735128 36628 ?        Ssl  Jul26  24:31 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__c9b5a59d-056f-44f5-b6d3-93ccb5fd340e
root      560688  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      551123  0.1  0.0 734104 33356 ?        Ssl  Jul26  24:31 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__4b6ebb2a-5b88-41e1-bca2-35d99d17696f
root      560798  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      551294  0.1  0.0 734616 33952 ?        Ssl  Jul26  23:24 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__f8931edc-166f-49e0-bb6c-9eb109cba75f
root      554594  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      551377  0.1  0.0 734872 36224 ?        Ssl  Jul26  23:19 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__fc2f8365-e3ee-438e-818a-ec13599d3f5b
root      554465  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      551448  0.1  0.0 734360 35556 ?        Ssl  Jul26  22:46 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__ed909c4d-0a2a-4fa4-a364-c167eb55ab87
root      559352  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      551591  0.1  0.0 734616 35976 ?        Ssl  Jul26  24:05 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__54b97513-d75a-4ee8-82f4-ffc83155b99f
root      559652  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      551689  0.1  0.0 734360 34728 ?        Ssl  Jul26  23:02 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__b42e3c30-0f86-47d3-b4ec-6bc312224341
root      560427  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>
root      551859  0.1  0.0 733848 34416 ?        Ssl  Jul26  23:40 /apps/titus-executor/bin/titus-executor-backend --runtime-dir=/run/titus-executor/default__fad05840-cb1d-4a30-bef1-34ac3842ed83
root      561145  0.0  0.0      0     0 ?        Z    Jul26   0:00  \_ [titus-vpc-tool] <defunct>

Not the end of the world, but it is annoying if you're grepping for
zombies, plus it eats up some pids.

It also looks like other vpc tool invocations don't use deferred wait, so
on some failure paths they will also leaked. Probably doesn't make much
difference, as they'll likely soon be reparented to init and init will reap
them, but worth fixing maybe.