### PR TITLE
Added panic/recover for main path

### DIFF
--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -276,7 +276,7 @@ func (b *Backend) RunWithOutputDir(ctx context.Context, dir string) error {
 
 func (b *Backend) handleUpdate(ctx context.Context, update runner.Update) {
 	b.pod.Status.Message = update.Mesg
-	if update.Details != nil {
+	if update.Details != nil && update.Details.NetworkConfiguration != nil {
 		b.pod.Status.PodIP = update.Details.NetworkConfiguration.PickPrimaryIP()
 
 		podIPs := []v1.PodIP{}


### PR DESCRIPTION
I appreciate the last minute `state.json` curl, but I think ideally we could catch crashes a little earliar and handle some of the cleanup.

This PR makes it so we are a tiny bit more graceful and let the user know what the panic was and to report it to #titus.
