### PR TITLE
TITUS-6224: add extra lxcfs endpoints

### DIFF
--- a/executor/runtime/docker/lxcfs.go
+++ b/executor/runtime/docker/lxcfs.go
@@ -13,11 +13,21 @@ const (
 
 func getLXCFsBindMounts() []string {
 	extraBinds := []string{}
-	for _, file := range []string{"cpuinfo", "meminfo", "uptime"} {
-		path := filepath.Join(lxcfs, "proc", file)
+	lxcfsEndpoints := []string{
+		"/proc/cpuinfo",
+		"/proc/diskstats",
+		"/proc/meminfo",
+		"/proc/stat",
+		"/proc/swaps",
+		"/proc/uptime",
+		"/proc/slabinfo",
+		"/sys/devices/system/cpu",
+		"/sys/devices/system/cpu/online",
+	}
+	for _, file := range lxcfsEndpoints {
+		path := filepath.Join(lxcfs, file)
 		if err := unix.Access(path, 0); err == nil {
-			destPath := filepath.Join("/proc", file)
-			extraBinds = append(extraBinds, fmt.Sprintf("%s:%s", path, destPath))
+			extraBinds = append(extraBinds, fmt.Sprintf("%s:%s", path, file))
 		}
 	}
 


### PR DESCRIPTION
in particular, we want /sys/devices/system/cpu/online, but with lxcfs 3.1.2 we get these other ones for free, so why not.

This needs to wait for merge until we have a new version of lxcfs that actually exports these files, otherwise these bind mounts will fail. But here's the patch for now so I don't lose track of it.
