### PR TITLE
Don't use cgroups in standalone mode

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -177,10 +177,13 @@ func NewDockerRuntime(ctx context.Context, m metrics.Reporter, dockerCfg Config,
 	defaultBindMounts := []string{}
 	defaultBindMounts = append(defaultBindMounts, filepath.Join(cfg.RuntimeDir, "pod.json")+":/titus/run/pod.json:ro")
 
-	pidCgroupPath, err := getOwnCgroup("pids")
-	if err != nil {
-		tracehelpers.SetStatus(err, span)
-		return nil, err
+	pidCgroupPath := ""
+	if !cfg.InStandaloneMode {
+		pidCgroupPath, err = getOwnCgroup("pids")
+		if err != nil {
+			tracehelpers.SetStatus(err, span)
+			return nil, err
+		}
 	}
 
 	storageOptEnabled := shouldEnableStorageOpts(info)


### PR DESCRIPTION
This probably isn't a 100% solution, but makes the standalone binary run on a ubuntu jammy server.
