### PR TITLE
allow most privileged profile to access to less privileged profile

### DIFF
--- a/root/etc/apparmor.d/docker_fuse
+++ b/root/etc/apparmor.d/docker_fuse
@@ -40,6 +40,7 @@ profile docker_fuse flags=(attach_disconnected,mediate_deleted) {
   deny /sys/kernel/security/** rwklx,
 
   ptrace (trace,read) peer=@{profile_name},
+  ptrace (read) peer=docker_titus,
 
   deny /titus/** wl,
 

--- a/root/etc/apparmor.d/docker_image_building
+++ b/root/etc/apparmor.d/docker_image_building
@@ -39,6 +39,7 @@ profile docker_image_building flags=(attach_disconnected,mediate_deleted) {
   deny /sys/kernel/security/** rwklx,
 
   ptrace (trace,read) peer=@{profile_name},
+  ptrace (read) peer=docker_titus,
 
   deny /titus/** wl,
 


### PR DESCRIPTION
### Description of the Change

Fuse/Imagebuilding profile container should have access to /proc process objects of the docker_titus role. 
