### PR TITLE
Component version refactor (With Titus System Services)

### DIFF
--- a/executor/runtime/docker/component_versions.go
+++ b/executor/runtime/docker/component_versions.go
@@ -12,7 +12,10 @@ func (r *DockerRuntime) getComponentVersions() map[string]string {
 	componentVersions := map[string]string{}
 	componentVersions["kernel-version"] = getKernelVersion()
 	componentVersions["titus-executor"] = executor.TitusExecutorVersion
-	componentVersions["tsa"] = getTSAVersion()
+	componentVersions["tss-tsa"] = getTSAVersion()
+	for k, v := range r.getTitusSystemServiceVersions() {
+		componentVersions["tss-"+k] = v
+	}
 	return componentVersions
 }
 
@@ -30,4 +33,16 @@ func getTSAVersion() string {
 		return fmt.Sprintf("problem reading tsa version: %v", err)
 	}
 	return strings.TrimSpace(string(tsaVersionRaw))
+}
+
+// getTitusSystemServiceVersions inspects the Titus System Service versions strings.
+// If they are set (by the function that pulls the image), then we can report them back
+func (r *DockerRuntime) getTitusSystemServiceVersions() map[string]string {
+	systemServiceVersions := map[string]string{}
+	for _, systemService := range r.systemServices {
+		if systemService.Version != "" {
+			systemServiceVersions[systemService.ServiceName] = systemService.Version
+		}
+	}
+	return systemServiceVersions
 }

--- a/executor/runtime/docker/component_versions.go
+++ b/executor/runtime/docker/component_versions.go
@@ -1,0 +1,33 @@
+package docker
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Netflix/titus-executor/executor"
+)
+
+func (r *DockerRuntime) getComponentVersions() map[string]string {
+	componentVersions := map[string]string{}
+	componentVersions["kernel-version"] = getKernelVersion()
+	componentVersions["titus-executor"] = executor.TitusExecutorVersion
+	componentVersions["tsa"] = getTSAVersion()
+	return componentVersions
+}
+
+func getKernelVersion() string {
+	kernelVersionRaw, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return fmt.Sprintf("problem reading kernel version: %v", err)
+	}
+	return strings.TrimSpace(string(kernelVersionRaw))
+}
+
+func getTSAVersion() string {
+	tsaVersionRaw, err := os.ReadFile("/apps/tsa/version")
+	if err != nil {
+		return fmt.Sprintf("problem reading tsa version: %v", err)
+	}
+	return strings.TrimSpace(string(tsaVersionRaw))
+}

--- a/executor/runtime/docker/docker.go
+++ b/executor/runtime/docker/docker.go
@@ -1466,6 +1466,7 @@ func (r *DockerRuntime) Start(parentCtx context.Context) (string, *runtimeTypes.
 			ResourceID:   fmt.Sprintf("resource-eni-%d", allocation.DeviceIndex()-1),
 			EniID:        eni.NetworkInterfaceId,
 		},
