### PR TITLE
docker: log image pull time

### DIFF
--- a/executor/runtime/docker/docker_image_pull.go
+++ b/executor/runtime/docker/docker_image_pull.go
@@ -53,6 +53,8 @@ func doDockerPull(ctx context.Context, cfg config.Config, metrics metrics.Report
 		metrics.Counter("titus.executor.dockerPullImageError", 1, nil)
 		return fmt.Errorf("Error creating docker registry credentials: %w", err)
 	}
+
+	pullStarted := time.Now()
 	resp, err := client.ImagePull(ctx, ref, types.ImagePullOptions{RegistryAuth: auth})
 	defer func() {
 		if resp != nil {
@@ -88,6 +90,7 @@ func doDockerPull(ctx context.Context, cfg config.Config, metrics metrics.Report
 			for _, pullMessage := range pullMessages {
 				log.Warning("Pull Message: ", pullMessage)
 			}
+			log.Infof("Image %s pull took: %s", ref, time.Since(pullStarted).String())
 			return err
 		}
 		pullMessages = append(pullMessages, msg)


### PR DESCRIPTION
By default, we don't log image pull lines, buffering them and only logging
them when an image pull fails. This results in weird timestamps though: all
the image pull lines are logged *after* the failure, making it look like
the image pull was nearly instantaneous, which for very large images it is
not.

We probably do this to keep down on log noise, which is reasonable. Let's
add one more line with the actual elapsed time in the failure case so that
it's more obvious when debugging how long this took.
