### PR TITLE
TITUS-6243: bump credential renewal window

### DIFF
--- a/metadataserver/iam.go
+++ b/metadataserver/iam.go
@@ -57,7 +57,7 @@ const (
 	requestTimeout         = 30 * time.Second
 	defaultSessionLifetime = time.Hour
 	maxSessionNameLen      = 64
-	renewalWindow          = 5 * time.Minute
+	renewalWindow          = 15 * time.Minute
 	awsTimeFormat          = "2006-01-02T15:04:05Z"
 	iamSelectionHeader     = "X-Titus-Role"
 )


### PR DESCRIPTION
### Description of the Change

STS will never supply credentials with less than 15 minutes of life. 3rd party libraries like [boto make assumptions based on this, causing issues when credentials with <10m of life are supplied](https://github.com/boto/botocore/issues/2670).