+		ComponentVersions: r.getComponentVersions(),
 	}
 
 	if a := allocation.IPV4Address(); a != nil {

--- a/executor/runtime/docker/docker_image.go
+++ b/executor/runtime/docker/docker_image.go
@@ -1,0 +1,77 @@
+package docker
+
+import (
+	"strings"
+
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+)
+
+// cleanContainerVersion tries to provide the most human-friendly version string we can get for
+// a particular image, given a version inspect.
+// It goes from most human-friendly to least (sha)
+func cleanContainerVersion(i *types.ImageInspect) string {
+	if i == nil {
+		return ""
+	}
+	tag := getImageTagFromInspect(i)
+	if tag != "" {
+		return tag
+	}
+	buildLabel := getBuildLabelFromInspect(i)
+	if buildLabel != "" {
+		return buildLabel
+	}
+	return getImageShaFromInspect(i)
+}
+
+func getImageTagFromInspect(i *types.ImageInspect) string {
+	if i.RepoTags == nil {
+		return ""
+	}
+	if len(i.RepoTags) < 1 {
+		return ""
+	}
+	return i.RepoTags[0]
+}
+
+func getBuildLabelFromInspect(i *types.ImageInspect) string {
+	if i.Config == nil {
+		return ""
+	}
+	if i.Config.Labels == nil {
+		return ""
+	}
+	nameLabel, ok := i.Config.Labels["image-name"]
+	if ok {
+		versionLabel, ok := i.Config.Labels["image-version"]
+		if ok {
+			return "image:" + fullImageNameToShortName(nameLabel) + " build:" + versionLabel
+		}
+	}
+	return ""
+}
+
+func getImageShaFromInspect(i *types.ImageInspect) string {
+	if i.RepoDigests == nil {
+		return ""
+	}
+	if len(i.RepoDigests) < 1 {
+		return ""
+	}
+	name := fullImageNameToShortName(i.RepoDigests[0])
+	splitDigest := strings.Split(i.RepoDigests[0], "@")
+	if len(splitDigest) < 2 {
+		return i.RepoDigests[0]
+	}
+	shortDigest := splitDigest[1]
+	return "image:" + name + " digest:" + shortDigest
+}
+
+func fullImageNameToShortName(i string) string {
+	ref, err := reference.ParseNamed(i)
+	if err != nil {
+		return i
+	}
+	return reference.Path(ref)
+}

--- a/executor/runtime/docker/docker_image_test.go
+++ b/executor/runtime/docker/docker_image_test.go
@@ -1,0 +1,39 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_fullImageNameToShortName(t *testing.T) {
+	actual := fullImageNameToShortName("registry.us-east-1.streamingtest.titus.netflix.net:7002/baseos/nflx-adminlogs@sha256:e4493a553868687b0cee2f7783c6eeb9c260374a4b5a137c52b7c53961433afe")
+	expected := "baseos/nflx-adminlogs"
+	assert.Equal(t, expected, actual)
+}
+
+func Test_cleanContainerVersionHandlesDigests(t *testing.T) {
+	i := &types.ImageInspect{
+		RepoDigests: []string{"registry.us-east-1.streamingtest.titus.netflix.net:7002/baseos/nflx-adminlogs@sha256:e4493a553868687b0cee2f7783c6eeb9c260374a4b5a137c52b7c53961433afe"},
+	}
+	actual := cleanContainerVersion(i)
+	expected := "image:baseos/nflx-adminlogs digest:sha256:e4493a553868687b0cee2f7783c6eeb9c260374a4b5a137c52b7c53961433afe"
+	assert.Equal(t, expected, actual)
+}
+
+func Test_cleanContainerVersionHandlesLabels(t *testing.T) {
+	i := &types.ImageInspect{
+		RepoDigests: []string{"registry.us-east-1.streamingtest.titus.netflix.net:7002/baseos/nflx-adminlogs@sha256:e4493a553868687b0cee2f7783c6eeb9c260374a4b5a137c52b7c53961433afe"},
+		Config: &container.Config{
+			Labels: map[string]string{
+				"image-version": "master.last.good-h427.308e880",
+				"image-name":    "dockerregistry.test.netflix.net:7002/baseos/nflx-adminlogs:pre-release",
+			},
+		},
+	}
+	actual := cleanContainerVersion(i)
+	expected := "image:baseos/nflx-adminlogs build:master.last.good-h427.308e880"
+	assert.Equal(t, expected, actual)
+}

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -561,4 +561,5 @@ type ServiceOpts struct {
 	Image         string              // If set, represents a docker image for the code representing this sidecar. This is populated at runtime.
 	Volumes       map[string]struct{} // Volumes to map in from the docker image into the main container, usually /titus/$servicename
 	ContainerName string              // A mutable string that is dynamically configured to be compatible with docker ps, calculated at runtime
+	Version       string              // A mutable string that represents the version of the system service, as specified by the image
 }

--- a/executor/runtime/types/types.go
+++ b/executor/runtime/types/types.go
@@ -3,14 +3,12 @@ package types
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/Netflix/titus-executor/config"
-	"github.com/Netflix/titus-executor/executor"
 	"github.com/Netflix/titus-executor/uploader"
 	vpcapi "github.com/Netflix/titus-executor/vpc/api"
 	podCommon "github.com/Netflix/titus-kube-common/pod"
@@ -501,30 +499,16 @@ func (n *NetworkConfigurationDetails) PickPrimaryIP() string {
 // Details contains additional details about a container that are
 // not returned by normal container start calls.
 type Details struct {
+	ComponentVersions    map[string]string
 	NetworkConfiguration *NetworkConfigurationDetails
 }
 
-func getKernelVersion() string {
-	kernelVersionRaw, err := os.ReadFile("/proc/sys/kernel/osrelease")
-	if err != nil {
-		return fmt.Sprintf("problem reading kernel version: %v", err)
+func (d Details) RenderVersionDetailsCSV() string {
+	componentVersions := []string{}
+	for k, v := range d.ComponentVersions {
+		componentVersions = append(componentVersions, fmt.Sprintf("%s=%s", k, v))
 	}
-
-	return strings.TrimSpace(string(kernelVersionRaw))
-
-}
-
-func getTSAVersion() string {
-	tsaVersionRaw, err := os.ReadFile("/apps/tsa/version")
-	if err != nil {
-		return fmt.Sprintf("problem reading tsa version: %v", err)
-	}
-
-	return strings.TrimSpace(string(tsaVersionRaw))
-}
-
-func (d Details) RenderVersionDetails() string {
-	return fmt.Sprintf("kernel-version=%s,titus-executor=%s,tsa=%s", getKernelVersion(), executor.TitusExecutorVersion, getTSAVersion())
+	return strings.Join(componentVersions, ",")
 }
 
 type ContainerRuntimeProvider func(ctx context.Context, c Container, startTime time.Time) (Runtime, error)

--- a/vk/backend/backend.go
+++ b/vk/backend/backend.go
@@ -339,7 +339,7 @@ func (b *Backend) handleUpdate(ctx context.Context, update runner.Update) {
 			b.pod.Annotations[k] = v
 		}
 
-		b.pod.Annotations[podCommon.AnnotationKeyRuntimeVersions] = update.Details.RenderVersionDetails()
+		b.pod.Annotations[podCommon.AnnotationKeyRuntimeVersions] = update.Details.RenderVersionDetailsCSV()
 	}
 }
 


### PR DESCRIPTION
This adds support for adding in Titus System Services into the componentVersions view in the UI.

A couple of thoughts when making this:
* I thought prefixing `tss-` would be a good idea to make it more clear these are system services, and not deb packages on an agent or container
* I tried to do the best I could to get the semantically meaningful version string, without being too verbose
* But also I didn't want to make up a fake docker url that doesn't exist (too far?)
* I butchered the image urls. I couldn't find the functions I wanted in the docker `reference` package

![Screenshot from 2023-01-06 11-23-09](https://user-images.githubusercontent.com/370205/211084685-76fba9f2-478d-42cd-aa5f-2c5387749293.png)
