### PR TITLE
Vpc service gc transition assignment

### DIFF
--- a/cmd/titus-vpc-tool/gc.go
+++ b/cmd/titus-vpc-tool/gc.go
@@ -34,8 +34,9 @@ func gcCommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentit
 					iipGetter(),
 					conn,
 					gc3.Args{
-						KubernetesPodsURL: v.GetString("kubernetes-pods-url"),
-						SourceOfTruth:     v.GetString(sourceOfTruthFlagName),
+						KubernetesPodsURL:      v.GetString("kubernetes-pods-url"),
+						SourceOfTruth:          v.GetString(sourceOfTruthFlagName),
+						TransitionNamespaceDir: v.GetString(transitionNSDirFlagName),
 					},
 				)
 			default:
@@ -47,6 +48,7 @@ func gcCommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentit
 	cmd.Flags().Duration("timeout", 10*time.Minute, "How long to allow the GC to run for")
 	cmd.Flags().String(sourceOfTruthFlagName, "kubernetes", "What to use as the source of truth?")
 	cmd.Flags().String("kubernetes-pods-url", "https://localhost:10250/pods", "The source of truth URL (pods or state.json)")
+	cmd.Flags().String(transitionNSDirFlagName, transitionNSDirDefaultValue, "Directory that transition namespaces are mounted into")
 	addSharedFlags(cmd.Flags())
 
 	return cmd

--- a/cmd/titus-vpc-tool/main.go
+++ b/cmd/titus-vpc-tool/main.go
@@ -30,14 +30,15 @@ const (
 	serviceAddrDefaultValue = "localhost:7001"
 	zipkinURLFlagName       = "zipkin"
 	// which generation of titus-vpc-tool version to use, it must be set to 1 or 2
-	generationFlagName      = "generation"
-	generationDefaultValue  = "v0"
-	interaceSubnet          = "interface-subnet"
-	interfaceAccount        = "interface-account"
-	sslCAFlagName           = "ssl-ca"
-	sslKeyFlagName          = "ssl-key"
-	sslCertFlagName         = "ssl-cert"
-	transitionNSDirFlagName = "transition-namespace-dir"
+	generationFlagName          = "generation"
+	generationDefaultValue      = "v0"
+	interaceSubnet              = "interface-subnet"
+	interfaceAccount            = "interface-account"
+	sslCAFlagName               = "ssl-ca"
+	sslKeyFlagName              = "ssl-key"
+	sslCertFlagName             = "ssl-cert"
+	transitionNSDirFlagName     = "transition-namespace-dir"
+	transitionNSDirDefaultValue = "/run/transition"
 )
 
 type instanceProviderResolver struct {

--- a/cmd/titus-vpc-tool/setup_container.go
+++ b/cmd/titus-vpc-tool/setup_container.go
@@ -28,6 +28,6 @@ func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter ins
 
 	cmd.Flags().Int("pid-1-dir-fd", 3, "The File Descriptor # of the pid 1 directory to setup")
 	cmd.Flags().String(generationFlagName, generationDefaultValue, "Generation of VPC Tool to use, specify v1, or v2")
-	cmd.Flags().String(transitionNSDirFlagName, "/run/transition", "Directory to mount transition namespaces into")
+	cmd.Flags().String(transitionNSDirFlagName, transitionNSDirDefaultValue, "Directory to mount transition namespaces into")
 	return cmd
 }

--- a/vpc/service/assign_addresses_v3.go
+++ b/vpc/service/assign_addresses_v3.go
@@ -1178,6 +1178,7 @@ func (vpcService *vpcService) UnassignIPV3(ctx context.Context, req *vpcapi.Unas
 		tracehelpers.SetStatus(err, span)
 		return nil, err
 	}
+	logger.G(ctx).WithError(err).Info("Successfully unassigned IP")
 	return resp, nil
 }
 
@@ -1219,7 +1220,15 @@ func (vpcService *vpcService) doUnassignIPV3(ctx context.Context, req *vpcapi.Un
 		_ = tx.Rollback()
 	}()
 
-	row := tx.QueryRowContext(ctx, "DELETE FROM assignments WHERE assignment_id = $1 RETURNING assignments.ipv4addr, assignments.ipv6addr, assignments.branch_eni_association", req.TaskId)
+	// For regular assignment, just delete it because it's not possible to be reused.
+	// For transition assignment, delete only if the tombstone is set. Because a concurrent AssignIPV3 request could
+	// have reused the transition assignment and unset the tombstone.
+	row := tx.QueryRowContext(ctx, `
+		DELETE FROM assignments WHERE assignment_id = $1 AND 
+									((NOT is_transition_assignment) OR 
+									(is_transition_assignment AND gc_tombstone IS NOT NULL))
+		RETURNING assignments.ipv4addr, assignments.ipv6addr, assignments.branch_eni_association
+	`, req.TaskId)
 	var ipv4, ipv6 sql.NullString
 	var association string
 	err = row.Scan(&ipv4, &ipv6, &association)

