### PR TITLE
Don't panic when injecting imds on errors

### DIFF
--- a/cmd/titus-inject-metadataproxy/main.go
+++ b/cmd/titus-inject-metadataproxy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/Netflix/titus-executor/cmd/common"
 	"github.com/Netflix/titus-executor/logger"
@@ -27,7 +28,8 @@ func main() {
 		Args: cobra.ArbitraryArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := v.BindPFlags(cmd.Flags()); err != nil {
-				panic(err)
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
 			}
 
 			switch level := v.GetString("log-level"); level {
@@ -50,14 +52,17 @@ func main() {
 	rootCmd.PersistentFlags().String("log-level", "info", "Log Level")
 
 	if err := v.BindPFlags(rootCmd.PersistentFlags()); err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
 	}
 	if err := v.BindEnv("titus-pid-1-dir", "TITUS_PID_1_DIR"); err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
 	}
 
 	err := rootCmd.Execute()
 	if err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/metadataserver/inject/inject_linux.go
+++ b/metadataserver/inject/inject_linux.go
@@ -393,6 +393,7 @@ func getLinkLocalIPv6Addr(ctx context.Context, handle *netlink.Handle, link netl
 }
 
 func waitForInterfacesUp(ctx context.Context, containerNSHandle, intermediateNSHandle *netlink.Handle) error {
+	start := time.Now()
 	t := time.NewTimer(1)
 	defer t.Stop()
 	var err error
@@ -400,7 +401,7 @@ func waitForInterfacesUp(ctx context.Context, containerNSHandle, intermediateNSH
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("Context complete before expected: %w, last states; toIMDSLink: %v, toContainerLink:%v", ctx.Err(), toIMDSLink, toContainerLink)
+			return fmt.Errorf("Context finished prematurely after %v while waiting interfaces to be up: %w, last states; toIMDSLink: %v, toContainerLink:%v", time.Since(start), ctx.Err(), toIMDSLink, toContainerLink)
 		case <-t.C:
 			toIMDSLink, err = containerNSHandle.LinkByName(toimdsInterfaceName)
 			if err != nil {


### PR DESCRIPTION
I don't like to see panics when the error is "normal". Granted, I don't like the bug, but it doesn't indicate an actual bug in the code (probably).

This also adds a timer so we can actually see how long we ended up waiting. Maybe we are not waiting long enough!
