### PR TITLE
Always makeall dirs

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1072,6 +1072,7 @@ func (r *DockerRuntime) Prepare(ctx context.Context) (err error) { // nolint: go
 // Creates the file $titusEnvironments/ContainerID.json as a serialized version of the ContainerInfo protobuf struct
 // so other systems can load it
 func (r *DockerRuntime) createTitusContainerInfoFile(ctx context.Context, c runtimeTypes.Container, startTime time.Time) error {
+	_ = os.MkdirAll(runtimeTypes.TitusEnvironmentsDir, 700)
 	containerConfigFile := filepath.Join(runtimeTypes.TitusEnvironmentsDir, fmt.Sprintf("%s.json", c.TaskID()))
 
 	cfg, err := runtimeTypes.GenerateSyntheticContainerInfoPass2(c, startTime)

--- a/executor/runtime/docker/docker_linux.go
+++ b/executor/runtime/docker/docker_linux.go
@@ -68,7 +68,7 @@ func getPeerInfo(unixConn *net.UnixConn) (ucred, error) {
 func (r *DockerRuntime) mountContainerProcPid1InTitusInits(parentCtx context.Context, c runtimeTypes.Container, cred ucred) error {
 	pidpath := filepath.Join("/proc", strconv.FormatInt(int64(cred.pid), 10))
 	path := filepath.Join(titusInits, c.TaskID())
-	if err := os.Mkdir(path, 0755); err != nil { // nolint: gosec
+	if err := os.MkdirAll(path, 0755); err != nil { // nolint: gosec
 		return err
 	}
 	r.registerRuntimeCleanup(func() error {


### PR DESCRIPTION
In standalone mode, these dirs don't exist on a fresh node.

These mkdirs ensure that standalone can run properly the first time.
