### PR TITLE
Make titus-mount-nfs use the container's hostname TITUS-6392

### DIFF
--- a/mount/titus-mount-nfs.c
+++ b/mount/titus-mount-nfs.c
@@ -270,6 +270,13 @@ static void switch_namespaces(int nsfd)
 		perror("setns net");
 		exit(1);
 	}
+	int uts_fd = openat(nsfd, "uts", O_RDONLY);
+	assert(uts_fd != -1);
+	ret = setns(uts_fd, CLONE_NEWUTS);
+	if (ret == -1) {
+		perror("setns uts");
+		exit(1);
+	}
 }
 
 static void mount_and_move(int fsfd, const char *target,


### PR DESCRIPTION
When mounting NFS multiple times in parallel from the same host (happens often in containers), NFS servers may reject clients with the same clientID.

We've seen this in real life with Netapp (ONTAP).
https://www.netapp.com/media/10720-tr-4067.pdf

This change makes the mount happen using the UTS (hostname) namespace of the container, instead of the titus agent.

Using wireshark, I've verified that the EXCHANGE_ID goes from the hostname of the agent to the hostname of the container (taskid).

(and nfs integration tests still pass)