### PR TITLE
Change the default vpc gen to gen3

### DIFF
--- a/cmd/titus-vpc-tool/gc.go
+++ b/cmd/titus-vpc-tool/gc.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Netflix/titus-executor/logger"
 	"github.com/Netflix/titus-executor/vpc/tool/gc3"
 	"github.com/spf13/cobra"
 	pkgviper "github.com/spf13/viper"
@@ -25,9 +24,6 @@ func gcCommand(ctx context.Context, v *pkgviper.Viper, iipGetter instanceIdentit
 			}
 			defer conn.Close()
 			switch generation := strings.ToLower(v.GetString(generationFlagName)); generation {
-			case "v1":
-				logger.G(ctx).Warnf("Generation %s does not support GC")
-				return nil
 			case "v3":
 				return gc3.GC(ctx,
 					v.GetDuration("timeout"),

--- a/cmd/titus-vpc-tool/main.go
+++ b/cmd/titus-vpc-tool/main.go
@@ -24,15 +24,14 @@ import (
 )
 
 const (
-	stateDirFlagName        = "state-dir"
-	stateDirDefaultValue    = "/run/titus-vpc-tool"
-	serviceAddrFlagName     = "service-addr"
-	serviceAddrDefaultValue = "localhost:7001"
-	zipkinURLFlagName       = "zipkin"
-	// which generation of titus-vpc-tool version to use, it must be set to 1 or 2
+	stateDirFlagName            = "state-dir"
+	stateDirDefaultValue        = "/run/titus-vpc-tool"
+	serviceAddrFlagName         = "service-addr"
+	serviceAddrDefaultValue     = "localhost:7001"
+	zipkinURLFlagName           = "zipkin"
 	generationFlagName          = "generation"
-	generationDefaultValue      = "v0"
-	interaceSubnet              = "interface-subnet"
+	generationDefaultValue      = "v3"
+	interfaceSubnet             = "interface-subnet"
 	interfaceAccount            = "interface-account"
 	sslCAFlagName               = "ssl-ca"
 	sslKeyFlagName              = "ssl-key"

--- a/cmd/titus-vpc-tool/setup_container.go
+++ b/cmd/titus-vpc-tool/setup_container.go
@@ -18,7 +18,7 @@ func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter ins
 			pid1dirfd := v.GetInt("pid-1-dir-fd")
 			transitionNamespaceDir := v.GetString(transitionNSDirFlagName)
 			switch strings.ToLower(v.GetString(generationFlagName)) {
-			case "v2", "v3":
+			case "v3":
 				return container2.SetupContainer(ctx, iipGetter(), pid1dirfd, transitionNamespaceDir)
 			default:
 				return fmt.Errorf("Version %q not recognized", v.GetString(generationFlagName))
@@ -27,7 +27,7 @@ func setupContainercommand(ctx context.Context, v *pkgviper.Viper, iipGetter ins
 	}
 
 	cmd.Flags().Int("pid-1-dir-fd", 3, "The File Descriptor # of the pid 1 directory to setup")
-	cmd.Flags().String(generationFlagName, generationDefaultValue, "Generation of VPC Tool to use, specify v1, or v2")
+	cmd.Flags().String(generationFlagName, generationDefaultValue, "Generation of VPC Tool to use")
 	cmd.Flags().String(transitionNSDirFlagName, transitionNSDirDefaultValue, "Directory to mount transition namespaces into")
 	return cmd
 }

--- a/cmd/titus-vpc-tool/setup_instance.go
+++ b/cmd/titus-vpc-tool/setup_instance.go
@@ -37,9 +37,9 @@ func setupInstanceCommand(ctx context.Context, v *pkgviper.Viper, iipGetter inst
 	}
 
 	addSharedFlags(cmd.Flags())
-	cmd.Flags().String(interaceSubnet, "", "subnet ID to place interfaces in")
+	cmd.Flags().String(interfaceSubnet, "", "subnet ID to place interfaces in")
 	cmd.Flags().String(interfaceAccount, "", "account ID to place interfaces in")
-	if err := v.BindEnv(interaceSubnet, "VPC_INTERFACE_SUBNET"); err != nil {
+	if err := v.BindEnv(interfaceSubnet, "VPC_INTERFACE_SUBNET"); err != nil {
 		panic(err)
 	}
 	if err := v.BindEnv(interfaceAccount, "VPC_INTERFACE_ACCOUNT"); err != nil {

--- a/cmd/titus-vpc-tool/shared.go
+++ b/cmd/titus-vpc-tool/shared.go
@@ -28,7 +28,7 @@ import (
 func addSharedFlags(flags *pflag.FlagSet) {
 	flags.String(stateDirFlagName, stateDirDefaultValue, "Where do we put the state")
 	flags.String(serviceAddrFlagName, serviceAddrDefaultValue, "VPC service address")
-	flags.String(generationFlagName, generationDefaultValue, "Generation of VPC Tool to use, specify v1, or v2")
+	flags.String(generationFlagName, generationDefaultValue, "Generation of VPC Tool to use")
 	flags.String(sslCAFlagName, "", "SSL CA")
 	flags.String(sslKeyFlagName, "", "SSL Key")
 	flags.String(sslCertFlagName, "", "SSL Cert")


### PR DESCRIPTION
We only have gen3 instance types now.
"v0" is an unsafe default.

I left the gen concept in place though, because it is pretty likely we will have a gen4 instance type.
