### PR TITLE
Added debug for full command printing when we get exit code 127

### DIFF
--- a/executor/standalone/standalone_test.go
+++ b/executor/standalone/standalone_test.go
@@ -218,7 +218,8 @@ func TestInvalidFlatStringAsCmd(t *testing.T) {
 	defer cancel()
 	jobResponse, err := StartTestTask(t, ctx, ji)
 	require.NoError(t, err)
-	if err := jobResponse.WaitForFailureWithStatusCode(ctx, 127); err != nil {
+	// There should be an error message that tells us exactly what we tried to run
+	if err := jobResponse.WaitForFailureWithStatusMessage(ctx, "[\"echo Hello Titus\"]"); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
It is pretty hard to debug exit code 127.

This PR adds some debug for the user to print *Exactly* what was (attempted to) run in the container.

This is a little weird though, because the command could still be a shell script which *also* can return 127.

I'm not super sure how to capture that nuance.

Example error on the titus ui:

> main container couldn't find the command 'bad_entrypoint' to run in the path (exit code 127). Full command: ["bad_entrypoint"]