### PR TITLE
fix gofmt

### DIFF
--- a/executor/runtime/types/sidecars.go
+++ b/executor/runtime/types/sidecars.go
@@ -199,7 +199,7 @@ func ShouldStartSystemDNS(cfg *config.Config, c Container) bool {
 	case titus.NetworkConfiguration_UnknownNetworkMode.String():
 		return cfg.SystemDNSEnabledUnknownNetworkMode
 	}
-	
+
 	return true
 }
 


### PR DESCRIPTION
executor/runtime/types/sidecars.go:202: File is not `gofmt`-ed with `-s` (gofmt)

Not sure why this didn't fail in the original PR.