--- a/vpc/service/generate_assignment_id.go
+++ b/vpc/service/generate_assignment_id.go
@@ -614,8 +614,12 @@ func finishPopulateAssignmentUsingAlreadyAttachedENI(ctx context.Context, req ge
 	if req.transitionAssignmentRequested {
 		var ipv4addr sql.NullString
 		transitionAssignmentName := fmt.Sprintf("t-%s", uuid.New().String())
-		_, err := fastTx.ExecContext(ctx,
-			"INSERT INTO assignments(branch_eni_association, assignment_id, is_transition_assignment, transition_last_used) VALUES ($1, $2, true, now()) ON CONFLICT (branch_eni_association) WHERE is_transition_assignment DO UPDATE SET transition_last_used = now()",
+		_, err := fastTx.ExecContext(ctx, `
+			INSERT INTO assignments(branch_eni_association, assignment_id, is_transition_assignment, transition_last_used) 
+						VALUES ($1, $2, true, now()) 
+			ON CONFLICT (branch_eni_association) 
+			WHERE is_transition_assignment 
+			DO UPDATE SET transition_last_used = now(), gc_tombstone = NULL`,
 			ass.branch.AssociationID, transitionAssignmentName)
 		if err != nil {
 			err = errors.Wrap(err, "Cannot insert transition assignment")

--- a/vpc/tool/container2/setup_container_unsupported.go
+++ b/vpc/tool/container2/setup_container_unsupported.go
@@ -21,3 +21,7 @@ func DoTeardownContainer(ctx context.Context, allocation *vpcapi.AssignIPRespons
 func TeardownNetwork(ctx context.Context, allocation *vpcapi.AssignIPResponseV3) error {
 	return types.ErrUnsupported
 }
+
+func TeardownTransitionNetwork(ctx context.Context, transitionNamespaceDir string, transitionNamespaceID string) error {
+	return types.ErrUnsupported
+}


### PR DESCRIPTION
# Background

When an `AssignIPV3` API is called with `transitionRequested=true`, it will create a transition assignment if one doesn't already exist. Then VPC tool receives the transition assignment in the response. VPC tool will create a transition namespace and mount it to `/run/transition/<transition-assignment-id>` if one doesn't exist. On one instance, multiple containers using the same branch ENI will share one transition assignment. 

# Problem

Currently, the transition assignments are not recycled. That means, even if a transition assignment is no longer used by any containers, the transition namespace will live on the instance forever and the IP allocated to this transition assignment will not be recycled. This will waste some IPv4 addresses and thus increase the state size.

# Solution

This PR reuses the GC assignment mechanism to also GC transition assignment. Specifically, 
1) In `GCV3` API, set tombstone for all unused transition assignments on the instance in addition to regular assignments. 
2) When VPC tool receives assignments to remove from `GCV3` API response, for regular assignments, tear down the container network as usual; for transition assignments, tear down the transition network namespace.
3) After tearing down the transition network namespace, VPC tool calls `UnassignIPV3` API to eventually delete the transition assignment from VPC service and thus release its IPv4 address.

# Race condition
One race condition to be aware is that, it's possible that when `UnassignIPV3` is called to delete the transition assignment, another concurrent `AssignIPV3` API may decide to reuse it. Because 1) both transition assignment reuse and deletion are in a transaction and 2) the reuse transaction is a serializable transaction, we can cover the case by a) set tombstone to NULL when reusing and b) delete only if tombstone is set.

Then, there are only 2 cases:

## Case 1: Delete then update
|  TX A                                                                                       | TX B                                                                                     |
| -------------------------------------------------------- | ------------------------------------------------------ |
| `UnassignIPV3` deletes transition assignments "t-123"   |                                                                                              |
|                                                                                                  |  `AssignIPV3` updates "t-123" tombstone to be NULL |
|  COMMIT                                                                                 |                                                                                              |
|                                                                                                  |   Rollback since the row is deleted, will retry                   |

## Case 2: Update then delete
|  TX A                                                                                       | TX B                                                                                     |
| -------------------------------------------------------- | ------------------------------------------------------ |
|                                                                                                  | `AssignIPV3` updates "t-123" tombstone to be NULL  |
| `UnassignIPV3` deletes transition assignments "t-123"   |                                                                                              |
|                                                                                                  |  COMMIT                                                                             |
|   Rollback since the tombstone is NULL, will skip               |                                                                                              |
