### PR TITLE
builder: drop BUILD_NUMBER code path

### DIFF
--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -38,14 +38,8 @@ install -t root/apps/titus-executor/bin build/bin/linux-amd64/*
 outdir="$(mktemp -d)"
 export git_sha=$(git rev-parse --verify HEAD)
 export git_sha_short=${git_sha:0:8}
-export version=${version:-$(git describe --tags --long)}
-
-# when on CI/Jenkins
-if [[ -n "${BUILD_NUMBER:-}" ]]; then
-    iteration="${ITERATION:-$(date +%s)}"
-    last_tag=$(git describe --abbrev=0 --tags | sed 's/^[a-zA-Z]//')
-    export version="${last_tag}-h${BUILD_NUMBER}.${git_sha_short}-$iteration"
-fi
+iteration="${ITERATION:-$(date +%s)}"
+export version=${version:-$(git describe --tags --long)-$iteration}
 
 ## Build the deb package
 export BUILD_DATE=$(date -u +"%Y-%m-%d_%H:%M:%S")


### PR DESCRIPTION
I think this is probably (?) leftover from a switch from jenkins. circleci
does not export BUILD_NUMBER at all:

https://app.circleci.com/pipelines/github/Netflix/titus-executor/2268/workflows/8f7aaa41-fe61-490c-b7da-291961aac486/jobs/21319?invite=true#step-99-2

let's add -iteration to the default $version and delete this code path so
it doesn't confuse anyone else.
