### PR TITLE
lxcfs: don't mask /sys/devices/system/cpu

### DIFF
--- a/executor/runtime/docker/lxcfs.go
+++ b/executor/runtime/docker/lxcfs.go
@@ -21,7 +21,6 @@ func getLXCFsBindMounts() []string {
 		"/proc/swaps",
 		"/proc/uptime",
 		"/proc/slabinfo",
-		"/sys/devices/system/cpu",
 		"/sys/devices/system/cpu/online",
 	}
 	for _, file := range lxcfsEndpoints {


### PR DESCRIPTION
It turns out lxcfs' implementation of this is wrong: https://github.com/lxc/lxcfs/pull/557 and this is not necessary at all (the kernel doesn't mask the cpu%d dirs when cpus are offlined). Since this causes problems for us, let's not bind mount this bit.