### PR TITLE
builder: re-include unix epoch in version number

### DIFF
--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -39,13 +39,12 @@ outdir="$(mktemp -d)"
 export git_sha=$(git rev-parse --verify HEAD)
 export git_sha_short=${git_sha:0:8}
 export version=${version:-$(git describe --tags --long)}
-export iteration="--iteration ${ITERATION:-$(date +%s)}"
 
 # when on CI/Jenkins
 if [[ -n "${BUILD_NUMBER:-}" ]]; then
+    iteration="${ITERATION:-$(date +%s)}"
     last_tag=$(git describe --abbrev=0 --tags | sed 's/^[a-zA-Z]//')
-    export version="${last_tag}-h${BUILD_NUMBER}.${git_sha_short}"
-    unset iteration
+    export version="${last_tag}-h${BUILD_NUMBER}.${git_sha_short}-$iteration"
 fi
 
 ## Build the deb package


### PR DESCRIPTION
This isn't an argument to nfpm, but we can add it to the version env var,
which is then included from nfpm.yaml.

With this, if I fake a build number locally:

    BUILD_NUMBER=2907 make build-standalone

I get a maybe-reasonable package version:

    + filename=/tmp/tmp.Od9U8WKEZX/titus-executor_20220830.0.0~h2907.eefe0753-1661956271_amd64.deb