### PR TITLE
NETSNI-59: allow SystemDNS for all network modes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,13 @@ type Config struct {
 	// Do we enable SystemDNS titus-system-service?
 	ContainerSystemDNS    bool
 	SystemDNSServiceImage string
+	// Flags to enable SystemDNS per NetworkMode
+	SystemDNSEnabledHighScale           bool
+	SystemDNSEnabledIpv6Only            bool
+	SystemDNSEnabledIpv6AndIpv4Fallback bool
+	SystemDNSEnabledIpv6andIpv4         bool
+	SystemDNSEnabledIpv4Only            bool
+	SystemDNSEnabledUnknownNetworkMode  bool
 
 	// Do we enable tracing-collector titus-system-service?
 	ContainerTracingCollector    bool
@@ -268,6 +275,36 @@ func NewConfig() (*Config, []cli.Flag) {
 			Name:        "container-systemdns-image",
 			EnvVar:      "SYSTEMDNS_SERVICE_IMAGE",
 			Destination: &cfg.SystemDNSServiceImage,
+		},
+		cli.BoolFlag{
+			Name:        "systemdns-enabled-high-scale",
+			EnvVar:      "SYSTEMDNS_ENABLED_HIGH_SCALE",
+			Destination: &cfg.SystemDNSEnabledHighScale,
+		},
+		cli.BoolFlag{
+			Name:        "systemdns-enabled-ipv6-only",
+			EnvVar:      "SYSTEMDNS_ENABLED_IPV6_ONLY",
+			Destination: &cfg.SystemDNSEnabledIpv6Only,
+		},
+		cli.BoolFlag{
+			Name:        "systemdns-enabled-ipv6-and-ipv4-fallback",
+			EnvVar:      "SYSTEMDNS_ENABLED_IPV6_AND_IPV4_FALLBACK",
+			Destination: &cfg.SystemDNSEnabledIpv6AndIpv4Fallback,
+		},
+		cli.BoolFlag{
+			Name:        "systemdns-enabled-ipv6-and-ipv4",
+			EnvVar:      "SYSTEMDNS_ENABLED_IPV6_AND_IPV4",
+			Destination: &cfg.SystemDNSEnabledIpv6andIpv4,
+		},
+		cli.BoolFlag{
+			Name:        "systemdns-enabled-ipv4-only",
+			EnvVar:      "SYSTEMDNS_ENABLED_IPV4_ONLY",
+			Destination: &cfg.SystemDNSEnabledIpv4Only,
+		},
+		cli.BoolFlag{
+			Name:        "systemdns-enabled-unknown-network-mode",
+			EnvVar:      "SYSTEMDNS_ENABLED_UNKNOWN_NETWORK_MODE",
+			Destination: &cfg.SystemDNSEnabledUnknownNetworkMode,
 		},
 		cli.BoolFlag{
 			Name:        "container-tracing-collector",

--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -175,10 +175,7 @@ func ShouldStartSystemDNS(cfg *config.Config, c Container) bool {
 	if cfg.InStandaloneMode {
 		return false
 	}
-	// don't start SystemDNS unless we're in IPv6-only mode
-	if c.EffectiveNetworkMode() != titus.NetworkConfiguration_Ipv6Only.String() {
-		return false
-	}
+
 	enabled := cfg.ContainerSystemDNS
 	if !enabled {
 		return false
@@ -186,6 +183,23 @@ func ShouldStartSystemDNS(cfg *config.Config, c Container) bool {
 	if cfg.SystemDNSServiceImage == "" {
 		return false
 	}
+
+	// Enable SystemDNS if the flag for the current Network Mode is true
+	switch c.EffectiveNetworkMode() {
+	case titus.NetworkConfiguration_HighScale.String():
+		return cfg.SystemDNSEnabledHighScale
+	case titus.NetworkConfiguration_Ipv6Only.String():
+		return cfg.SystemDNSEnabledIpv6Only
+	case titus.NetworkConfiguration_Ipv6AndIpv4Fallback.String():
+		return cfg.SystemDNSEnabledIpv6AndIpv4Fallback
+	case titus.NetworkConfiguration_Ipv6AndIpv4.String():
+		return cfg.SystemDNSEnabledIpv6andIpv4
+	case titus.NetworkConfiguration_Ipv4Only.String():
+		return cfg.SystemDNSEnabledIpv4Only
+	case titus.NetworkConfiguration_UnknownNetworkMode.String():
+		return cfg.SystemDNSEnabledUnknownNetworkMode
+	}
+	
 	return true
 }
 


### PR DESCRIPTION
Adds flags to selectively enable SystemDNS per network mode. Currently it will only be enabled for IPv6Only containers, but this will allow us to roll it out to the entire ecosystem, one network mode at a time.