### PR TITLE
Fix a VPC Service crash

### DIFF
--- a/vpc/service/generate_assignment_id.go
+++ b/vpc/service/generate_assignment_id.go
@@ -148,6 +148,7 @@ func (vpcService *vpcService) generateAssignmentID(ctx context.Context, req getE
 
 	ass := &assignment{
 		trunk:            req.trunkENI,
+		branch:           &data.BranchENI{}, // Will be populated in populateAssignment
 		assignmentName:   req.assignmentID,
 		securityGroups:   req.securityGroups,
 		subnet:           req.subnet,
@@ -556,6 +557,9 @@ WHERE c < $4
 ORDER BY c DESC, branch_eni_attached_at ASC
 LIMIT 1`, ass.subnet.SubnetID, ass.trunk, pq.Array(ass.securityGroups), req.maxIPAddresses)
 
+	if ass.branch == nil {
+		ass.branch = &data.BranchENI{}
+	}
 	err := row.Scan(&ass.branch.ID, &ass.branch.BranchENI, &ass.branch.AssociationID, &ass.branch.AZ, &ass.branch.AccountID, &ass.branch.Idx, &ass.assignmentChangedSecurityGroups)
 	if err == nil {
 		logger.WithLogger(ctx, logger.G(ctx).WithFields(map[string]interface{}{

--- a/vpc/service/trunk_enis.go
+++ b/vpc/service/trunk_enis.go
@@ -335,7 +335,7 @@ RETURNING id
 		return err
 	}
 
-	_, err = tx.ExecContext(ctx, "INSERT INTO htb_classid(trunk_eni, class_id) SELECT $1, generate_series(10010, 11000)", id)
+	_, err = tx.ExecContext(ctx, "INSERT INTO htb_classid(trunk_eni, class_id) SELECT $1, generate_series(10010, 11000) ON CONFLICT DO NOTHING", id)
 	if err != nil {
 		err = errors.Wrap(err, "Cannot get generate HTB class ID slots")
 		return err


### PR DESCRIPTION
### Description of the Change

In [this PR](https://github.com/Netflix/titus-executor/pull/935), I changed `branch` field in `assignment` to be a pointer but forgot to initialize it. That caused a nil pointer reference error during `AssignIPV3` call.

The problem was caught in staging. Ideally, there should be an E2E CI test to catch it. The test case is to be added.