### PR TITLE
RFC: Added emptyDir tmpfs support

### DIFF
--- a/executor/runtime/types/pod.go
+++ b/executor/runtime/types/pod.go
@@ -34,6 +34,7 @@ const (
 	serviceMeshServiceName    = "servicemesh"
 	serviceMeshServiceVersion = 1
 	ShmMountPath              = "/dev/shm"
+	ShmVolumeName             = "dev-shm"
 )
 
 // VK adds env vars to each container's env in order to maintain compatibility with Kubelet. We need this list

--- a/executor/runtime/types/pod_test.go
+++ b/executor/runtime/types/pod_test.go
@@ -251,7 +251,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 			MountPath: "/efs1-rw",
 		},
 		{
-			Name:      "dev-shm",
+			Name:      ShmVolumeName,
 			MountPath: "/dev/shm",
 		},
 		{
@@ -272,7 +272,7 @@ func TestNewPodContainerWithEverything(t *testing.T) {
 			},
 		},
 		{
-			Name: "dev-shm",
+			Name: ShmVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{
 					Medium:    corev1.StorageMediumMemory,
@@ -534,7 +534,7 @@ func TestNewPodContainerErrors(t *testing.T) {
 
 	pod.Spec.Containers[0].Image = testImageWithTag
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-		Name:      "dev-shm",
+		Name:      ShmVolumeName,
 		MountPath: ShmMountPath,
 	})
 	_, err = NewPodContainer(pod, &sync.Mutex{}, *conf)

--- a/executor/standalone/jobrunner_test.go
+++ b/executor/standalone/jobrunner_test.go
@@ -423,12 +423,12 @@ func createPodTask(jobInput *JobInput, jobID string, task *runner.Task, env map[
 	if jobInput.ShmSize != nil {
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 			MountPath: runtimeTypes.ShmMountPath,
-			Name:      "dev-shm",
+			Name:      runtimeTypes.ShmVolumeName,
 		})
 
 		shmSize := resource.MustParse(fmt.Sprintf("%dMi", *jobInput.ShmSize))
 		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-			Name: "dev-shm",
+			Name: runtimeTypes.ShmVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{
 					SizeLimit: &shmSize,


### PR DESCRIPTION
I don't thinks this is "right".

It is simple though: we initialize ram disks at container launch time.

But it doesn't really match what k8s does: where each volume is mounted by the individual containers.

I think to do it "right", I'll need to make a ram disk for each volume and inject the mount (via titus-storage).