### PR TITLE
Added first pass at titus-mount-lustre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ checkstyle-result.xml
 /root/apps/titus-executor/bin/titus-mount-bind
 /root/apps/titus-executor/bin/titus-mount-container-to-container
 /root/apps/titus-executor/bin/titus-mount-nfs
+/root/apps/titus-executor/bin/titus-mount-lustre
 /root/apps/titus-executor/bin/tini-static
 /root/apps/titus-executor/bin/titus-inject-metadataproxy
 /root/apps/titus-executor/bin/titus-standalone
@@ -101,6 +102,7 @@ checkstyle-result.xml
 /mount/titus-mount-nfs
 /mount/titus-mount-bind
 /mount/titus-mount-container-to-container
+/mount/titus-mount-lustre
 
 # unignore directories named titus-executor
 !*/titus-executor/

--- a/cmd/titus-storage/lustre.go
+++ b/cmd/titus-storage/lustre.go
@@ -64,9 +64,9 @@ func setupLustreMount(parentCtx context.Context, taskID, cname string, vol *core
 	fsxFileSystemID := vol.FlexVolume.Options["fsxFileSystemId"]
 	lustreHost := fmt.Sprintf("%s.fsx.%s.amazonaws.com", fsxFileSystemID, region)
 	mountOptions := "recovery_time_soft=300,recovery_time_hard=900"
-	flags := 0
+	flags := MOUNT_ATTR_NOATIME
 	if vm.ReadOnly {
-		flags = flags | MS_RDONLY
+		flags = flags | MOUNT_ATTR_RDONLY
 	}
 
 	cmd := exec.CommandContext(ctx, lustreMountCmd)

--- a/cmd/titus-storage/lustre.go
+++ b/cmd/titus-storage/lustre.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	executorDocker "github.com/Netflix/titus-executor/executor/runtime/docker"
+	"github.com/Netflix/titus-executor/logger"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -31,7 +31,7 @@ func lustreStart(ctx context.Context, config MountConfig) error {
 	pod := config.pod
 	nameToMount := map[string]corev1.Volume{}
 	for _, v := range pod.Spec.Volumes {
-		if v.FlexVolume != nil && v.FlexVolume.Driver == "LustreVolumeSource" && v.FlexVolume.Options != nil {
+		if v.FlexVolume != nil && v.FlexVolume.Driver == "FSxLustreVolumeSource" && v.FlexVolume.Options != nil {
 			nameToMount[v.Name] = v
 		}
 	}
@@ -54,37 +54,35 @@ func lustreStart(ctx context.Context, config MountConfig) error {
 }
 
 func setupLustreMount(parentCtx context.Context, taskID, cname string, vol *corev1.Volume, vm *corev1.VolumeMount) error {
-	baseMountOptions := []string{"noatime,flock"}
+	l := logger.GetLogger(parentCtx)
 	ctx, cancel := context.WithTimeout(parentCtx, mountTimeout)
 	defer cancel()
 
 	pidDir := executorDocker.GetTitusInitsPath(taskID, cname)
-	cmd := exec.CommandContext(ctx, lustreMountCmd)
-	flags := 0
-	fsxFileSystemID := vol.FlexVolume.Options["fsxFileSystemId"]
 	fsxMountName := vol.FlexVolume.Options["fsxMountName"]
 	region := os.Getenv("EC2_REGION")
+	fsxFileSystemID := vol.FlexVolume.Options["fsxFileSystemId"]
 	lustreHost := fmt.Sprintf("%s.fsx.%s.amazonaws.com", fsxFileSystemID, region)
-	lustreMountName := fsxMountName
-
+	mountOptions := "recovery_time_soft=300,recovery_time_hard=900"
+	flags := 0
 	if vm.ReadOnly {
 		flags = flags | MS_RDONLY
 	}
-	mountOptions := append(
-		baseMountOptions,
-		fmt.Sprintf("source=[%s]@tcp:%s", lustreHost, lustreMountName),
-	)
+
+	cmd := exec.CommandContext(ctx, lustreMountCmd)
 	cmd.Env = []string{
 		fmt.Sprintf("TITUS_PID1_DIR=%s", pidDir),
 		fmt.Sprintf("MOUNT_TARGET=%s", filepath.Clean(vm.MountPath)),
 		fmt.Sprintf("MOUNT_LUSTRE_HOSTNAME=%s", lustreHost),
+		fmt.Sprintf("MOUNT_LUSTRE_MOUNTNAME=%s", fsxMountName),
 		fmt.Sprintf("MOUNT_FLAGS=%d", flags),
-		fmt.Sprintf("MOUNT_OPTIONS=%s", strings.Join(mountOptions, ",")),
+		fmt.Sprintf("MOUNT_OPTIONS=%s", mountOptions),
 	}
 
+	l.Infof("Running lustre mount command %+v %+v", cmd.Env, cmd)
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("Lustre Mount failure: %+v: %s", cmd, string(stdoutStderr))
+		return fmt.Errorf("Lustre Mount failure: %+v: %s (%w)", cmd, string(stdoutStderr), err)
 	}
 
 	return nil

--- a/cmd/titus-storage/main.go
+++ b/cmd/titus-storage/main.go
@@ -26,6 +26,11 @@ const (
 	titusPid1DirFlagName  = "titus-pid1-dir"
 	start                 = "start"
 	stop                  = "stop"
+	// These mount attributes should be used with the newer mount syscalls:
+	// https://sourcegraph.com/github.com/torvalds/linux@01f856ae6d0ca5ad0505b79bf2d22d7ca439b2a1/-/blob/include/uapi/linux/mount.h?L131
+	// And should not be confused with the MS_* flags used by the classic mount syscall.
+	MOUNT_ATTR_RDONLY  = 1          // nolint: golint
+	MOUNT_ATTR_NOATIME = 0x00000010 // nolint: golint
 )
 
 type MountConfig struct {

--- a/cmd/titus-storage/nfs.go
+++ b/cmd/titus-storage/nfs.go
@@ -48,7 +48,7 @@ func setupNFSMount(parentCtx context.Context, taskID, cname string, vol *corev1.
 
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("Mount failure: %+v: %s", cmd, string(stdoutStderr))
+		return fmt.Errorf("Mount failure: %+v: %s (%w)", cmd, string(stdoutStderr), err)
 	}
 
 	return nil

--- a/cmd/titus-storage/nfs.go
+++ b/cmd/titus-storage/nfs.go
@@ -15,8 +15,6 @@ import (
 const (
 	nfsMountCmd  = "/apps/titus-executor/bin/titus-mount-nfs"
 	mountTimeout = 10 * time.Second
-	// MS_RDONLY indicates that mount is read-only
-	MS_RDONLY = 1 // nolint: golint
 )
 
 // setupNFSMount calls out to the titus-mount-nfs command to set up a single
@@ -31,7 +29,7 @@ func setupNFSMount(parentCtx context.Context, taskID, cname string, vol *corev1.
 	flags := 0
 
 	if vm.ReadOnly {
-		flags = flags | MS_RDONLY
+		flags = flags | MOUNT_ATTR_RDONLY
 	}
 	mountOptions := append(
 		baseMountOptions,

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -974,7 +974,7 @@ func (r *DockerRuntime) Prepare(ctx context.Context) (err error) { // nolint: go
 			continue
 		} else if sidecarConfig.ContainerName == sidecarConfig.ServiceName {
 			// If the ContainerName is still just ServiceName, that indicates it has not be initialized yet,
-			// probably because if failed to be pulled, potentically indicating that the image doesn't exist,
+			// probably because if failed to be pulled, potentially indicating that the image doesn't exist,
 			// or a bad deploy, or heck just a typo in the name or something
 			if sidecarConfig.Required {
 				return fmt.Errorf("Unable to get volume container of required sidecar %s", sidecarConfig.ServiceName)

--- a/hack/builder/titus-executor-builder.sh
+++ b/hack/builder/titus-executor-builder.sh
@@ -17,6 +17,7 @@ mv mount/titus-mount-block-device build/bin/linux-amd64/
 mv mount/titus-mount-nfs build/bin/linux-amd64/
 mv mount/titus-mount-bind build/bin/linux-amd64/
 mv mount/titus-mount-container-to-container build/bin/linux-amd64/
+mv mount/titus-mount-lustre build/bin/linux-amd64/
 
 # tini
 make build/tini/tini-static

--- a/mount/Makefile
+++ b/mount/Makefile
@@ -1,9 +1,14 @@
-all: titus-mount-nfs titus-mount-block-device titus-mount-ceph titus-mount-bind titus-mount-container-to-container
+all: titus-mount-nfs titus-mount-block-device titus-mount-ceph titus-mount-bind titus-mount-container-to-container titus-mount-lustre
 
 titus-mount-nfs: titus-mount-nfs.c scm_rights.c common.h
 	# musl needs this extra path here
 	# so it can pick up our linux headers for syscalls
 	C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu/:/usr/include/:. musl-gcc -std=gnu11 -Wall -static -g -o titus-mount-nfs titus-mount-nfs.c scm_rights.c
+
+titus-mount-lustre: titus-mount-lustre.c scm_rights.c common.h
+	# musl needs this extra path here
+	# so it can pick up our linux headers for syscalls
+	C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu/:/usr/include/:. musl-gcc -std=gnu11 -Wall -static -g -o titus-mount-lustre titus-mount-lustre.c scm_rights.c
 
 titus-mount-ceph: titus-mount-ceph.c scm_rights.c common.h
 	gcc -g -static -Wall -o titus-mount-ceph titus-mount-ceph.c scm_rights.c
@@ -17,11 +22,11 @@ titus-mount-bind: titus-mount-bind.c
 titus-mount-container-to-container: titus-mount-container-to-container.c
 	gcc -g -static -Wall -o titus-mount-container-to-container titus-mount-container-to-container.c scm_rights.c
 	
-install: titus-mount-nfs titus-mount-ceph titus-mount-block-device titus-mount-bind titus-mount-container-to-container
-	sudo rsync -a titus-mount-nfs titus-mount-block-device titus-mount-ceph titus-mount-bind titus-mount-container-to-container /apps/titus-executor/bin/
+install: titus-mount-nfs titus-mount-ceph titus-mount-block-device titus-mount-bind titus-mount-container-to-container titus-mount-lustre
+	sudo rsync -a titus-mount-nfs titus-mount-block-device titus-mount-ceph titus-mount-bind titus-mount-container-to-container titus-mount-lustre /apps/titus-executor/bin/
 
 clean:
-	rm -f titus-mount-nfs titus-mount-block-device titus-mount-ceph titus-mount-bind titus-mount-container-to-container
+	rm -f titus-mount-nfs titus-mount-block-device titus-mount-ceph titus-mount-bind titus-mount-container-to-container titus-mount-lustre
 
 fmt:
 	# You can install these tools on linux with `sudo apt install clang-format iwyu`

--- a/mount/titus-mount-lustre.c
+++ b/mount/titus-mount-lustre.c
@@ -1,0 +1,372 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+/* getaddrinfo */
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <string.h>
+/* setns */
+#include <sched.h>
+/* for mount syscalls */
+#include <asm-generic/unistd.h>
+#include <linux/mount.h>
+/* fcntl */
+#include "scm_rights.h"
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common.h"
+
+#define E(x)                                                                   \
+	do {                                                                   \
+		if ((x) == -1) {                                               \
+			perror(#x);                                            \
+			exit(1);                                               \
+		}                                                              \
+	} while (0)
+
+#define IP_ADDRESS_LEN 256
+
+/*
+ *Construct lustre device mount options in the format expected by the syscall
+ */
+static void add_device_options(const char *ipaddress, const char *mount_name,
+			       char *final_options)
+{
+	strcat(final_options, ",device=");
+	strcat(final_options, ipaddress);
+	strcat(final_options, "@tcp:/");
+	strcat(final_options, mount_name);
+}
+
+/*
+ * Perform a DNS lookup and add to the DNS options. Prefer v6 over v4 
+ * (rely on /etc/gai.conf)
+ */
+static int hostname_to_ip_option(const char *hostname, const char *mount_name,
+				 char *final_options)
+{
+	struct addrinfo *result, *iter;
+	int error;
+	unsigned char buf[INET6_ADDRSTRLEN];
+
+	error = inet_pton(AF_INET, hostname, buf);
+	if (error == 1) {
+		fprintf(stderr, "Valid IPv4 address %s - No DNS needed\n",
+			hostname);
+		add_device_options(hostname, mount_name, final_options);
+		return 0;
+	}
+
+	error = inet_pton(AF_INET6, hostname, buf);
+	if (error == 1) {
+		fprintf(stderr, "Valid IPv6 address %s - No DNS needed\n",
+			hostname);
+		add_device_options(hostname, mount_name, final_options);
+		return 0;
+	}
+
+	error = getaddrinfo(hostname, NULL, NULL, &result);
+	if (error) {
+		fprintf(stderr, "Error trying to resolve %s - %s: \n", hostname,
+			gai_strerror(error));
+		return -1;
+	}
+
+	for (iter = result; iter != NULL; iter = iter->ai_next) {
+		char ipaddress[IP_ADDRESS_LEN];
+		void *ptr_to_ip;
+		inet_ntop(iter->ai_family, iter->ai_addr->sa_data, ipaddress,
+			  IP_ADDRESS_LEN);
+		switch (iter->ai_family) {
+		case AF_INET:
+			ptr_to_ip =
+				&((struct sockaddr_in *)iter->ai_addr)->sin_addr;
+			break;
+		case AF_INET6:
+			ptr_to_ip = &((struct sockaddr_in6 *)iter->ai_addr)
+					     ->sin6_addr;
+			break;
+		}
+		inet_ntop(iter->ai_family, ptr_to_ip, ipaddress,
+			  IP_ADDRESS_LEN);
+		fprintf(stderr, "titus-mount-lustre: Resolved %s to %s\n",
+			hostname, ipaddress);
+		add_device_options(ipaddress, mount_name, final_options);
+		break;
+	}
+	freeaddrinfo(result);
+	return 0;
+}
+
+static void check_messages(int fd)
+{
+	char buf[4096];
+	int err, n;
+	err = errno;
+	for (;;) {
+		n = read(fd, buf, sizeof(buf));
+		if (n < 0)
+			break;
+		n -= 2;
+		switch (buf[0]) {
+		case 'e':
+			fprintf(stderr, "Error: %*.*s\n", n, n, buf + 2);
+			break;
+		case 'w':
+			fprintf(stderr, "Warning: %*.*s\n", n, n, buf + 2);
+			break;
+		case 'i':
+			fprintf(stderr, "Info: %*.*s\n", n, n, buf + 2);
+			break;
+		}
+	}
+	errno = err;
+}
+
+static __attribute__((noreturn)) void mount_error(int fd, const char *s)
+{
+	check_messages(fd);
+	fprintf(stderr, "titus-mount-lustre mount error on '%s': %m\n", s);
+	exit(1);
+}
+
+static inline int pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(__NR_pidfd_open, pid, flags);
+}
+
+static inline int fsopen(const char *fs_name, unsigned int flags)
+{
+	return syscall(__NR_fsopen, fs_name, flags);
+}
+
+static inline int fsmount(int fsfd, unsigned int flags, unsigned int ms_flags)
+{
+	return syscall(__NR_fsmount, fsfd, flags, ms_flags);
+}
+
+static inline int fsconfig(int fsfd, unsigned int cmd, const char *key,
+			   const void *val, int aux)
+{
+	return syscall(__NR_fsconfig, fsfd, cmd, key, val, aux);
+}
+
+static inline int move_mount(int from_dfd, const char *from_pathname,
+			     int to_dfd, const char *to_pathname,
+			     unsigned int flags)
+{
+	return syscall(__NR_move_mount, from_dfd, from_pathname, to_dfd,
+		       to_pathname, flags);
+}
+
+#define E_fsconfig(fd, cmd, key, val, aux)                                     \
+	do {                                                                   \
+		if (fsconfig(fd, cmd, key, val, aux) == -1)                    \
+			mount_error(fd, key ?: "create");                      \
+	} while (0)
+
+static void process_option(char *option, int fsfd)
+{
+	/* Splits up a k=v string and runs fsconfig on it.
+           We supply all the inputs here, so it is safe, but parsing things
+           like this is a little dangerous */
+	char *key, *value, *saveptr;
+	key = strtok_r(option, "=", &saveptr);
+	option = NULL;
+	value = strtok_r(option, "=", &saveptr);
+	fprintf(stderr,
+		"titus-mount-lustre: Setting filesystem mount option %s=%s\n",
+		key, value);
+	E_fsconfig(fsfd, FSCONFIG_SET_STRING, key, value, 0);
+}
+
+static void do_fsconfigs(int fsfd, char *options)
+{
+	char *str1, *token, *saveptr;
+	/* Mount options come in in the classic comma-separated key=value pairs
+	   we need to split them up and pass them in for fsconfig to handle one at a time */
+	for (str1 = options;; str1 = NULL) {
+		token = strtok_r(str1, ",", &saveptr);
+		if (token == NULL)
+			break;
+		process_option(token, fsfd);
+	}
+	/* This last FSCONFIG_CMD_CREATE fsconfig call actually creates the superblock */
+	E_fsconfig(fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0);
+}
+
+static int setup_fsfd_in_namespaces(int sk, int nsfd)
+{
+	int fsfd, ret;
+	int usernsfd = openat(nsfd, "user", O_RDONLY);
+	int mnt_fd = openat(nsfd, "mnt", O_RDONLY);
+	int net_fd = openat(nsfd, "net", O_RDONLY);
+	assert(usernsfd != -1);
+	assert(mnt_fd != -1);
+	assert(net_fd != -1);
+	ret = setns(usernsfd, CLONE_NEWUSER);
+	if (ret == -1) {
+		perror("setns user");
+		return 1;
+	}
+	ret = setns(mnt_fd, CLONE_NEWNS);
+	if (ret == -1) {
+		perror("setns mnt");
+		return 1;
+	}
+	ret = setns(net_fd, CLONE_NEWNET);
+	if (ret == -1) {
+		perror("setns net");
+		return 1;
+	}
+	fsfd = fsopen("lustre", 0);
+	if (fsfd == -1) {
+		perror("fsopen");
+		return 1;
+	}
+	assert(send_fd(sk, fsfd) == 0);
+	return 0;
+}
+
+static int fork_and_get_fsfd(long int nsfd)
+{
+	int sk_pair[2], ret, fsfd, status;
+	pid_t worker;
+
+	if (socketpair(PF_LOCAL, SOCK_SEQPACKET, 0, sk_pair) < 0) {
+		perror("socketpair");
+		exit(1);
+	}
+	worker = fork();
+	if (worker < 0) {
+		perror("fork");
+		exit(1);
+	}
+	if (worker == 0) {
+		close(sk_pair[0]);
+		ret = setup_fsfd_in_namespaces(sk_pair[1], nsfd);
+		close(sk_pair[1]);
+		exit(ret);
+	}
+	close(sk_pair[1]);
+	fsfd = recv_fd(sk_pair[0]);
+	assert(fsfd >= 0);
+	if (waitpid(worker, &status, 0) != worker) {
+		perror("waitpid");
+		exit(1);
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status)) {
+		fprintf(stderr, "worker exited nonzero\n");
+		exit(1);
+	}
+	close(sk_pair[0]);
+	return fsfd;
+}
+
+static void switch_namespaces(int nsfd)
+{
+	int ret;
+	int mnt_fd = openat(nsfd, "mnt", O_RDONLY);
+	assert(mnt_fd != -1);
+	ret = setns(mnt_fd, CLONE_NEWNS);
+	if (ret == -1) {
+		perror("setns mount");
+		exit(1);
+	}
+	int net_fd = openat(nsfd, "net", O_RDONLY);
+	assert(net_fd != -1);
+	ret = setns(net_fd, CLONE_NEWNET);
+	if (ret == -1) {
+		perror("setns net");
+		exit(1);
+	}
+}
+
+static void mount_and_move(int fsfd, const char *target, unsigned long flags)
+{
+	int mfd = fsmount(fsfd, 0, flags);
+	if (mfd < 0) {
+		mount_error(fsfd, "fsmount");
+		E(close(fsfd));
+	}
+	E(move_mount(mfd, "", AT_FDCWD, target, MOVE_MOUNT_F_EMPTY_PATH));
+	E(close(mfd));
+}
+
+int main(int argc, char *argv[])
+{
+	int nsfd, fsfd, res = -1;
+	unsigned long flags_ul;
+	/*
+	 * We do this because parsing args is a bigger pain than passing
+	 * via environment variable, although passing via environment
+	 * variable has a "cost" in that they are limited in size
+	 */
+	const char *pidDir = getenv("TITUS_PID1_DIR");
+	const char *lustre_mount_hostname = getenv("MOUNT_LUSTRE_HOSTNAME");
+	const char *lustre_mount_mountname = getenv("MOUNT_LUSTRE_MOUNTNAME");
+	const char *target = getenv("MOUNT_TARGET");
+	const char *flags = getenv("MOUNT_FLAGS");
+	const char *options = getenv("MOUNT_OPTIONS");
+
+	if (!(target && flags && options && pidDir)) {
+		fprintf(stderr,
+			"Usage: must provide MOUNT_TARGET, MOUNT_FLAGS, TITUS_PID1_DIR, and MOUNT_OPTIONS env vars");
+		return 1;
+	}
+
+	if (!(lustre_mount_hostname && lustre_mount_mountname)) {
+		fprintf(stderr,
+			"Usage: must provide MOUNT_LUSTRE_HOSTNAME, MOUNT_LUSTRE_MOUNTNAME env vars");
+		return 1;
+	}
+
+	int buf_size = sysconf(_SC_PAGESIZE);
+	char final_options[buf_size];
+	strncpy(final_options, options, buf_size);
+
+	errno = 0;
+	flags_ul = strtoul(flags, NULL, 10);
+	if (errno) {
+		perror("flags");
+		return 1;
+	}
+	/* This nsfd is used to extract other namespaces to switch to, similar to a pidfd */
+	char pid1_ns_path[PATH_MAX];
+	snprintf(pid1_ns_path, PATH_MAX - 1, "%s/ns", pidDir);
+	nsfd = open(pid1_ns_path, O_PATH);
+	if (nsfd == -1) {
+		perror("pidfd_open");
+		return 1;
+	}
+
+	/* First we need to get a fsfd, but it must be created inside the user namespace */
+	fsfd = fork_and_get_fsfd(nsfd);
+
+	/* Now we can switch net/mount namespaces so we can lookup the ip and eventually mount */
+	switch_namespaces(nsfd);
+	fprintf(stderr, "titus-mount-lustre: user-inputed options: %s\n",
+		options);
+	res = hostname_to_ip_option(lustre_mount_hostname,
+				    lustre_mount_mountname, final_options);
+	if (res != 0) {
+		fprintf(stderr,
+			"Error resolving hostname to IP address on mount\n");
+		return 1;
+	}
+	fprintf(stderr, "titus-mount-lustre: computed final_options: %s\n",
+		final_options);
+
+	/* Now we can do the fs_config calls and actual mount */
+	do_fsconfigs(fsfd, final_options);
+	mkdir_p(target);
+	mount_and_move(fsfd, target, flags_ul);
+
+	fprintf(stderr, "titus-mount-lustre: All done, mounted on %s\n",
+		target);
+	return 0;
+}


### PR DESCRIPTION
This code does work!
It borrows heavily from titus-mount-nfs, which is a different network filesystem.

However, the nuances about mount `src` vs `device` are weird and different.

Another thing I was unable to solve was how to mount this with `MS_NOATIME`. No matter what I did I got EINVAL when trying to mount with that flag.
