### PR TITLE
docker: set fd limit for containers

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -477,7 +477,12 @@ func (r *DockerRuntime) mainContainerDockerConfig(c runtimeTypes.Container, bind
 		Soft: ((c.Resources().Disk * MiB) + 1*GiB),
 		Hard: ((c.Resources().Disk * MiB) + 1*GiB),
 	}
-	hostCfg.Ulimits = []*units.Ulimit{coreLimit}
+	fdLimit := &units.Ulimit{
+		Name: "nofile",
+		Soft: 100000,
+		Hard: 100000,
+	}
+	hostCfg.Ulimits = []*units.Ulimit{coreLimit, fdLimit}
 
 	// This is just factored out mutation of these objects to make the code cleaner.
 	r.setupLogs(c, hostCfg)


### PR DESCRIPTION
There was a limit before, but it was docker's default at a bit over 1M:

open files                          (-n) 1048576

let's drop it to a more reasonable 100k.
