### PR TITLE
Added Environment stuff for extra containers

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1064,6 +1064,12 @@ func (r *DockerRuntime) Prepare(ctx context.Context) (err error) { // nolint: go
 	if err != nil {
 		return err
 	}
+	for _, c := range append(r.c.ExtraPlatformContainers(), r.c.ExtraUserContainers()...) {
+		err = r.pushEnvironmentForExtraContainer(ctx, c)
+		if err != nil {
+			return err
+		}
+	}
 	logger.G(ctx).Info("Titus environment pushed")
 
 	return nil
@@ -1313,6 +1319,45 @@ func (r *DockerRuntime) pushEnvironment(ctx context.Context, c runtimeTypes.Cont
 	}
 
 	return r.client.CopyToContainer(ctx, c.ID(), "/", bytes.NewReader(tarBuf.Bytes()), cco)
+}
+
+func (r *DockerRuntime) pushEnvironmentForExtraContainer(ctx context.Context, e *runtimeTypes.ExtraContainer) error {
+	var envTemplateBuf, tarBuf bytes.Buffer
+
+	if err := executeEnvFileTemplate(r.c.ExtraContainerEnv(e), e.ImageInspect, &envTemplateBuf); err != nil {
+		return err
+	}
+
+	tw := tar.NewWriter(&tarBuf)
+
+	path := "etc/profile.d/netflix_environment.sh"
+	if version, ok := e.ImageInspect.Config.Labels["nflxenv"]; ok && strings.HasPrefix(version, "1.") {
+		path = "etc/nflx/base-environment.d/200titus"
+	}
+
+	hdr := &tar.Header{
+		Name: path,
+		Mode: 0644,
+		Size: int64(envTemplateBuf.Len()),
+	}
+
+	if err := tw.WriteHeader(hdr); err != nil {
+		log.WithError(err).Fatal()
+	}
+	if _, err := tw.Write(envTemplateBuf.Bytes()); err != nil {
+		log.WithError(err).Fatal()
+	}
+	// Make sure to check the error on Close.
+
+	if err := tw.Close(); err != nil {
+		return err
+	}
+
+	cco := types.CopyToContainerOptions{
+		AllowOverwriteDirWithFile: true,
+	}
+
+	return r.client.CopyToContainer(ctx, e.Status.ContainerID, "/", bytes.NewReader(tarBuf.Bytes()), cco)
 }
 
 func maybeConvertIntoBadEntryPointError(err error) error {
@@ -1946,7 +1991,7 @@ func (r *DockerRuntime) k8sContainerToDockerConfigs(c *runtimeTypes.ExtraContain
 		}
 	}
 
-	baseEnv := r.c.SortedEnvArray()
+	baseEnv := r.c.SortedEnvArrayExtraContainer(c)
 	baseEnv = append(baseEnv, "TITUS_CONTAINER_NAME="+v1Container.Name)
 
 	// Only redirect stdout/err if we have shared logs

--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -357,6 +357,10 @@ func (c *PodContainer) Env() map[string]string {
 	return populateContainerEnv(c, c.config, c.userEnv)
 }
 
+func (c *PodContainer) ExtraContainerEnv(e *ExtraContainer) map[string]string {
+	return populateContainerEnv(c, c.config, v1EnvVarsToMap(e.V1Container.Env))
+}
+
 func (c *PodContainer) EnvOverrides() map[string]string {
 	c.envLock.Lock()
 	envOverrides := maps.CopySS(c.envOverrides)
@@ -738,6 +742,10 @@ func (c *PodContainer) SortedEnvArray() []string {
 	return sortedEnv(c.Env())
 }
 
+func (c *PodContainer) SortedEnvArrayExtraContainer(e *ExtraContainer) []string {
+	return sortedEnv(c.ExtraContainerEnv(e))
+}
+
 func (c *PodContainer) SubnetIDs() *[]string {
 	return c.podConfig.SubnetIDs
 }
@@ -1034,4 +1042,15 @@ func stringSliceContains(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// v1EnvVarsToMap constructs a map of environment name to value from a slice
+// of env vars.
+func v1EnvVarsToMap(envs []v1.EnvVar) map[string]string {
+	result := map[string]string{}
+	for _, env := range envs {
+		result[env.Name] = env.Value
+	}
+
+	return result
 }

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -163,6 +163,7 @@ type Container interface {
 	ElasticIPs() *string
 	ExtraUserContainers() []*ExtraContainer
 	ExtraPlatformContainers() []*ExtraContainer
+	ExtraContainerEnv(c *ExtraContainer) map[string]string
 	GPUInfo() GPUContainer
 	HostnameStyle() *string
 	IamRole() *string
@@ -213,6 +214,7 @@ type Container interface {
 	SystemServices() ([]*ServiceOpts, error)
 	SignedAddressAllocationUUID() *string
 	SortedEnvArray() []string
+	SortedEnvArrayExtraContainer(c *ExtraContainer) []string
 	SubnetIDs() *[]string
 	TaskID() string
 	TTYEnabled() bool


### PR DESCRIPTION
Previously I was cheating a little bit by populating extra containers via `Env()`, which really represents the env of the main container.

This was a shortcut, and now we are ready to use `ExtraContainerEnv()`, which compiles env based on the extra container.

This comes with all the analgous functions, as well as the function to push in the environment file on disk using docker cp.
