### PR TITLE
docker: bind mount entire runtime dir vs. just pod

### DIFF
--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -175,7 +175,7 @@ func NewDockerRuntime(ctx context.Context, m metrics.Reporter, dockerCfg Config,
 	}
 
 	defaultBindMounts := []string{}
-	defaultBindMounts = append(defaultBindMounts, filepath.Join(cfg.RuntimeDir, "pod.json")+":/titus/run/pod.json:ro")
+	defaultBindMounts = append(defaultBindMounts, cfg.RuntimeDir+":/titus/run:ro")
 
 	pidCgroupPath := ""
 	if !cfg.InStandaloneMode {
@@ -2011,9 +2011,9 @@ func (r *DockerRuntime) k8sContainerToDockerConfigs(c *runtimeTypes.ExtraContain
 	mounts := []mount.Mount{
 		{
 			Type:     "bind",
-			Source:   path.Join(r.cfg.RuntimeDir, "pod.json"),
+			Source:   r.cfg.RuntimeDir,
 			ReadOnly: true,
-			Target:   "/titus/run/pod.json",
+			Target:   "/titus/run",
 		},
 	}
 	if mainContainerRoot != "" {

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -201,7 +201,12 @@ func (b *Backend) waitForTerminationSignal(ctx context.Context, r *runner.Runner
 func (b *Backend) writePod(ctx context.Context, statedir string) error {
 	f, err := renameio.TempFile(statedir, filepath.Join(statedir, "state.json"))
 	if err != nil {
-		return fmt.Errorf("Cannot create temporary pod file")
+		return fmt.Errorf("Cannot create temporary pod file: %v", err)
+	}
+
+	err = f.Chmod(0644)
+	if err != nil {
+		return fmt.Errorf("Couldn't chown temporary pod file: %v", err)
 	}
 
 	encoder := json.NewEncoder(f)


### PR DESCRIPTION
This will save us from having to do fancy tricks to keep the pod.json visible in the container, and might be useful for shipping other things to the container (e.g. tini sockets)

We have to manually add a chown because the file is root owned, and we want users to be able to read it.