### PR TITLE
Use nfpm instead of fpm for packaging

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -9,11 +9,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install curl && 
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     apt-get install -y build-essential make cmake g++ gcc libc6-dev pkg-config \
-        libattr1-dev git curl wget jq ruby ruby-dev rubygems lintian unzip bison flex clang llvm musl-tools \
+        libattr1-dev git curl wget jq lintian unzip bison flex clang llvm musl-tools \
         linux-libc-dev=5.17.1-1~exp1 libcap-dev libseccomp-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN gem install --no-ri --no-rdoc fpm
+RUN wget -q https://github.com/goreleaser/nfpm/releases/download/v2.18.1/nfpm_amd64.deb && dpkg -i nfpm_amd64.deb && rm nfpm_amd64.deb
 
 COPY --from=golang:1.17-stretch /usr/local/go /usr/local/go
 ENV GOPATH /go

--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -35,88 +35,32 @@ install -t root/apps/titus-executor/bin build/bin/linux-amd64/*
 
 
 ## Setup the environment
-
 outdir="$(mktemp -d)"
-git_sha=$(git rev-parse --verify HEAD)
-git_sha_short=${git_sha:0:8}
-version=${version:-$(git describe --tags --long)}
-iteration="--iteration ${ITERATION:-$(date +%s)}"
+export git_sha=$(git rev-parse --verify HEAD)
+export git_sha_short=${git_sha:0:8}
+export version=${version:-$(git describe --tags --long)}
+export iteration="--iteration ${ITERATION:-$(date +%s)}"
 
 # when on CI/Jenkins
 if [[ -n "${BUILD_NUMBER:-}" ]]; then
     last_tag=$(git describe --abbrev=0 --tags | sed 's/^[a-zA-Z]//')
-    version="${last_tag}-h${BUILD_NUMBER}.${git_sha_short}"
+    export version="${last_tag}-h${BUILD_NUMBER}.${git_sha_short}"
     unset iteration
 fi
 
-# Build a tarball
-mkdir -p build/tarball
-install -t build/tarball build/bin/linux-amd64/*
-tar  -czv -C build/tarball -f ${outdir}/titus-executor-${version}.tar.gz .
-
 ## Build the deb package
-
-MAYBE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-if [[ ${BUILDKITE_BRANCH:-$MAYBE_BRANCH} != "master" && "${ENABLE_DEV:-true}" == "true" ]]; then
-    provides="--provides titus-executor-dev"
-fi
-
-cat <<-EOF >/tmp/post-install.sh
-#!/bin/bash
-systemctl --system daemon-reload
-# TODO(Sargun): Make this reload apparmor only if apparmor is "started"
-systemctl reload apparmor || echo "Could not reload apparmor"
-EOF
-chmod +x /tmp/post-install.sh
-
-fpm -t deb -s dir -C root \
-  -a amd64 \
-  -n titus-executor \
-  --maintainer titus-developers@netflix.com \
-  ${iteration:-} \
-  --version "$version" \
-  --deb-field "Build-Host: ${BUILD_HOST:-}" \
-  --deb-field "Build-Job: ${BUILD_JOB:-}" \
-  --deb-field "Build-Number: ${BUILD_NUMBER:-}" \
-  --deb-field "Build-Id: ${BUILD_ID:-}" \
-  --deb-field "Implementation-Vendor: Netflix, Inc." \
-  --deb-field "Built-By: fpm" \
-  --deb-field "Built-OS: Linux" \
-  --deb-field "Build-Date: $(date -u +"%Y-%m-%d_%H:%M:%S")" \
-  --deb-field "Module-Owner: titus-developers@netflix.com" \
-  --deb-field "Module-Email: titus-developers@netflix.com" \
-  --deb-field "Module-Origin: ssh://git@github.com:Netflix/titus-executor.git" \
-  --deb-field "Change: ${git_sha_short}" \
-  --deb-field "Branch: ${git_sha}" \
-  --deb-activate ldconfig \
-  --depends libc6 \
-  --depends 'apparmor >= 2.12' \
-  --deb-recommends 'docker-ce >= 5:18.09.1~3-0~ubuntu-xenial' \
-  --deb-recommends lxcfs \
-  --deb-recommends atlas-titus-agent \
-  --deb-recommends nvidia-container-runtime-hook \
-  ${provides:-} \
-  --after-install /tmp/post-install.sh \
-  --package "${outdir}/"
-
+export BUILD_DATE=$(date -u +"%Y-%m-%d_%H:%M:%S")
+nfpm package --target $outdir --packager deb
 num_debs=$(find "$outdir" -iname "*.deb" | wc -l)
 if [[ $num_debs -ne 1 ]]; then
     echo "Expected exactly one deb file in ${outdir}" >&2
     ls "$outdir" >&2
     exit 1
 fi
-
 filename=$(ls -t ${outdir}/*.deb | grep -v latest | head -n 1)
-
-# TODO: only run the linter on the file above
-# see: nebula/src/main/groovy/netflix/nebula/ospackage/NebulaOsPackageDebRepositoryPublish.groovy
-lintian --suppress-tags dir-or-file-in-opt,statically-linked-binary,unstripped-binary-or-object,debian-changelog-file-missing-or-wrong-name,no-copyright-file,extended-description-is-empty,python-script-but-no-python-dep,non-standard-toplevel-dir,maintainer-name-missing,maintainer-address-malformed,maintainer-script-should-not-use-adduser-system-without-home \
-  --no-tag-display-limit ${filename}
 
 mkdir -p build/distributions
 mv ${filename} build/distributions
-mv ${outdir}/titus-executor-${version}.tar.gz build/distributions
 
 echo "## Updating the symlink: titus-executor_latest.deb -> ${filename}" >&2
 pushd build/distributions

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,43 @@
+# nfpm example config file
+#
+# check https://nfpm.goreleaser.com/configuration for detailed usage
+#
+name: "titus-executor"
+arch: "amd64"
+platform: "linux"
+version: "${version}"
+section: "default"
+depends:
+- libc6
+- 'apparmor (>= 2.12)'
+#deb:
+#  fields:
+#    "Build-Host": "${BUILD_HOST:-}"
+#    "Build-Job": "${BUILD_JOB:-}"
+#    "Build-Number": "${BUILD_NUMBER:-}"
+#    "Build-Id": "${BUILD_ID:-}"
+#    "Implementation-Vendor": "Netflix, Inc."
+#    "Built-Using": "nfpm"
+#    "Built-OS": "Linux"
+#    "Build-Date": "${BUILD_DATE}"
+#    "Module-Owner": "titus-developers@netflix.com"
+#    "Module-Email": "titus-developers@netflix.com"
+#    "Module-Origin": "ssh://git@github.com:Netflix/titus-executor.git"
+#    "Change": "${git_sha_short}"
+#    "Branch": "${git_sha}"
+scripts:
+  postinstall: ./scripts/postinstall.sh
+recommends:
+- 'docker-ce (>= 5:18.09.1~3-0~ubuntu-xenial)'
+- lxcfs
+- atlas-titus-agent
+- nvidia-container-runtime-hook
+maintainer: "titus-developers@netflix.com"
+description: |
+  titus-executor is spawned by titus-virtual-kubelet
+vendor: "Netflix"
+homepage: "https://github.com/Netflix/titus-executor"
+license: "Apache 2"
+contents:
+- src: ./root/**/*
+  dst: /

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+systemctl --system daemon-reload
+# TODO(Sargun): Make this reload apparmor only if apparmor is "started"
+systemctl reload apparmor || echo "Could not reload apparmor"


### PR DESCRIPTION
Ruby kinda sucks. nfpm is more self-contained.

Here is the info of a deb created this way:

```
 new Debian package, version 2.0.
 size 141167754 bytes: control archive=2153 bytes.
       1 bytes,     0 lines      conffiles
     439 bytes,    11 lines      control
    4382 bytes,    55 lines      md5sums
     179 bytes,     4 lines   *  postinst             #!/bin/bash
 Package: titus-executor
 Version: 20210319.0.0~922-g295e3e86
 Section: default
 Priority: optional
 Architecture: amd64
 Maintainer: titus-developers@netflix.com
 Installed-Size: 314583
 Depends: libc6, apparmor >= 2.12
 Recommends: docker-ce >= 5:18.09.1~3-0~ubuntu-xenial, lxcfs, atlas-titus-agent, nvidia-container-runtime-hook
 Homepage: https://github.com/Netflix/titus-executor
 Description: titus-executor is spawned by titus-virtual-kubelet
```

There is some loss here, but nothing major.
