### PR TITLE
Support readOnly containers

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -364,7 +364,7 @@ func maybeAddOptimisticDad(sysctl map[string]string) {
 	}
 }
 
-func (r *DockerRuntime) mainContainerDockerConfig(c runtimeTypes.Container, binds []string, imageSize int64, volumeContainers []string, isPrivileged bool) (*container.Config, *container.HostConfig, error) { // nolint: gocyclo
+func (r *DockerRuntime) mainContainerDockerConfig(c runtimeTypes.Container, binds []string, imageSize int64, volumeContainers []string, v1Container v1.Container) (*container.Config, *container.HostConfig, error) { // nolint: gocyclo
 	// Extract the entrypoint and command from the pod. If either is empty,
 	// pass them along and let Docker extract them from the image instead.
 	entrypoint, cmd := c.Process()
@@ -403,8 +403,9 @@ func (r *DockerRuntime) mainContainerDockerConfig(c runtimeTypes.Container, bind
 
 			"net.ipv6.conf.default.accept_ra_pinfo": "0",
 		},
-		Init:    &useInit,
-		Runtime: c.Runtime(),
+		Init:           &useInit,
+		Runtime:        c.Runtime(),
+		ReadonlyRootfs: isContainerReadOnly(v1Container),
 	}
 
 	maybeAddOptimisticDad(hostCfg.Sysctls)
@@ -488,7 +489,7 @@ func (r *DockerRuntime) mainContainerDockerConfig(c runtimeTypes.Container, bind
 	r.setupLogs(c, hostCfg)
 	r.setupTiniForContainer(hostCfg, containerCfg, "main")
 
-	if isPrivileged {
+	if r.isContainerPrivileged(v1Container) {
 		hostCfg.Privileged = true
 	} else {
 		err = setupAdditionalCapabilities(c, hostCfg, runtimeTypes.MainContainerName)
@@ -998,7 +999,7 @@ func (r *DockerRuntime) Prepare(ctx context.Context) (err error) { // nolint: go
 	}
 	bindMounts = append(bindMounts, mainContainerBindMounts...)
 
-	dockerCfg, hostCfg, err := r.mainContainerDockerConfig(r.c, bindMounts, imageSize, volumeContainers, r.isContainerPrivileged(pod.Spec.Containers[0]))
+	dockerCfg, hostCfg, err := r.mainContainerDockerConfig(r.c, bindMounts, imageSize, volumeContainers, pod.Spec.Containers[0])
 	if err != nil {
 		return err
 	}
@@ -2169,6 +2170,7 @@ func (r *DockerRuntime) k8sContainerToDockerConfigs(c *runtimeTypes.ExtraContain
 		Tmpfs: map[string]string{
 			"/run": "rw,exec,size=" + defaultRunTmpFsSize,
 		},
+		ReadonlyRootfs: isContainerReadOnly(v1Container),
 	}
 
 	// Security options are inherited from the main container's configuration
@@ -3053,4 +3055,14 @@ func (r *DockerRuntime) isContainerPrivileged(c v1.Container) bool {
 		return false
 	}
 	return *c.SecurityContext.Privileged && r.cfg.InStandaloneMode
+}
+
+func isContainerReadOnly(c v1.Container) bool {
+	if c.SecurityContext == nil {
+		return false
+	}
+	if c.SecurityContext.ReadOnlyRootFilesystem == nil {
+		return false
+	}
+	return *c.SecurityContext.ReadOnlyRootFilesystem
 }


### PR DESCRIPTION
This is a pretty easy feature to support, because it translates directly
from the pod spec to a docker launch config.

---

This PR is stacked on https://github.com/Netflix/titus-executor/pull/950