### PR TITLE
Allow no-iam and no-bucket pods

### DIFF
--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -399,7 +399,12 @@ func (c *PodContainer) HostnameStyle() *string {
 }
 
 func (c *PodContainer) IamRole() *string {
-	return c.podConfig.IAMRole
+	role := c.podConfig.IAMRole
+	if role == nil {
+		s := ""
+		return &s
+	}
+	return role
 }
 
 func (c *PodContainer) ID() string {
@@ -853,7 +858,9 @@ func createLogUploadConfig(pConf *podCommon.Config) *uploader.Config {
 	if pConf.LogS3PathPrefix != nil {
 		conf.S3PathPrefix = *pConf.LogS3PathPrefix
 	}
-
+	if conf.S3BucketName == "" {
+		conf.DisableUpload = true
+	}
 	return &conf
 }
 

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -420,9 +420,10 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 	assert.DeepEqual(t, c.LogStdioCheckInterval(), &expStdioCheckInterval)
 	assert.DeepEqual(t, c.LogUploadCheckInterval(), &expUploadCheckInterval)
 	assert.DeepEqual(t, c.LogUploaderConfig(), &uploader.Config{
-		S3WriterRole: "",
-		S3BucketName: "",
-		S3PathPrefix: "",
+		S3WriterRole:  "",
+		S3BucketName:  "",
+		S3PathPrefix:  "",
+		DisableUpload: true,
 	})
 
 	logUploadRegExp := c.LogUploadRegexp()


### PR DESCRIPTION
Not all pods (like standalone ones) have an IAM or a S3 bucket. This makes it so we can move forward even if we don't have those.
