### PR TITLE
Make the timeout of populateAssignment configurable

### DIFF
--- a/vpc/service/generate_assignment_id.go
+++ b/vpc/service/generate_assignment_id.go
@@ -32,8 +32,8 @@ import (
 )
 
 const (
-	generateAssignmentIDTimeout = time.Second * 30
-	securityGroupBlockTimeout   = 1 * time.Minute
+	generateAssignmentIDTimeoutSecond = 30
+	securityGroupBlockTimeout         = 1 * time.Minute
 )
 
 type eniLockWrapper struct {
@@ -415,7 +415,8 @@ func (vpcService *vpcService) populateAssignment(ctx context.Context, req getENI
 	}
 	defer unlock()
 
-	ctx, cancel := context.WithTimeout(ctx, generateAssignmentIDTimeout)
+	timeoutSecond := vpcService.dynamicConfig.GetInt(ctx, "GENERATE_ASSIGNMENT_ID_TIMEOUT", generateAssignmentIDTimeoutSecond)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSecond)*time.Second)
 	defer cancel()
 
 retry:


### PR DESCRIPTION
# Background

The `AssignIPv3` API [has a 5-minute timeout](https://github.com/Netflix/titus-executor/blob/7c731fb36a3a00b2fe848009efa232e046feeaa7/vpc/service/assign_addresses_v3.go#L35). In the past, vpc tool uses a 45-second timeout, which was later changed to 2 minutes in PR #974. That means, the expected timeout of `AssignIPv3` should be min(5, 2) = 2 minutes.

# Problem
I found that some of the `AssignIPv3` API calls timed out after 30 seconds rather than 2 minutes. Looking more into the code, the `populateAssignment` function on the callstack of `AssignIPv3` has a 30-second timeout and the failure of this call can fail the entire `AssignIPv3`. As a result, the whole timeout is 30 seconds.

# Solution
This PR makes this timeout of `populateAssignment` configurable with a 30 seconds default value. The reason I didn't change it to 120 seconds is that this function uses `goto` implement a retry logic so that increasing the timeout will cause the goto block to be executed more times. I'm unsure of the side-effect so making it configurable and easy to roll back in case of a problem.
