### PR TITLE
CODEOWNERS: fix wildcard match

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
-* @solarkennedy
-* @tych0
+* @solarkennedy @tych0 @nickbp
 
 /vpc/ @aloktiagi @DonavanFritz @MyUmmaGumma @hechaoli @jromero-nflx
 


### PR DESCRIPTION
The docs https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
say:

    # Order is important; the last matching pattern takes the most
    # precedence.

so I think Kyle would never get a review request; let's align this with the
rest of the file and just put everything on the same line.
