### PR TITLE
Increase timeouts to vpc tool assign/unassign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GOBIN                 ?= $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))
 PATH                  := $(PATH):$(GOBIN)
 GOBIN_TOOL            = $(shell which gobin || echo $(GOBIN)/gobin)
 GOIMPORT_TOOL		  = $(GOBIN_TOOL) -m -run golang.org/x/tools/cmd/goimports@v0.1.0 -w
-GOLANGCI_LINT_TIMEOUT := 2m
+GOLANGCI_LINT_TIMEOUT := 6m
 ifdef FAST
 	GOLANGCI_LINT_ARGS = --fast
 endif

--- a/executor/runtime/docker/networking.go
+++ b/executor/runtime/docker/networking.go
@@ -27,13 +27,14 @@ import (
 
 const (
 	defaultNetworkBandwidthBps = 128 * MB
-	vpctoolTimeout             = 45 * time.Second
+	assignVpctoolTimeout       = 120 * time.Second
+	unassignVpctoolTimeout     = 60 * time.Second
 )
 
 // This will setup c.Allocation
 func prepareNetworkDriver(ctx context.Context, cfg Config, c runtimeTypes.Container) (cleanupFunc, error) { // nolint: gocyclo
 	start := time.Now()
-	ctx, cancel := context.WithTimeout(ctx, vpctoolTimeout)
+	ctx, cancel := context.WithTimeout(ctx, assignVpctoolTimeout)
 	defer cancel()
 
 	ctx, span := trace.StartSpan(ctx, "prepareNetworkDriver")
@@ -142,7 +143,7 @@ func prepareNetworkDriver(ctx context.Context, cfg Config, c runtimeTypes.Contai
 		} else {
 			errs = multierror.Append(errs, fmt.Errorf("stderr output: %s", string(data)))
 		}
-		errs = multierror.Append(errs, fmt.Errorf("Error waiting on allocation command after %s (timeout %s): %w", time.Since(start), vpctoolTimeout, allocationCommand.Wait()))
+		errs = multierror.Append(errs, fmt.Errorf("Error waiting on allocation command after %s (timeout %s): %w", time.Since(start), assignVpctoolTimeout, allocationCommand.Wait()))
 		tracehelpers.SetStatus(errs, span)
 		return nil, errs
 	}
@@ -176,7 +177,7 @@ func prepareNetworkDriver(ctx context.Context, cfg Config, c runtimeTypes.Contai
 	}
 
 	return func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), unassignVpctoolTimeout)
 		defer cancel()
 		unassignCommand := exec.CommandContext(ctx, vpcToolPath(), "unassign", "--task-id", c.TaskID()) // nolint: gosec
 		err := unassignCommand.Run()


### PR DESCRIPTION
Align vpctool call timeouts from docker to what vpctool uses internally

https://github.com/Netflix/titus-executor/blob/master/vpc/tool/assign3/assign_network.go#L113
https://github.com/Netflix/titus-executor/blob/master/vpc/tool/assign3/unassign.go#L18