### PR TITLE
Revert "runner: always delegate all cgroups"

### DIFF
--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -272,6 +272,10 @@ func cleanupCgroups(cgroupPath string) error {
 }
 
 func setCgroupOwnership(parentCtx context.Context, c runtimeTypes.Container, cred ucred) error {
+	if !c.IsSystemD() {
+		return nil
+	}
+
 	cgroupPath := filepath.Join("/proc/", strconv.Itoa(int(cred.pid)), "cgroup")
 	cgroups, err := ioutil.ReadFile(cgroupPath) // nolint: gosec
 	if err != nil {
@@ -289,18 +293,19 @@ func setCgroupOwnership(parentCtx context.Context, c runtimeTypes.Container, cre
 		}
 		// This is to handle the name=systemd cgroup, we should probably parse /proc/mounts, but this is a little bit easier
 		controllerType = strings.TrimPrefix(controllerType, "name=")
+		if controllerType != "systemd" {
+			continue
+		}
 
-		// systemd needs to be the owner of its systemd cgroup in order
-		// to start up, and needs to be the owner of e.g. its memory
-		// controller path to do memory accounting.
+		// systemd needs to be the owner of its systemd cgroup in order to start up
 		controllerPath := cgroupInfo[2]
 		fsPath := filepath.Join(sysFsCgroup, controllerType, controllerPath)
-		logrus.Debugf("chowning cgroup path: %s to %d %d", fsPath, cred.uid, cred.gid)
+		logrus.Infof("chowning systemd cgroup path: %s", fsPath)
 		err = os.Chown(fsPath, int(cred.uid), int(cred.gid))
 		if err != nil {
 			logrus.WithError(err).Error("Could not chown systemd cgroup path")
-			return err
 		}
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This reverts commit 8f5dd2f73535c9c5af31c69b314d08c626ac7ef7.

We are having problems with containers doing too much cgroup manipulation and causing high cgroup_mutex contention. Let's turn off individual resource cgroup manipulation for containers for now. This was originally turned on so that systemd inside containers could do resource accounting, which they will no longer be able to. Hopefully we can figure out another fix and revert this revert soon.

I tested this while reproducing the problem and running the following script:

    #!/usr/bin/env python3
    import subprocess
    import time

    max_streak=0
    cur_streak=0
    total=0

    try:
        while True:
            try:
                subprocess.check_call(["dbus-send", "--system", "--print-reply",
                                       "--reply-timeout=2000", "--type=method_call",
                                       "--dest=org.freedesktop.systemd1",
                                       "/org/freedesktop/systemd1",
                                       "org.freedesktop.DBus.Peer.Ping"])
                time.sleep(2)
            except subprocess.CalledProcessError:
                total+=1
                cur_streak+=1
                if cur_streak > max_streak:
                    max_streak = cur_streak
            else:
                cur_streak = 0
    except KeyboardInterrupt:
        print(f"total failures: {total}, longest failures streak: {max_streak}")

and got (top line is unpatched, bottom line is patched):

run 1:

total failures: 82, longest failures streak: 47
total failures: 13, longest failures streak: 7

run 2:

total failures: 88, longest failures streak: 76
total failures: 59, longest failures streak: 19

run 3:

total failures: 76, longest failures streak: 39
total failures: 70, longest failures streak: 20

run 5:

total failures: 76, longest failures streak: 36
total failures: 7, longest failures streak: 4

run 6:

total failures: 103, longest failures streak: 60
total failures: 38, longest failures streak: 16

so it doesn't fix it, but it does help somewhat.
