### PR TITLE
HighScale now defaults to using TSA

### DIFF
--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -382,10 +382,10 @@ func computeEffectiveNetworkMode(originalNetworkMode string, assignIPv6Address b
 		return titus.NetworkConfiguration_Ipv4Only.String()
 	}
 	if originalNetworkMode == titus.NetworkConfiguration_HighScale.String() {
-		if !enableTransitionNetwork {
-			return titus.NetworkConfiguration_Ipv6AndIpv4.String()
+		if enableTransitionNetwork {
+			return titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String()
 		}
-		return titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String()
+		return titus.NetworkConfiguration_Ipv6AndIpv4.String()
 	}
 	if originalNetworkMode == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() && !enableTransitionNetwork {
 		return titus.NetworkConfiguration_Ipv6AndIpv4.String()

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -382,7 +382,10 @@ func computeEffectiveNetworkMode(originalNetworkMode string, assignIPv6Address b
 		return titus.NetworkConfiguration_Ipv4Only.String()
 	}
 	if originalNetworkMode == titus.NetworkConfiguration_HighScale.String() {
-		return titus.NetworkConfiguration_Ipv6Only.String()
+		if !enableTransitionNetwork {
+			return titus.NetworkConfiguration_Ipv6AndIpv4.String()
+		}
+		return titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String()
 	}
 	if originalNetworkMode == titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String() && !enableTransitionNetwork {
 		return titus.NetworkConfiguration_Ipv6AndIpv4.String()


### PR DESCRIPTION
HighScale network mode now uses TSA by default for better adoption
