### PR TITLE
Fix a typo in tear down transition network error log

### DIFF
--- a/vpc/tool/container2/setup_container_linux.go
+++ b/vpc/tool/container2/setup_container_linux.go
@@ -785,7 +785,6 @@ func TeardownTransitionNetwork(ctx context.Context, transitionNamespaceDir strin
 			logger.G(ctx).WithError(err).Warningf("Transition namespace %s doesn't exist", transitionNamespaceID)
 		} else {
 			logger.G(ctx).WithError(err).Errorf("Failed to unmount transition namespace %s", transitionNamespaceID)
-			return err
 		}
 	}
 
@@ -795,7 +794,7 @@ func TeardownTransitionNetwork(ctx context.Context, transitionNamespaceDir strin
 			// Same as above.
 			logger.G(ctx).WithError(err).Warningf("Transition namespace %s doesn't exist", transitionNamespaceID)
 		} else {
-			logger.G(ctx).WithError(err).Errorf("Failed to unmount transition namespace %s", transitionNamespaceID)
+			logger.G(ctx).WithError(err).Errorf("Failed to remove transition namespace %s", transitionNamespaceID)
 			return err
 		}
 	}
@@ -849,7 +848,6 @@ func deleteFromIPv4BPFMap(ctx context.Context, assignment *vpcapi.AssignIPRespon
 	if err == unix.ENOENT {
 		err := errors.Wrap(err, "Unable to delete element for ipv4 map (notfound) ")
 		logger.G(ctx).WithError(err).WithField("ip", assignment.Ipv4Address.Address.Address).WithField("classid", assignment.ClassId).WithField("vlanid", assignment.VlanId).Error("Element not found")
-		return err
 	} else if err != 0 {
 		logger.G(ctx).WithError(err).Errorf("Unable to delete element for ipv4 map with file descriptor %d", fd)
 		err2 := errors.Wrap(err, "Unable to delete element for ipv4 map")
@@ -901,7 +899,6 @@ func deleteFromIPv6BPFMap(ctx context.Context, assignment *vpcapi.AssignIPRespon
 	if errno == unix.ENOENT {
 		err := errors.Wrap(errno, "Unable to delete element for ipv6 map (notfound)")
 		logger.G(ctx).WithError(err).WithField("ip", assignment.Ipv6Address.Address.Address).WithField("classid", assignment.ClassId).WithField("vlanid", assignment.VlanId).Error("Element not found")
-		return err
 	} else if errno != 0 {
 		logger.G(ctx).WithError(errors.Wrapf(errno, "Unable to delete element for map with file descriptor %d", fd)).Error()
 		err := errors.Wrap(errno, "Unable to delete element for ipv6 map")


### PR DESCRIPTION
# Problem:

We found a problem with the following sequence:

1) container A starts, it creates transition namespace T
2) container A tears down
3) After 30 minutes, vpc service tells vpc tool to GC transition namespace T
4) vpc tool tries to remove it but failed
5) container B is scheduled to run on the same instance
6) vpc tool asks for an IP from vpc service
7) vpc service finds that transition namespace T is marked as GC but can be reused. So it removes GC tombstone and tells B to use it
8) vpc tool tries to set up network for B. And it tries to get or create transition namespace T for B. However, it's interesting 9) that though previously it failed to remove this transition namespace, it now decides to create one, which failed because of "address already in use".
10) With many "address already in use" in the log. The alert triggered evacuation.

We need to understand why 4) failed.

During debugging, we found that the error log in tearing down the transition network has a typo in it. It should be "failed to remove" rather than "failed to unmount". As a result, we don't know which error it was actually. 

I now suspect the problem is the following sequence:

1) Tries to tear down transition namespace
2) Tries to unmount it. Success
3) Tries to delete it. Failed for unknown reason.
4) Retry 2 after a while. Failed because "target is not a mount point"

Then fails at 2) forever due to "target is not a mount point".

# Fix

This PR fixes the typo as well as 
* Removes the return statement when failing to unmount. That way, if it is indeed the failing sequence above, then when retrying it should pass 2) even after a retry. If it still fails, then we can debug why it fails to delete. 
* Removes the return statement in `deleteFromIPv6BPFMap` and `deleteFromIPv4BPFMap` when the error is `ENOENT` so that the deletion can be retried multiple times without causing any problem.